### PR TITLE
Fix #48: Move initiation reward docs from Phase 5 to Phase 4

### DIFF
--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -409,14 +409,18 @@ stateDiagram-v2
     Completed --> [*]
 ```
 
-## Phase 5: Check-In Follow-Up
+### Task Initiation Rewards
 
-When a user accepts a task, the system provides a brief **initiation reward** (acknowledging that starting is the hardest part), sets `started_at`, and sets a timer for 1.25x the estimated time. If the user hasn't marked the task complete, the system proactively checks in.
+When a user accepts a task, the system provides a brief **initiation reward** acknowledging that starting is the hardest part.
 
 > **Task Initiation Rewards (Issue #7):** Starting is harder than finishing for
 > ADHD brains. The moment of acceptance triggers a brief acknowledgment:
 > "You're in. That's the hardest part." This is lighter than completion
 > celebrations — encouragement, not a party.
+
+## Phase 5: Check-In Follow-Up
+
+After acceptance, the system sets `started_at` and sets a timer for 1.25x the estimated time. If the user hasn't marked the task complete, the system proactively checks in.
 
 ```mermaid
 flowchart TD


### PR DESCRIPTION
Resolves #48

## Summary
- Moved the initiation reward documentation from Phase 5 (Check-In Follow-Up) to Phase 4 (Task Execution) as a new subsection, since the initiation reward fires at task acceptance time, not check-in time
- Updated Phase 5 intro text to focus on timer and check-in behavior rather than initiation rewards
- The mermaid flowchart in Phase 5 still shows the full accept→reward→timer flow for completeness

## Test Plan
- [ ] Review `docs/task-lifecycle.md` and verify the initiation reward content now appears under Phase 4
- [ ] Verify Phase 5 intro text correctly describes check-in/timer behavior
- [ ] Confirm the mermaid diagrams still render correctly

Generated with Claude Code