### PR TITLE
Add Docker build and smoke test to pre-push hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -15,4 +15,45 @@ cargo clippy --all-targets -- -D warnings
 echo "pre-push: running tests..."
 cargo test
 
+echo "pre-push: running Docker build and smoke test..."
+if [ -f "Dockerfile" ] && command -v docker >/dev/null 2>&1; then
+    IMAGE_TAG="hide-my-list-pre-push:$$"
+    CONTAINER_NAME="pre-push-smoke-$$"
+
+    cleanup() {
+        docker stop "$CONTAINER_NAME" >/dev/null 2>&1 || true
+        docker rm "$CONTAINER_NAME" >/dev/null 2>&1 || true
+        docker rmi "$IMAGE_TAG" >/dev/null 2>&1 || true
+    }
+    trap cleanup EXIT
+
+    docker build -t "$IMAGE_TAG" .
+
+    docker run -d --name "$CONTAINER_NAME" -p 8080:8080 "$IMAGE_TAG"
+
+    echo "pre-push: waiting for container health check (max 30s)..."
+    for i in $(seq 1 30); do
+        if ! docker ps -q --filter "name=$CONTAINER_NAME" | grep -q .; then
+            echo "pre-push: container exited unexpectedly!"
+            docker logs "$CONTAINER_NAME"
+            exit 1
+        fi
+
+        if curl -sf http://localhost:8080/health >/dev/null 2>&1; then
+            echo "pre-push: container smoke test passed"
+            break
+        fi
+
+        if [ "$i" -eq 30 ]; then
+            echo "pre-push: container failed to become healthy within 30 seconds"
+            docker logs "$CONTAINER_NAME"
+            exit 1
+        fi
+
+        sleep 1
+    done
+else
+    echo "pre-push: skipping Docker smoke test (no Dockerfile or Docker not available)"
+fi
+
 echo "pre-push: all checks passed."


### PR DESCRIPTION
## Summary
- Adds Docker build validation and container startup smoke test to the pre-push git hook, matching what CI already runs in `pr-tests.yml`
- Gracefully skips if no Dockerfile exists or Docker is not available
- Uses PID-scoped container/image names and trap-based cleanup to avoid conflicts and resource leaks

## Test plan
- [ ] Verify `git push` triggers Docker build and smoke test when Docker is available
- [ ] Verify the hook skips gracefully when Docker is not installed
- [ ] Verify cleanup runs on both success and failure (no leftover containers/images)
- [ ] Verify existing clippy and cargo test checks still run before the Docker step

🤖 Generated with [Claude Code](https://claude.com/claude-code)