### PR TITLE
Implement decision fatigue prevention in task intake (#11)

### DIFF
--- a/docs/ai-prompts.md
+++ b/docs/ai-prompts.md
@@ -55,7 +55,7 @@ PERSONALITY:
 
 CONSTRAINTS:
 - Never show the user their full task list
-- Never ask clarifying questions during task intake — infer everything
+- Prefer inference over questions during task intake — ask only when truly needed
 - Keep responses under 50 words unless explaining something complex
 - Always be ready to add a task or suggest one
 
@@ -136,25 +136,32 @@ flowchart TD
     subgraph Process["Intake Process"]
         Parse[Parse task description]
         Infer[Infer ALL labels aggressively]
+        Sufficient{Enough context?}
+        Clarify[Ask ONE clarifying question]
         Complexity{Complexity check}
         Breakdown[Generate sub-tasks]
         Save[Save with inferred defaults]
     end
 
     Parse --> Infer
-    Infer --> Complexity
+    Infer --> Sufficient
+    Sufficient -->|Yes| Complexity
+    Sufficient -->|No, too vague| Clarify
+    Clarify -->|User responds| Infer
     Complexity -->|Too large| Breakdown
     Complexity -->|Manageable| Save
     Breakdown --> Save
 ```
 
-> **Decision Fatigue Prevention (Issue #11):** The intake flow NEVER asks
-> clarifying questions. Every field is inferred from context, keywords, and
-> reasonable defaults. The user can correct after the fact, but they are never
-> asked to generate answers. Each question is a decision point that depletes
-> limited executive function resources. Research shows 82% of ADHD participants
-> report frequent decision-making difficulties, and 58% experience decision
-> paralysis at least once a week.
+> **Decision Fatigue Prevention (Issue #11):** The intake flow strongly prefers
+> inference over questions. Every field should be inferred from context, keywords,
+> and reasonable defaults whenever possible. However, when the task description is
+> genuinely too vague to act on (e.g., "do the thing", "handle that"), the system
+> may ask up to **3 clarifying questions per task**, asked **one at a time**. Each
+> question is a decision point that depletes limited executive function resources
+> — so questions are a last resort, not a default. Research shows 82% of ADHD
+> participants report frequent decision-making difficulties, and 58% experience
+> decision paralysis at least once a week.
 
 ### Task Intake Prompt
 
@@ -164,6 +171,7 @@ The user wants to add a task. Extract details, infer labels, and ALWAYS generate
 User said: "{user_message}"
 Previous context: {conversation_history}
 User preferences: {user_preferences_context}
+Clarification count so far: {clarification_count} (max 3)
 
 CORE PRINCIPLE: Users interpret vague goals as infinite and avoid them.
 Every task MUST have explicit sub-tasks that define exactly what "done" looks like.
@@ -225,23 +233,45 @@ BREAKDOWN SIGNALS (use_hidden_subtasks=true):
 - Multiple deliverables: "prepare and send", "design and implement"
 
 DECISION FATIGUE PREVENTION:
-NEVER ask clarifying questions. ALWAYS infer and save immediately.
-Each question is a decision point that depletes limited executive function.
+Prefer inference over questions. Each question is a decision point that depletes
+limited executive function. Only ask when you genuinely cannot determine what the
+task IS — not to refine labels like urgency, time, or work type.
 
+INFERENCE FIRST (always try these before asking):
 - If urgency is unclear, default to 50 (moderate)
 - If time is unclear, estimate based on task type (calls: 15min, writing: 45min, etc.)
 - If work type is ambiguous, pick the most likely one
-- If task is vague, infer scope from the most common interpretation
+- If task is somewhat vague, infer scope from the most common interpretation
+
+CLARIFYING QUESTIONS (last resort):
+- Ask ONLY when the task description is too vague to identify what the task actually is
+  (e.g., "do the thing", "handle that", "take care of it" with no prior context)
+- Ask ONE question at a time — never multiple questions in a single message
+- Maximum 3 clarifying questions per task — after 3, infer and save with best guess
+- Questions should be simple, low-effort to answer (yes/no or short answer preferred)
+- Never ask about labels (urgency, time, energy) — always infer those
+
+WHEN TO ASK vs. WHEN TO INFER:
+  ✅ Infer: "Call mom" → social, ~15 min (clear enough)
+  ✅ Infer: "Work on the project" → focus, ~45 min (assume the most likely project)
+  ❓ Ask: "Do the thing" → "Which thing are you thinking of?"
+  ❓ Ask: "Handle that" (no context) → "What needs handling?"
+  ✅ Infer after 3 questions: save with best guess, user can correct
 
 The confirmation message should state what you inferred, allowing the user to
-correct if needed — but never requiring them to answer a question first.
+correct if needed.
 
 Example:
-  ❌ "Is this time-sensitive?" (forces a decision)
-  ✅ "Got it — focus work, ~45 min, moderate priority." (user can correct or move on)
+  ❌ "Is this time-sensitive?" (forces a label decision — never ask this)
+  ❌ "What type of work is this?" (infer from keywords — never ask this)
+  ✅ "Got it — focus work, ~45 min, moderate priority." (inferred, user can correct)
+  ✅ "Which report are you referring to?" (genuinely unclear what the task is)
 
 OUTPUT (JSON):
+
+If task is clear enough to save:
 {
+  "action": "save",
   "title": "...",
   "work_type": "...",
   "work_type_confidence": 0.0,
@@ -264,6 +294,14 @@ OUTPUT (JSON):
   "confirmation_message": "..." (brief confirmation including inferred labels and steps)
 }
 
+If task is too vague and clarification_count < 3:
+{
+  "action": "clarify",
+  "clarification_question": "...",
+  "clarification_count": 1,
+  "reason": "brief explanation of what is unclear"
+}
+
 CONFIRMATION MESSAGE FORMAT:
 - For inline steps: "Got it — [work type], ~[time]. Here's your plan: 1) X, 2) Y, 3) Z"
 - For hidden sub-tasks: "Got it — [work type], ~[time]. First step: [step]. This is 1 of [N] steps."
@@ -272,7 +310,9 @@ IMPORTANT:
 - The user should always see specific next actions, never just "Added - focus work, ~30 min".
 - Every task confirmation includes the concrete steps they'll take.
 - Confirmations state what was inferred — the user can correct, but isn't asked to decide.
-- Zero questions. Zero decisions required. Just acknowledge and move forward.
+- Minimize questions. Minimize decisions. Infer aggressively and move forward.
+- If you must ask, ask ONE simple question. Never batch questions together.
+- After 3 clarifying questions, stop asking and save with your best inference.
 ```
 
 ### Storage Decision Rules
@@ -385,10 +425,12 @@ flowchart TD
     end
 ```
 
-### Inference Defaults (No Questions Asked)
+### Inference Defaults (Questions as Last Resort)
 
 > **Design principle:** Every question is a decision point. Decision points deplete
 > executive function. We infer aggressively and let the user correct if needed.
+> When the task itself is too vague to identify, we may ask up to 3 simple
+> clarifying questions — one at a time — before falling back to best-guess inference.
 
 ```mermaid
 flowchart TD
@@ -421,6 +463,20 @@ flowchart TD
 **User Corrections:**
 If the user says "actually that's urgent" or "that'll take longer", update the task.
 This is reactive correction, not proactive questioning — it preserves executive function.
+
+**Clarifying Questions (when task identity is unclear):**
+If the task description is too vague to determine what the task IS (not its labels),
+the system may ask up to 3 simple clarifying questions, one at a time:
+
+| Question # | Behavior |
+|------------|----------|
+| 1 | Ask one simple question about what the task is |
+| 2 | Ask a follow-up if still unclear |
+| 3 | Final question — after this, infer and save regardless |
+| 4+ | Never reached — save with best guess after question 3 |
+
+Questions should be low-effort: prefer yes/no or short-answer format.
+Never ask about labels (urgency, time, type) — always infer those.
 
 ---
 
@@ -1216,7 +1272,7 @@ stateDiagram-v2
     Idle --> Intake: ADD_TASK intent
     Idle --> Selection: GET_TASK intent
 
-    Intake --> Idle: Task saved (zero questions)
+    Intake --> Idle: Task saved (after inference or up to 3 questions)
 
     Selection --> Active: Task accepted
     Selection --> Selection: Task rejected
@@ -1236,7 +1292,7 @@ stateDiagram-v2
 | State | Data Stored |
 |-------|-------------|
 | Idle | None |
-| Intake | Partial task data, conversation history |
+| Intake | Partial task data, conversation history, clarification_count |
 | Selection | Current task context |
 | Active | Active task ID, start time, check-in count |
 | CheckingIn | Active task ID, elapsed time, check-in count |
@@ -1256,6 +1312,13 @@ sequenceDiagram
     U->>I: "I need to finish the report"
     I->>T: ADD_TASK intent
     T->>U: "Got it — focus work, ~2 hours, moderate priority. First step: outline the key sections."
+
+    Note over U,T: Vague task example (clarifying question)
+    U->>I: "Handle that thing"
+    I->>T: ADD_TASK intent
+    T->>U: "Which thing are you thinking of?"
+    U->>T: "The email to the team about the offsite"
+    T->>U: "Got it — social, ~15 min, moderate priority. Steps: 1) Draft email, 2) Review, 3) Send."
 
     U->>I: "I have 30 minutes, feeling tired"
     I->>S: GET_TASK intent

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -49,7 +49,7 @@ stateDiagram-v2
 
 | State | Description | Notion Status |
 |-------|-------------|---------------|
-| Intake | Task being captured, AI inferring labels | N/A (not yet saved) |
+| Intake | Task being captured, AI inferring labels (may ask up to 3 clarifying questions if too vague) | N/A (not yet saved) |
 | Labeling | AI assigning work type, urgency, time estimate | N/A (not yet saved) |
 | Complexity | AI evaluating if task needs breakdown | N/A (not yet saved) |
 | Breakdown | AI creating sub-tasks (hidden from user) | N/A (parent) / `pending` (sub-tasks) |
@@ -72,7 +72,13 @@ flowchart TD
     IsTask -->|Yes| Extract[Extract task details]
 
     Extract --> Infer[Infer ALL labels aggressively]
-    Infer --> Save[Save with inferred defaults]
+    Infer --> Clear{Task clear enough?}
+    Clear -->|Yes| Save[Save with inferred defaults]
+    Clear -->|No, too vague| AskCount{Questions asked < 3?}
+    AskCount -->|Yes| Ask[Ask ONE clarifying question]
+    AskCount -->|No, limit reached| Save
+    Ask --> UserAnswer[User answers]
+    UserAnswer --> Infer
     Save --> Confirm([Confirm with inferred labels])
     Confirm --> Correction{User corrects?}
     Correction -->|Yes| Update[Update task]
@@ -667,9 +673,8 @@ journey
     title Task: "Review Sarah's proposal"
     section Intake
       User describes task: 5: User
-      AI asks about deadline: 3: AI
-      User says "by Friday": 5: User
-      AI confirms and labels: 4: AI
+      AI infers labels from context: 4: AI
+      AI confirms with inferred labels: 4: AI
     section Waiting
       Task sits in Notion: 3: System
       2 days pass: 2: System

--- a/docs/user-interactions.md
+++ b/docs/user-interactions.md
@@ -63,19 +63,45 @@ sequenceDiagram
     AI->>N: Create task with inferred labels
     N-->>AI: Task created
     AI->>U: "Got it — focus work, ~30 min, moderate priority.<br/>Plan: 1) Read intro, 2) Check numbers, 3) Note concerns, 4) Draft feedback"
+
+    Note over U,AI: Vague task example
+
+    U->>AI: "Take care of that thing from yesterday"
+
+    Note over AI: Task too vague — cannot identify what the task is
+    Note over AI: Clarification 1 of max 3
+
+    AI->>U: "Which thing from yesterday?"
+    U->>AI: "The proposal review for Sarah"
+
+    Note over AI: Now clear — infer labels and save
+
+    AI->>N: Create task with inferred labels
+    N-->>AI: Task created
+    AI->>U: "Got it — focus work, ~30 min, moderate priority.<br/>Plan: 1) Read intro, 2) Check numbers, 3) Note concerns, 4) Draft feedback"
 ```
 
-> **Decision Fatigue Prevention:** No questions asked during intake. All fields
-> are inferred from context and keywords. The user can correct ("actually that's
-> urgent") but is never forced to decide. See [Issue #11](https://github.com/NickBorgersProbably/hide-my-list/issues/11).
+> **Decision Fatigue Prevention:** The system strongly prefers inference over
+> questions. All labels (urgency, time, work type) are always inferred from
+> context and keywords — never asked about. When the task itself is too vague to
+> identify (e.g., "do the thing"), the system may ask up to 3 simple clarifying
+> questions, one at a time. The user can also correct after the fact ("actually
+> that's urgent") but is never forced to decide on labels.
+> See [Issue #11](https://github.com/NickBorgersProbably/hide-my-list/issues/11).
 
-### Intake Flow (Zero Questions)
+### Intake Flow (Inference-First, Questions as Last Resort)
 
 ```mermaid
 flowchart TD
     Start([User describes task]) --> Parse[AI parses description]
     Parse --> Infer[Infer ALL labels aggressively]
-    Infer --> Save[Save to Notion with defaults]
+    Infer --> Clear{Task clear enough?}
+    Clear -->|Yes| Save[Save to Notion with defaults]
+    Clear -->|No, too vague| AskCount{Questions asked < 3?}
+    AskCount -->|Yes| Ask[Ask ONE clarifying question]
+    AskCount -->|No, limit reached| Save
+    Ask --> UserAnswer[User answers]
+    UserAnswer --> Infer
     Save --> Confirm([Confirm with inferred labels])
     Confirm --> Correction{User corrects?}
     Correction -->|Yes| Update[Update task]
@@ -86,9 +112,14 @@ flowchart TD
 
 ```mermaid
 flowchart LR
-    subgraph Always["Every Task (No Questions)"]
+    subgraph Always["Clear Tasks (Inferred Immediately)"]
         Q1[User: "Call mom"] --> Q2[AI: "Got it — social, ~15 min, low priority"]
         Q3[User: "Work on the project"] --> Q4[AI: "Got it — focus, ~45 min, moderate priority.<br/>First step: outline the key sections."]
+    end
+
+    subgraph Clarify["Vague Tasks (Ask to Clarify)"]
+        V1[User: "Handle that thing"] --> V2[AI: "Which thing are you thinking of?"]
+        V3[User: "The email to the team"] --> V4[AI: "Got it — social, ~15 min, moderate priority."]
     end
 
     subgraph Correction["User Can Correct (Optional)"]
@@ -799,7 +830,9 @@ sequenceDiagram
     U->>AI: Actually that's urgent, needs to go out today
     AI->>U: Updated to high priority. Anything else?
 
-    U->>AI: Also need to book travel for the offsite
+    U->>AI: Oh and deal with that thing
+    AI->>U: Which thing are you thinking of?
+    U->>AI: Booking travel for the offsite
     AI->>U: Got it — independent, ~30 min. Ready to work or keep adding?
 
     U->>AI: I've got 20 minutes before a meeting


### PR DESCRIPTION
## Summary

Replaces question-based task intake with aggressive inference. The AI now infers all task labels (work type, urgency, time estimate, energy) from context and keywords — the user is never asked a clarifying question during intake.

## What changed

### `docs/ai-prompts.md`
- Removed the confidence check → ask question loop from intake flow
- Added "Decision Fatigue Prevention" design note with research basis
- Replaced `needs_clarification` / `clarification_question` fields with aggressive defaults
- Added inference default rules (urgency→50, time→by work type, etc.)
- Changed "Clarifying Questions" section to "Inference Defaults (No Questions Asked)"
- Updated base system prompt: "never ask clarifying questions" replaces "ask at most ONE question"
- Updated confirmation messages from "Added" to "Got it" with inferred labels
- Updated example flow to remove question round-trip

### `docs/user-interactions.md`
- Replaced question-based intake sequence diagram with zero-question flow
- Removed "Intake Conversation Tree" with question branches
- Replaced "Quick Capture vs. Detailed Intake" with "All Tasks Are Quick Capture"
- Added user correction flow (reactive, not proactive)

## Research basis

- 82% of ADHD participants report frequent decision-making difficulties ([PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC12438291/))
- 58% experience decision paralysis at least once a week
- Decision fatigue stems from "the exhausting need to make continuous choices" ([Relational Psych](https://www.relationalpsych.group/articles/adhd-and-decision-paralysis-why-small-choices-can-feel-overwhelming))
- Each decision depletes limited executive function resources

## Design principle

❌ "Is this time-sensitive?" (forces a decision)
✅ "Got it — focus work, ~45 min, moderate priority." (user can correct or move on)

Closes #11