### PR TITLE
Add .env.example for developer onboarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Copy this to .env and fill in your values
+# .env is gitignored and will NOT be committed
+
+# Notion integration token (from https://www.notion.so/my-integrations)
+NOTION_API_KEY=
+
+# Notion database ID for your test database
+NOTION_DATABASE_ID=
+
+# Anthropic API key (from https://console.anthropic.com)
+ANTHROPIC_API_KEY=


### PR DESCRIPTION
## Summary

- Adds `.env.example` template showing the environment variables needed for local development
- Covers Notion API key, Notion database ID, and Anthropic API key
- `.env` is already gitignored so developers can safely copy this file and fill in their values

## Context

As the Rust application grows to integrate with Notion and the Anthropic API, developers will need these tokens available in their local devcontainers. This template makes onboarding straightforward: copy to `.env`, fill in values, and go.

## Test plan

- [x] `.env` is in `.gitignore` — confirmed
- [ ] Verify `.env.example` contains the expected variable names

🤖 Generated with [Claude Code](https://claude.com/claude-code)