### PR TITLE
Implement task initiation rewards (#7)

### DIFF
--- a/docs/ai-prompts.md
+++ b/docs/ai-prompts.md
@@ -1187,11 +1187,13 @@ stateDiagram-v2
     Intake --> Intake: Clarifying
     Intake --> Idle: Task saved
 
-    Selection --> Active: Task accepted
+    Selection --> Active: Task accepted + initiation reward
     Selection --> Selection: Task rejected
     Selection --> Idle: No suitable task
 
-    Active --> Idle: Task completed
+    Active --> FirstStep: First sub-step done + reward
+    FirstStep --> Active: Continue working
+    Active --> Idle: Task completed + celebration
     Active --> Selection: Task abandoned
     Active --> CheckingIn: Timer expires
 

--- a/docs/notion-schema.md
+++ b/docs/notion-schema.md
@@ -30,6 +30,9 @@ erDiagram
         relation parent_task_id FK "Parent task (if sub-task)"
         number sequence "Order within parent (1, 2, 3...)"
         rich_text progress_notes "What user accomplished"
+        date started_at "Set when user accepts task"
+        number steps_completed "Sub-steps finished"
+        number resume_count "Times user returned to task"
     }
 
     USER_PREFERENCES {
@@ -397,6 +400,26 @@ Format:
 - Understanding what work remains after CANNOT_FINISH
 - Creating accurate sub-tasks for remaining work
 - Providing context when resuming work
+
+### StartedAt (date)
+
+Timestamp set when the user accepts and begins a task. Used for:
+- Calculating actual task duration (with CompletedAt)
+- Triggering initiation rewards
+- Building per-user time estimation data for time blindness compensation (Issue #6)
+
+### StepsCompleted (number)
+
+Count of sub-steps the user has completed within the current task. Used for:
+- Triggering first-step rewards (when incrementing from 0 to 1)
+- Tracking partial progress during CANNOT_FINISH events
+- Providing encouragement on sub-task completion
+
+### ResumeCount (number)
+
+Number of times the user has returned to a task after stepping away. Used for:
+- Triggering "back at it" rewards (re-starting is hard)
+- Understanding user work patterns (frequent breaks vs. sustained sessions)
 
 ---
 

--- a/docs/reward-system.md
+++ b/docs/reward-system.md
@@ -47,6 +47,9 @@ The reward system operates on the principle that **completing tasks should feel 
 ```mermaid
 flowchart TB
     subgraph Trigger["Reward Triggers"]
+        Initiation[Task Started]
+        FirstStep[First Step Done]
+        Resume[Resumed After Break]
         Complete[Task Completed]
         Streak[Streak Achieved]
         Milestone[Milestone Reached]
@@ -70,6 +73,9 @@ flowchart TB
         Outing[Suggest Outing]
     end
 
+    Initiation --> Select
+    FirstStep --> Select
+    Resume --> Select
     Complete --> Select
     Streak --> Select
     Milestone --> Select
@@ -115,7 +121,49 @@ flowchart LR
     Epic --> EpicEmoji
 ```
 
-#### Celebration Message Templates
+#### Initiation Reward Templates (Issue #7)
+
+> **Design principle:** Starting is harder than finishing for ADHD brains.
+> Initiation rewards acknowledge this truth. They should feel like genuine
+> encouragement from someone who understands, not participation trophies.
+> Keep them brief — the user is about to start working.
+
+```mermaid
+flowchart TD
+    subgraph Triggers["Initiation Trigger Points"]
+        Accept[User accepts task] --> StartReward[Initiation Reward]
+        FirstStep[First sub-step completed] --> ProgressReward[First-Step Reward]
+        Return[User returns to paused task] --> ResumeReward[Resume Reward]
+    end
+
+    subgraph Intensity["Reward Intensity Scale"]
+        Init["Initiation: Lightest<br/>Brief acknowledgment"]
+        First["First Step: Light<br/>Momentum confirmation"]
+        Res["Resume: Light-Medium<br/>Extra recognition (re-starting is hard)"]
+        Comp["Completion: Full<br/>Real celebration"]
+    end
+
+    StartReward --> Init
+    ProgressReward --> First
+    ResumeReward --> Res
+```
+
+| Trigger | Intensity | Example Messages |
+|---------|-----------|------------------|
+| Task accepted (starting) | Lightest | "You're in. That's the hardest part.", "Starting — nice.", "Let's go." |
+| First sub-step done | Light | "First step done — you're in motion now.", "One down. Momentum's real." |
+| Resumed after break | Light-Medium | "Back at it — picking up where you left off is a skill.", "Welcome back. Ready to keep going?" |
+| Started 3+ tasks today | Light | "Third start today — your initiation muscle is getting stronger." |
+
+**Important design constraints:**
+- Initiation rewards must be **briefer and lighter** than completion rewards
+- Never celebrate starting so much that it diminishes the completion celebration
+- Tone is **acknowledgment of difficulty**, not generic cheerleading
+- "You started" validates that starting is genuinely hard — don't trivialize it
+- First-time users should always get an initiation reward; for returning users,
+  vary frequency to avoid habituation (see Issue #12 for novelty)
+
+#### Completion Celebration Message Templates
 
 | Trigger | Intensity | Example Messages |
 |---------|-----------|------------------|

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -410,11 +410,18 @@ stateDiagram-v2
 
 ## Phase 5: Check-In Follow-Up
 
-When a user accepts a task, the system sets a timer for 1.25x the estimated time. If the user hasn't marked the task complete, the system proactively checks in.
+When a user accepts a task, the system provides a brief **initiation reward** (acknowledging that starting is the hardest part), sets `started_at`, and sets a timer for 1.25x the estimated time. If the user hasn't marked the task complete, the system proactively checks in.
+
+> **Task Initiation Rewards (Issue #7):** Starting is harder than finishing for
+> ADHD brains. The moment of acceptance triggers a brief acknowledgment:
+> "You're in. That's the hardest part." This is lighter than completion
+> celebrations — encouragement, not a party.
 
 ```mermaid
 flowchart TD
-    Accept([User accepts task]) --> SetTimer[Set timer: estimate × 1.25]
+    Accept([User accepts task]) --> InitReward[Initiation reward:<br/>"You're in. That's the hardest part."]
+    InitReward --> SetStarted[Set started_at timestamp]
+    SetStarted --> SetTimer[Set timer: estimate × 1.25]
     SetTimer --> Wait[Timer running...]
 
     Wait --> TimerFires{Timer expires}


### PR DESCRIPTION
## Summary

Adds reward triggers for task initiation, first-step completion, and resuming after breaks. Starting is harder than finishing for ADHD brains — the hardest moment should not go unreinforced.

## What changed

### `docs/reward-system.md`
- Added Initiation, FirstStep, and Resume to reward trigger architecture
- Added initiation reward templates with intensity hierarchy:
  - Initiation (lightest): "You're in. That's the hardest part."
  - First step (light): "First step done — you're in motion now."
  - Resume (light-medium): "Back at it — picking up where you left off is a skill."
  - Completion (full): existing celebration system
- Design constraints: initiation rewards must be briefer and lighter than completion rewards

### `docs/notion-schema.md`
- Added `started_at` (date) for tracking when user begins task
- Added `steps_completed` (number) for sub-step progress
- Added `resume_count` (number) for tracking returns after breaks

### `docs/ai-prompts.md`
- Added FirstStep state to conversation state machine
- Updated Selection → Active transition to include initiation reward

### `docs/task-lifecycle.md`
- Added initiation reward and started_at recording to task acceptance flow

## Research basis

- [Healing Psychiatry FL](https://www.healingpsychiatryflorida.com/adhd/adhd-task-initiation/): "Getting started is often the most difficult part"
- [Tiimo](https://www.tiimoapp.com/resource-hub/task-initiation-adhd): Low dopamine makes initiation specifically difficult
- [PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC2626918/): ADHD reward systems need immediate reinforcement

Closes #7