### PR TITLE
Add rust-analyzer to devcontainer image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,6 +4,9 @@
 
 FROM mcr.microsoft.com/devcontainers/rust:1
 
+# Install rust-analyzer LSP (used by Claude Code for diagnostics)
+RUN rustup component add rust-analyzer
+
 # Install system packages: Playwright browser dependencies, zsh, and utilities
 # Consolidates what was previously in common-utils feature
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary
- Pre-install `rust-analyzer` as a rustup component in the devcontainer Dockerfile
- Eliminates runtime prompt from Claude Code to install the LSP
- Baked into a Docker layer so it's cached for both local dev and GHA CI pipelines

## Test plan
- [ ] Rebuild devcontainer and verify `rust-analyzer` is available (`rust-analyzer --version`)
- [ ] Confirm Claude Code no longer prompts to install rust-analyzer LSP

🤖 Generated with [Claude Code](https://claude.com/claude-code)