### PR TITLE
Fix #42: Assign NickBorgers to pipeline-created PRs and issues

### DIFF
--- a/.github/workflows/claude-diagnose-workflow-failure.yml
+++ b/.github/workflows/claude-diagnose-workflow-failure.yml
@@ -232,6 +232,7 @@ jobs:
             gh label create \"github-actions\" --color \"0366d6\" --description \"GitHub Actions workflow issues\" 2>/dev/null || true
             gh issue create \\
               --title \"Workflow Failure: ${WORKFLOW_NAME} run #${RUN_ID} - Actions Configuration Issue\" \\
+              --assignee NickBorgers \\
               --label \"bug,github-actions\" \\
               --body \"\$(cat <<'ISSUE_BODY'
             ## Workflow Failure Report

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -392,6 +392,7 @@ jobs:
 
             PR CREATION:
             gh pr create --title 'Fix #${ISSUE_NUMBER}: <brief description>' \\
+              --assignee NickBorgers \\
               --body 'Resolves #${ISSUE_NUMBER}
 
             ## Summary

--- a/.github/workflows/review-coverage-evaluator.yml
+++ b/.github/workflows/review-coverage-evaluator.yml
@@ -175,6 +175,7 @@ jobs:
             2. Create a GitHub issue:
                gh issue create \\
                  --title \"Review Pipeline Gap: <brief description of the gap>\" \\
+                 --assignee NickBorgers \\
                  --label \"review-pipeline\" \\
                  --body \"\$(cat <<'ISSUE_BODY'
             ## Review Pipeline Coverage Gap


### PR DESCRIPTION
Resolves #42

## Summary
- Added `--assignee NickBorgers` to the `gh pr create` command in `claude.yml` (resolve-issue job)
- Added `--assignee NickBorgers` to the `gh issue create` command in `claude-diagnose-workflow-failure.yml`
- Added `--assignee NickBorgers` to the `gh issue create` command in `review-coverage-evaluator.yml`

All three autonomous pipeline workflows that create PRs or issues will now assign them to NickBorgers by default.

## Test Plan
- Verify the YAML syntax is valid by inspecting the workflow diffs
- On next issue-triggered pipeline run, confirm the created PR is assigned to NickBorgers
- On next workflow failure diagnosis, confirm the created issue is assigned to NickBorgers
- On next review coverage evaluation gap, confirm the created issue is assigned to NickBorgers

🤖 Generated with [Claude Code](https://claude.com/claude-code)