### PR TITLE
Add user preferences system for personalized task breakdowns

### DIFF
--- a/docs/notion-schema.md
+++ b/docs/notion-schema.md
@@ -27,6 +27,24 @@ erDiagram
         rich_text progress_notes "What user accomplished"
     }
 
+    USER_PREFERENCES {
+        string id PK "Notion page ID"
+        string user_id "User identifier"
+        select preferred_beverage "tea|coffee|water|none"
+        rich_text comfort_spot "Favorite working spot"
+        rich_text transition_ritual "Between-task ritual"
+        select focus_music "lo-fi|classical|silence|none"
+        rich_text break_activity "Preferred break activity"
+        rich_text focus_prefs "JSON: focus work preferences"
+        rich_text creative_prefs "JSON: creative work preferences"
+        rich_text social_prefs "JSON: social work preferences"
+        rich_text independent_prefs "JSON: independent work preferences"
+        rich_text task_patterns "JSON: task pattern preferences"
+        rich_text time_prefs "JSON: time-of-day preferences"
+        rich_text energy_prefs "JSON: energy level adjustments"
+        date updated_at "Last preference update"
+    }
+
     TASKS ||--o{ TASKS : "has sub-tasks"
 ```
 
@@ -374,6 +392,203 @@ Format:
 - Understanding what work remains after CANNOT_FINISH
 - Creating accurate sub-tasks for remaining work
 - Providing context when resuming work
+
+---
+
+## User Preferences Properties
+
+The User Preferences table stores personalized settings that help create an environment for success during task execution. See [user-preferences.md](./user-preferences.md) for full documentation.
+
+### PreferredBeverage (select)
+
+User's preferred drink when working on tasks.
+
+| Value | Description |
+|-------|-------------|
+| `tea` | Hot tea (default for social/creative tasks) |
+| `coffee` | Coffee (default for focus tasks) |
+| `water` | Water or no specific preference |
+| `none` | User prefers no beverage prompts |
+
+---
+
+### ComfortSpot (rich text)
+
+Description of the user's favorite working location(s).
+
+```
+Examples:
+- "Cozy chair in the living room"
+- "Standing desk in the office"
+- "Kitchen table with morning light"
+- "Patio when weather is nice"
+```
+
+**Used for:** Suggesting environment setup in task breakdowns.
+
+---
+
+### TransitionRitual (rich text)
+
+Brief activity the user prefers between tasks.
+
+```
+Examples:
+- "Quick stretch"
+- "3 deep breaths"
+- "Walk to get water"
+- "Pet the cat"
+```
+
+**Used for:** Suggesting breaks between tasks and helping user reset.
+
+---
+
+### FocusMusic (select)
+
+Music preference during focused work.
+
+| Value | Description |
+|-------|-------------|
+| `lo-fi` | Lo-fi beats, ambient electronic |
+| `classical` | Classical music, instrumentals |
+| `silence` | Prefers quiet environment |
+| `none` | No music suggestions needed |
+
+---
+
+### BreakActivity (rich text)
+
+Preferred activity after completing tasks.
+
+```
+Examples:
+- "Quick walk around the block"
+- "Cup of tea on the patio"
+- "5 minutes with a book"
+- "Check in with partner"
+```
+
+---
+
+### Work Type Preferences (rich text - JSON)
+
+Four fields storing JSON objects with work-type-specific preferences:
+
+**FocusPrefs:**
+```json
+{
+  "beverage": "coffee",
+  "environment": "quiet office, door closed",
+  "prep_steps": ["put phone in another room", "close email"],
+  "music": "lo-fi",
+  "ideal_duration": "45-90 min"
+}
+```
+
+**CreativePrefs:**
+```json
+{
+  "beverage": "tea",
+  "environment": "natural light, open space",
+  "prep_steps": ["brief walk", "grab notebook"],
+  "tools": "paper before digital"
+}
+```
+
+**SocialPrefs:**
+```json
+{
+  "beverage": "tea",
+  "environment": "comfortable, quiet spot",
+  "prep_steps": ["review context", "set intention"],
+  "follow_up": "note key takeaways"
+}
+```
+
+**IndependentPrefs:**
+```json
+{
+  "beverage": "water",
+  "environment": "anywhere",
+  "batching": true,
+  "reward": "treat after batch"
+}
+```
+
+---
+
+### TaskPatterns (rich text - JSON)
+
+Preferences for specific recurring task types.
+
+```json
+{
+  "phone_calls": {
+    "prep_steps": ["find quiet room", "review last interaction"],
+    "environment": "comfortable seat",
+    "beverage": "tea"
+  },
+  "writing": {
+    "warmup": "2 min free-write",
+    "breaks": "every 25 min"
+  },
+  "email_batch": {
+    "setup": ["close tabs", "set timer"],
+    "approach": "quick ones first"
+  }
+}
+```
+
+---
+
+### TimePrefs (rich text - JSON)
+
+Preferences that vary by time of day.
+
+```json
+{
+  "morning": {
+    "beverage": "coffee",
+    "best_for": ["focus", "creative"],
+    "energy_tolerance": "high"
+  },
+  "afternoon": {
+    "beverage": "tea",
+    "best_for": ["social", "creative"],
+    "note": "post-lunch dip"
+  },
+  "evening": {
+    "beverage": "herbal tea",
+    "best_for": ["independent"],
+    "energy_tolerance": "low"
+  }
+}
+```
+
+---
+
+### EnergyPrefs (rich text - JSON)
+
+Adjustments based on user's current energy level.
+
+```json
+{
+  "high": {
+    "prep_style": "minimal",
+    "task_duration": "longer ok"
+  },
+  "medium": {
+    "prep_style": "standard rituals",
+    "task_duration": "normal"
+  },
+  "low": {
+    "prep_style": "extended, comfort-focused",
+    "task_duration": "shorter tasks",
+    "extra_steps": ["comfortable spot", "warm drink"]
+  }
+}
+```
 
 ---
 

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -141,9 +141,13 @@ After labeling, the AI **always** generates a series of actionable sub-tasks for
 
 **Key Principle:** Every task, no matter how simple it appears, gets explicit sub-tasks that define exactly what "done" looks like.
 
+**Key Enhancement:** Sub-tasks are personalized based on user preferences to create an environment for success. The first 1-2 steps focus on preparation and comfort.
+
 ```mermaid
 flowchart TD
-    Labeled([Task Labeled]) --> Generate[Generate sub-tasks for ALL tasks]
+    Labeled([Task Labeled]) --> FetchPrefs[Fetch user preferences]
+    FetchPrefs --> BuildContext[Build preference context]
+    BuildContext --> Generate[Generate personalized sub-tasks]
 
     Generate --> Evaluate{Task size?}
 
@@ -167,21 +171,54 @@ flowchart LR
     end
 
     subgraph Solution["The Solution"]
-        Specific["'Call mom'<br/>1. Find quiet spot<br/>2. Dial and greet<br/>3. Ask about health<br/>4. Wrap up"]
+        Specific["'Call mom'<br/>1. Make a cup of tea<br/>2. Settle into cozy chair<br/>3. Make the call<br/>4. Note any follow-ups"]
         Bounded["Clear, finite steps"]
+        Comfort["Personalized comfort"]
         Action["User takes action"]
     end
 
     Problem --> Solution
 ```
 
+### Personalized Prep Steps
+
+Before generating core task steps, the system fetches user preferences and injects them into the breakdown prompt. This enables personalized "environment for success" steps.
+
+```mermaid
+flowchart TD
+    subgraph Preferences["User Preferences Lookup"]
+        General["General: tea, cozy chair"]
+        WorkType["Social: quiet spot, review context"]
+        Pattern["Phone calls: review last chat"]
+        Context["Afternoon, medium energy"]
+    end
+
+    subgraph Generation["Personalized Generation"]
+        Prep["Prep steps: beverage + environment"]
+        Core["Core steps: actual task actions"]
+        FollowUp["Follow-up: capture outcomes"]
+    end
+
+    subgraph Output["Final Breakdown"]
+        Step1["1. Make a cup of tea"]
+        Step2["2. Settle into the cozy chair"]
+        Step3["3. Make the call"]
+        Step4["4. Note any follow-ups"]
+    end
+
+    Preferences --> Generation
+    Generation --> Output
+```
+
+See [user-preferences.md](./user-preferences.md) for full preference system documentation.
+
 ### Sub-task Generation Rules
 
-| Task Type | Sub-task Approach | Example |
+| Task Type | Sub-task Approach | Example (with preferences: tea, cozy chair) |
 |-----------|-------------------|---------|
-| Quick (15 min) | 2-3 inline steps | "Call mom" → 1. Find quiet spot, 2. Make call, 3. Note any follow-ups |
-| Standard (30-60 min) | 3-5 inline steps | "Review proposal" → 1. Read intro, 2. Check numbers, 3. Note concerns, 4. Draft feedback |
-| Large (60+ min) | Hidden sub-tasks | "Complete report" → 4 separate tasks in Notion |
+| Quick (15 min) | 2-4 inline steps | "Call mom" → 1. Make tea, 2. Settle into cozy chair, 3. Make call, 4. Note follow-ups |
+| Standard (30-60 min) | 3-6 inline steps | "Review proposal" → 1. Make coffee, 2. Find quiet spot, 3. Read intro, 4. Check numbers, 5. Note concerns, 6. Draft feedback |
+| Large (60+ min) | Hidden sub-tasks | "Complete report" → 4+ separate tasks in Notion (each with prep steps) |
 
 ### Complexity Signals (For Hidden vs. Inline)
 
@@ -264,11 +301,12 @@ flowchart TD
 
 ### Task Reframing
 
-| User Says | What User Sees | Hidden Reality |
-|-----------|----------------|----------------|
-| "Complete the project" | "Draft project outline - 30 min" | 4 sub-tasks created |
-| "Finish the report" | "Write report introduction - 45 min" | 4 sub-tasks created |
-| "Plan the event" | "List event requirements - 20 min" | 5 sub-tasks created |
+| User Says | What User Sees (personalized) | Hidden Reality |
+|-----------|-------------------------------|----------------|
+| "Complete the project" | "Make coffee, then draft project outline - 35 min" | 4 sub-tasks created (each with personalized prep) |
+| "Finish the report" | "Find your quiet spot, then write report introduction - 50 min" | 4 sub-tasks created |
+| "Plan the event" | "Grab a tea and list event requirements - 25 min" | 5 sub-tasks created |
+| "Call mom" | "Make tea, settle into cozy chair, make call - 15 min" | Inline steps with prep |
 
 ## Phase 3: Task Selection
 

--- a/docs/user-preferences.md
+++ b/docs/user-preferences.md
@@ -1,0 +1,515 @@
+# User Preferences & Comfort System
+
+## Overview
+
+The user preferences system tracks individual user comforts, rituals, and preferences that help create an environment for success when approaching different types of tasks. Rather than generic task breakdowns, the system generates personalized steps that acknowledge what helps each user perform their best.
+
+## Core Philosophy
+
+```mermaid
+mindmap
+  root((Environment<br/>for Success))
+    Physical Comfort
+      Hot beverages
+      Comfortable seating
+      Ambient lighting
+      Temperature
+    Mental Preparation
+      Rituals before tasks
+      Calming activities
+      Focus techniques
+      Transition routines
+    Sensory Preferences
+      Background music
+      Quiet spaces
+      Natural light
+      Aromatherapy
+    Social Comforts
+      Check-in with partner
+      Brief walk
+      Pet interaction
+      Deep breaths
+```
+
+**Key Insight:** Users are more likely to start (and complete) tasks when the environment feels supportive. A personalized "prep step" like "Make a cup of tea" can reduce the activation energy needed to begin.
+
+---
+
+## Preference Architecture
+
+```mermaid
+flowchart TB
+    subgraph Storage["Preference Storage"]
+        General[General Preferences]
+        WorkType[Work Type Specific]
+        TaskPattern[Task Pattern Specific]
+    end
+
+    subgraph Context["Context Factors"]
+        TimeOfDay[Time of Day]
+        Energy[Energy Level]
+        Mood[Current Mood]
+    end
+
+    subgraph Application["Applied To"]
+        Breakdown[Task Breakdown]
+        Prep[Prep Steps]
+        Environment[Environment Setup]
+    end
+
+    Storage --> Context
+    Context --> Application
+```
+
+---
+
+## Preference Categories
+
+### 1. General Preferences
+
+Universal comforts that apply across all task types.
+
+| Preference | Example Values | Usage |
+|------------|----------------|-------|
+| preferred_beverage | tea, coffee, water, none | Suggested before longer tasks |
+| comfort_spot | cozy chair, standing desk, patio | Suggested for focus/social tasks |
+| transition_ritual | stretch, deep breaths, brief walk | Suggested between tasks |
+| focus_music | lo-fi, classical, silence | Suggested during focus work |
+| break_activity | walk, snack, pet time | Suggested after completions |
+
+### 2. Work Type Preferences
+
+Specific preferences tied to the four work types.
+
+```mermaid
+flowchart TD
+    subgraph Focus["Focus Work Preferences"]
+        F1[phone_away: true]
+        F2[beverage: coffee]
+        F3[environment: quiet office]
+        F4[prep_ritual: 2 min meditation]
+    end
+
+    subgraph Creative["Creative Work Preferences"]
+        C1[music: ambient]
+        C2[tools: notebook first]
+        C3[environment: natural light]
+        C4[prep_ritual: brief walk]
+    end
+
+    subgraph Social["Social Work Preferences"]
+        S1[beverage: tea]
+        S2[environment: comfortable seat]
+        S3[prep_ritual: review notes]
+        S4[follow_up: note key points]
+    end
+
+    subgraph Independent["Independent Work Preferences"]
+        I1[music: podcast]
+        I2[environment: anywhere]
+        I3[batching: group similar tasks]
+        I4[reward: treat after completion]
+    end
+```
+
+### 3. Task Pattern Preferences
+
+Preferences for specific recurring task patterns.
+
+| Pattern | Preference | Example |
+|---------|------------|---------|
+| phone_calls | pre_call_ritual | "Review contact notes, prepare talking points" |
+| phone_calls | environment | "Quiet room, pacing allowed" |
+| writing | warmup | "Free-write for 2 min first" |
+| email_batch | setup | "Close other tabs, set timer" |
+| meetings | prep | "Review agenda, prepare 1 question" |
+| exercise | motivation | "Put on workout playlist" |
+
+---
+
+## Preference Schema
+
+### User Preferences Table (Notion or Config)
+
+```mermaid
+erDiagram
+    USER_PREFERENCES {
+        string user_id PK "User identifier"
+        string preferred_beverage "tea|coffee|water|none"
+        string comfort_spot "Description of favorite spot"
+        string transition_ritual "Between-task ritual"
+        string focus_music_preference "lo-fi|classical|silence|none"
+        string break_activity "Preferred break activity"
+        json work_type_prefs "Work type specific JSON"
+        json task_pattern_prefs "Pattern specific JSON"
+        json time_of_day_prefs "Morning/afternoon/evening"
+        json energy_level_prefs "High/medium/low energy"
+    }
+```
+
+### Work Type Preferences JSON Structure
+
+```json
+{
+  "focus": {
+    "beverage": "coffee",
+    "environment": "quiet office with door closed",
+    "prep_steps": ["put phone in another room", "close email tabs"],
+    "music": "lo-fi beats",
+    "ideal_duration": "45-90 min blocks"
+  },
+  "creative": {
+    "beverage": "tea",
+    "environment": "natural light, open space",
+    "prep_steps": ["take a brief walk", "grab notebook"],
+    "music": "ambient or silence",
+    "tools": "start with paper before digital"
+  },
+  "social": {
+    "beverage": "tea",
+    "environment": "comfortable, quiet spot",
+    "prep_steps": ["review context/notes", "set intention"],
+    "follow_up": "note key takeaways after"
+  },
+  "independent": {
+    "beverage": "water",
+    "environment": "anywhere comfortable",
+    "batching": true,
+    "music": "podcast or music",
+    "reward": "small treat after batch complete"
+  }
+}
+```
+
+### Task Pattern Preferences JSON Structure
+
+```json
+{
+  "phone_calls": {
+    "prep_steps": ["find quiet room", "review last interaction", "prepare 2-3 topics"],
+    "environment": "comfortable seat, room to pace",
+    "beverage": "tea",
+    "follow_up": "send follow-up text/email if needed"
+  },
+  "writing": {
+    "warmup": "2 min free-write",
+    "environment": "quiet, minimal distractions",
+    "tools": "outline first, then draft",
+    "breaks": "every 25 min"
+  },
+  "email_batch": {
+    "setup": ["close other tabs", "set 20 min timer"],
+    "approach": "quick responses first, then complex",
+    "environment": "desk, focused"
+  }
+}
+```
+
+---
+
+## Preference Learning
+
+The system learns preferences through explicit input and implicit observation.
+
+### Explicit Learning
+
+```mermaid
+flowchart TD
+    subgraph Prompts["Learning Prompts"]
+        Onboard["Onboarding: 'What helps you focus?'"]
+        PostTask["Post-task: 'Did that setup work well?'"]
+        Periodic["Periodic: 'Any new rituals working for you?'"]
+    end
+
+    subgraph Storage["Preference Storage"]
+        Save[Save to user preferences]
+    end
+
+    Prompts --> Storage
+```
+
+**Onboarding Questions:**
+
+| Question | Maps To |
+|----------|---------|
+| "Do you have a favorite drink while working?" | preferred_beverage |
+| "Where do you do your best thinking?" | comfort_spot |
+| "What helps you transition between tasks?" | transition_ritual |
+| "Music or silence while working?" | focus_music_preference |
+
+### Implicit Learning
+
+```mermaid
+flowchart LR
+    subgraph Signals["Observed Signals"]
+        S1["Task completed quickly after tea mention"]
+        S2["Focus tasks always at standing desk"]
+        S3["Social tasks completed faster in morning"]
+    end
+
+    subgraph Learning["Pattern Detection"]
+        L1[Associate beverage with task success]
+        L2[Link location to work type]
+        L3[Map time-of-day to performance]
+    end
+
+    subgraph Apply["Applied Preferences"]
+        A1[Suggest tea before similar tasks]
+        A2[Recommend standing desk for focus]
+        A3[Schedule social tasks AM when possible]
+    end
+
+    Signals --> Learning --> Apply
+```
+
+---
+
+## Preference Injection
+
+### Task Breakdown Enhancement
+
+When generating task breakdowns, user preferences are injected as context for the LLM.
+
+```mermaid
+flowchart TD
+    subgraph Input["Breakdown Inputs"]
+        Task[Task to break down]
+        WorkType[Work Type]
+        UserPrefs[User Preferences]
+    end
+
+    subgraph Context["Context Assembly"]
+        BasePrompt[Base breakdown prompt]
+        PrefContext[Preference context block]
+        Combined[Combined prompt]
+    end
+
+    subgraph Output["Personalized Breakdown"]
+        PrepSteps[Personalized prep steps]
+        ActionSteps[Core task actions]
+        FollowUp[Follow-up steps]
+    end
+
+    Task --> BasePrompt
+    WorkType --> PrefContext
+    UserPrefs --> PrefContext
+    BasePrompt --> Combined
+    PrefContext --> Combined
+    Combined --> Output
+```
+
+### Context Block Format
+
+The preference context is added to LLM prompts when generating breakdowns:
+
+```
+USER CONTEXT:
+This user has the following preferences for {work_type} tasks:
+- Environment: {environment_preference}
+- Beverage: {beverage_preference}
+- Prep ritual: {prep_ritual}
+- Additional notes: {any_relevant_patterns}
+
+When generating sub-tasks, include personalized prep steps that align with these preferences.
+The first 1-2 steps should focus on environment setup and mental preparation.
+```
+
+### Example: Generic vs. Personalized Breakdown
+
+**Generic breakdown for "Call mom":**
+```
+1. Find quiet spot
+2. Make call
+3. Note follow-ups
+```
+
+**Personalized breakdown for user who drinks tea and likes comfortable spots:**
+```
+1. Make a cup of tea
+2. Settle into the cozy chair in the living room
+3. Make the call
+4. Note any follow-ups or commitments
+```
+
+---
+
+## Time & Energy Context
+
+Preferences can vary by time of day and energy level.
+
+### Time-of-Day Preferences
+
+```mermaid
+flowchart LR
+    subgraph Morning["Morning (6am-12pm)"]
+        M1[Higher energy tolerance]
+        M2[Coffee preferred]
+        M3[Best for focus work]
+    end
+
+    subgraph Afternoon["Afternoon (12pm-5pm)"]
+        A1[Post-lunch dip considered]
+        A2[Tea or water]
+        A3[Good for social/creative]
+    end
+
+    subgraph Evening["Evening (5pm-10pm)"]
+        E1[Lower energy tolerance]
+        E2[Herbal tea or water]
+        E3[Best for independent/light]
+    end
+```
+
+### Energy-Based Adjustments
+
+| Energy Level | Prep Step Adjustments |
+|--------------|----------------------|
+| High | Minimal prep, dive in quickly |
+| Medium | Standard prep rituals |
+| Low | Extended prep, comfort-focused, smaller first steps |
+
+---
+
+## Implementation Flow
+
+### Preference Retrieval
+
+```mermaid
+sequenceDiagram
+    participant AI as AI Assistant
+    participant Prefs as Preference Store
+    participant LLM as Claude API
+
+    Note over AI: Task breakdown requested
+
+    AI->>Prefs: Get user preferences
+    Prefs-->>AI: User preference object
+
+    AI->>AI: Determine work type
+    AI->>AI: Get time of day
+    AI->>AI: Get user energy level
+
+    AI->>AI: Assemble preference context
+
+    AI->>LLM: Breakdown prompt + preference context
+    LLM-->>AI: Personalized breakdown
+
+    AI->>AI: Present to user
+```
+
+### Breakdown Generation with Preferences
+
+```mermaid
+flowchart TD
+    subgraph Request["Breakdown Request"]
+        Task["Task: Call mom"]
+        Type["Type: social"]
+        Time["Time: afternoon"]
+        Energy["Energy: medium"]
+    end
+
+    subgraph Lookup["Preference Lookup"]
+        General["General: tea, cozy chair"]
+        Social["Social: quiet spot, prep context"]
+        Pattern["Phone calls: review last chat"]
+    end
+
+    subgraph Generate["Generate Breakdown"]
+        Combine[Combine all relevant prefs]
+        Inject[Inject into LLM prompt]
+        Create[Create personalized steps]
+    end
+
+    subgraph Output["Personalized Steps"]
+        Step1["1. Make a cup of tea"]
+        Step2["2. Settle into the cozy chair"]
+        Step3["3. Glance at last text from mom"]
+        Step4["4. Make the call"]
+        Step5["5. Note any follow-ups"]
+    end
+
+    Request --> Lookup
+    Lookup --> Generate
+    Generate --> Output
+```
+
+---
+
+## User Experience
+
+### Learning Preferences Naturally
+
+The system learns preferences through natural conversation:
+
+```
+User: "I need to call the dentist"
+AI: "Added - social, ~10 min. Quick question: what helps you gear up for phone calls? Some folks like a drink, others a quiet spot."
+User: "I usually make tea first"
+AI: "Good to know! I'll remember that. ☕"
+```
+
+### Applying Preferences
+
+```
+User: "Ready for a task"
+AI: "How about calling your dentist? Here's the plan:
+     1. Put the kettle on for tea
+     2. Find a quiet spot - maybe the living room?
+     3. Make the call
+     4. Note any appointment times
+
+     Start with step 1 when you're ready!"
+```
+
+### Confirming Preference Relevance
+
+```
+User: "Done with the call!"
+AI: "Nice work! Did having tea help, or should I skip that next time?"
+User: "Definitely helps"
+AI: "Noted - tea before calls it is! 🍵"
+```
+
+---
+
+## Privacy & Control
+
+### User Control
+
+| Control | Description |
+|---------|-------------|
+| View preferences | User can see all stored preferences |
+| Edit preferences | User can modify any preference |
+| Delete preferences | User can clear all learned preferences |
+| Pause learning | User can disable implicit learning |
+| Opt-out of prep steps | User can request "just the task" |
+
+### Data Minimization
+
+- Preferences stored only for personalization
+- No sensitive personal data in preferences
+- Preferences never shared externally
+- Learning limited to task-relevant patterns
+
+---
+
+## Future Enhancements
+
+### Environmental Integration
+
+- Connect to smart home for automatic environment setup
+- Dim lights for focus work
+- Play preferred music automatically
+- Adjust thermostat based on task type
+
+### Partner Preferences
+
+- Learn what helps when working alongside partner
+- Coordinate quiet hours
+- Shared rituals for joint tasks
+
+### Seasonal Adjustments
+
+- Adjust beverage preferences by season
+- Outdoor suggestions in good weather
+- Cozy indoor alternatives in winter


### PR DESCRIPTION
## Summary

- Introduces a user preferences system that tracks individual user comforts, rituals, and preferences to create an "environment for success" during task execution
- Task breakdowns now include personalized prep steps based on user preferences (e.g., "Make a cup of tea" instead of generic "Find quiet spot")
- Preferences are tied to task types (social tasks → tea, focus tasks → coffee) and can vary by time of day and energy level

### Example Before vs After

**Before (generic):**
> "Call mom" → "Added - social, ~15 min. Plan: 1) Find quiet spot, 2) Make call, 3) Note follow-ups"

**After (personalized):**
> "Call mom" → "Added - social, ~15 min. Plan: 1) Make a cup of tea, 2) Settle into the cozy chair, 3) Make call, 4) Note follow-ups"

## Changes

- **New file:** `docs/user-preferences.md` - Full documentation of the preference system
- **Updated:** `docs/notion-schema.md` - Added User Preferences table schema
- **Updated:** `docs/ai-prompts.md` - Added preference context injection for LLM prompts
- **Updated:** `docs/architecture.md` - Added preferences component to architecture diagrams
- **Updated:** `docs/task-lifecycle.md` - Updated breakdown flow to include personalization

## Preference Categories

1. **General preferences** - beverage, comfort spot, transition ritual
2. **Work type-specific** - focus, creative, social, independent
3. **Task pattern-specific** - phone calls, writing, email batch
4. **Contextual adjustments** - time of day, energy level

## Test plan

- [ ] Review new `docs/user-preferences.md` for completeness
- [ ] Verify Notion schema updates are compatible with existing structure
- [ ] Confirm AI prompt changes maintain structured output format
- [ ] Review architecture diagrams for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)