### PR TITLE
Fix #46: Define resume detection mechanism for resume_count

### DIFF
--- a/docs/notion-schema.md
+++ b/docs/notion-schema.md
@@ -417,9 +417,17 @@ Count of sub-steps the user has completed within the current task. Used for:
 
 ### ResumeCount (number)
 
-Number of times the user has returned to a task after stepping away. Used for:
-- Triggering "back at it" rewards (re-starting is hard)
+Number of times the user has returned to a task after stepping away. Incremented when the system detects a resume (see [task-lifecycle.md — Resume Detection](./task-lifecycle.md#phase-51-resume-detection) for the full detection mechanism).
+
+**Detection triggers** (any one is sufficient):
+1. **Session boundary** — a new conversation session starts while a task is `in_progress`
+2. **Inactivity gap** — no user messages for >= 15 minutes, then user re-engages with the active task
+3. **Explicit signal** — user says "I'm back", "resuming", or similar phrases
+
+**Used for:**
+- Triggering "back at it" rewards (re-starting is hard — see reward table in task-lifecycle.md)
 - Understanding user work patterns (frequent breaks vs. sustained sessions)
+- Logging resume events in `progress_notes` with gap duration
 
 ---
 

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -500,6 +500,98 @@ The system limits check-ins to 3 per task session to avoid nagging:
 
 If the user returns later and re-accepts the same task, the check-in count resets.
 
+## Phase 5.1: Resume Detection
+
+When a user returns to a task after stepping away, the system detects the resume and increments `resume_count`. Re-engaging with a task after a break requires real effort (especially for ADHD brains), and the system acknowledges this with a "back at it" reward.
+
+### What Constitutes a Resume
+
+A resume is detected when **all** of the following are true:
+
+1. A task has status `in_progress`
+2. There has been a **gap in user interaction** of at least **15 minutes** (no messages from the user in any conversation with the agent)
+3. The user sends a new message that relates to the active task (either explicitly referencing it or continuing work in the same conversation context)
+
+```mermaid
+flowchart TD
+    Msg([User sends message]) --> HasActive{Task currently<br/>in_progress?}
+
+    HasActive -->|No| Normal[Handle normally]
+    HasActive -->|Yes| CheckGap{Last user message<br/>> 15 min ago?}
+
+    CheckGap -->|No| Continue[Continue session<br/>No resume triggered]
+    CheckGap -->|Yes| CheckIntent{Message relates to<br/>active task?}
+
+    CheckIntent -->|No| NewIntent[Handle as new intent<br/>No resume triggered]
+    CheckIntent -->|Yes| Resume[Trigger resume]
+
+    Resume --> Increment[Increment resume_count]
+    Increment --> Reward["'Welcome back! Picking up<br/>where you left off is a superpower.'"]
+    Reward --> ResetCheckins[Reset check-in count]
+    ResetCheckins --> SetTimer[Set new check-in timer]
+```
+
+### Detection Signals (Priority Order)
+
+The system uses a layered approach to detect resumes:
+
+| Priority | Signal | Detection Method | Example |
+|----------|--------|------------------|---------|
+| 1 | **Session boundary** | A new conversation session starts while a task is `in_progress` | User opens a new chat window |
+| 2 | **Inactivity gap** | No user messages for >= 15 minutes with an `in_progress` task | User goes to lunch, comes back |
+| 3 | **Explicit signal** | User says phrases like "I'm back", "picking up where I left off", "resuming" | User announces return |
+
+Any one of these signals is sufficient to trigger a resume. Session boundaries and explicit signals always trigger a resume regardless of the time gap.
+
+### Time Threshold Rationale
+
+The 15-minute threshold balances two concerns:
+
+- **Too short** (< 10 min): Normal pauses (bathroom, getting water) would trigger false resumes
+- **Too long** (> 30 min): Genuine re-engagement after distraction would go unrecognized
+
+15 minutes is chosen because it exceeds typical micro-breaks but catches the common ADHD pattern of getting pulled away by a distraction and returning.
+
+### Resume vs. Abandon
+
+```mermaid
+flowchart TD
+    Gap{Inactivity gap<br/>with in_progress task} --> Short{< 15 min?}
+    Short -->|Yes| NoAction[No action — normal pause]
+    Short -->|No| Medium{< 4 hours?}
+    Medium -->|Yes| ResumeDetected[Resume detected<br/>Increment resume_count]
+    Medium -->|No| Long{< 24 hours?}
+    Long -->|Yes| GentleResume["Resume + gentle check-in<br/>'Still working on X?'"]
+    Long -->|No| AbandonCheck["Offer to return task to queue<br/>'Want to keep going or set this aside?'"]
+```
+
+| Gap Duration | Behavior |
+|-------------|----------|
+| < 15 min | No action (normal pause) |
+| 15 min – 4 hours | Resume detected, increment `resume_count`, brief encouragement |
+| 4 – 24 hours | Resume detected, increment `resume_count`, confirm user still wants to work on task |
+| > 24 hours | Ask if user wants to continue or return task to `pending` |
+
+### Resume Rewards
+
+Returning to a task is psychologically harder than starting one fresh. The system acknowledges this:
+
+| Resume Count | Reward |
+|-------------|--------|
+| 1st resume | "Welcome back! Picking up where you left off is a superpower." |
+| 2nd resume | "Back again — that's persistence." |
+| 3rd+ resume | "You keep coming back to this. That takes real grit." |
+
+### On Resume: State Restoration
+
+When a resume is detected, the system:
+
+1. Increments `resume_count`
+2. Appends a timestamped entry to `progress_notes`: `[timestamp] Resumed (gap: Xm)`
+3. Resets the check-in count to 0 (fresh check-in cycle)
+4. Sets a new check-in timer based on remaining estimated time
+5. Briefly reminds the user where they left off (using `progress_notes` and `steps_completed`)
+
 ## Phase 6: Rejection Handling
 
 ```mermaid

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -506,24 +506,27 @@ When a user returns to a task after stepping away, the system detects the resume
 
 ### What Constitutes a Resume
 
-A resume is detected when **all** of the following are true:
+A resume is detected when a task has status `in_progress` and **any one** of the following detection signals fires:
 
-1. A task has status `in_progress`
-2. There has been a **gap in user interaction** of at least **15 minutes** (no messages from the user in any conversation with the agent)
-3. The user sends a new message that relates to the active task (either explicitly referencing it or continuing work in the same conversation context)
+1. **Session boundary** — a new conversation session starts while a task is `in_progress` (triggers regardless of time since last message)
+2. **Inactivity gap** — no user messages for >= 15 minutes with an `in_progress` task, then the user re-engages with the active task
+3. **Explicit signal** — user says phrases like "I'm back", "picking up where I left off", "resuming" (triggers regardless of time since last message)
 
 ```mermaid
 flowchart TD
-    Msg([User sends message]) --> HasActive{Task currently<br/>in_progress?}
+    HasActive{Task currently<br/>in_progress?}
 
     HasActive -->|No| Normal[Handle normally]
-    HasActive -->|Yes| CheckGap{Last user message<br/>> 15 min ago?}
+    HasActive -->|Yes| NewSession{New conversation<br/>session?}
+
+    NewSession -->|Yes| Resume[Trigger resume]
+    NewSession -->|No| ExplicitSignal{User says<br/>'I'm back' etc.?}
+
+    ExplicitSignal -->|Yes| Resume
+    ExplicitSignal -->|No| CheckGap{Last user message<br/>> 15 min ago?}
 
     CheckGap -->|No| Continue[Continue session<br/>No resume triggered]
-    CheckGap -->|Yes| CheckIntent{Message relates to<br/>active task?}
-
-    CheckIntent -->|No| NewIntent[Handle as new intent<br/>No resume triggered]
-    CheckIntent -->|Yes| Resume[Trigger resume]
+    CheckGap -->|Yes| Resume
 
     Resume --> Increment[Increment resume_count]
     Increment --> Reward["'Welcome back! Picking up<br/>where you left off is a superpower.'"]
@@ -535,13 +538,13 @@ flowchart TD
 
 The system uses a layered approach to detect resumes:
 
-| Priority | Signal | Detection Method | Example |
-|----------|--------|------------------|---------|
-| 1 | **Session boundary** | A new conversation session starts while a task is `in_progress` | User opens a new chat window |
-| 2 | **Inactivity gap** | No user messages for >= 15 minutes with an `in_progress` task | User goes to lunch, comes back |
-| 3 | **Explicit signal** | User says phrases like "I'm back", "picking up where I left off", "resuming" | User announces return |
+| Priority | Signal | Detection Method | Time gap required? | Example |
+|----------|--------|------------------|--------------------|---------|
+| 1 | **Session boundary** | A new conversation session starts while a task is `in_progress` | No | User opens a new chat window |
+| 2 | **Explicit signal** | User says phrases like "I'm back", "picking up where I left off", "resuming" | No | User announces return |
+| 3 | **Inactivity gap** | No user messages for >= 15 minutes with an `in_progress` task | Yes (>= 15 min) | User goes to lunch, comes back |
 
-Any one of these signals is sufficient to trigger a resume. Session boundaries and explicit signals always trigger a resume regardless of the time gap.
+Any one of these signals is sufficient to trigger a resume. Session boundaries and explicit signals always trigger a resume regardless of the time gap; the 15-minute threshold applies only to passive inactivity detection.
 
 ### Time Threshold Rationale
 


### PR DESCRIPTION
## Problem

The system prompt injects the current time in UTC. Since `envelopeTimezone` defaults to UTC when the `{{TZ_IDENTIFIER}}` placeholder isn't populated during setup, every new session starts with the wrong time-of-day context. This leads to awkward interactions (e.g., greeting "you're up early" at 11pm local) and incorrect relative date/time reasoning.

AGENTS.md step 8 tries to paper over this with a prompt-level instruction to call `scripts/user-time-context.sh`, but that's a weak guardrail — the agent has to remember to do it, and the injected `Current Date & Time` in the system prompt still says UTC regardless.

## Proposed Fix

### 1. Setup: ensure `{{TZ_IDENTIFIER}}` is populated during installation

The template already uses `"envelopeTimezone": "{{TZ_IDENTIFIER}}"` — the placeholder approach is correct. The setup process needs to:

- Auto-detect the host timezone (e.g., `timedatectl show -p Timezone --value`, `cat /etc/timezone`, or `readlink /etc/localtime`)
- Fall back to prompting the user if detection fails
- Substitute the detected/provided IANA timezone into the config

This keeps hide-my-list timezone-agnostic while ensuring every install gets the right value.

### 2. Config-drift sync: add `envelopeTimezone` to the drift-sync path

Currently `.config-drift` (written by `scripts/pull-main.sh` on template changes) only syncs the `agents.defaults.heartbeat` subtree. Extend the drift-sync logic in AGENTS.md step 7 (and the janitor's corresponding check) to also sync `agents.defaults.envelopeTimezone` from the template — but only when the live value is still the default/empty/UTC, so it doesn't overwrite a user who intentionally set a different timezone.

Alternatively, if setup reliably populates TZ on install, drift-sync could prompt or detect again for existing installs that are still on UTC.

### 3. Remove AGENTS.md step 8 (user-time-context.sh fallback)

Once the platform injects the correct local time, the prompt-level `user-time-context.sh` fallback is unnecessary for timezone resolution. Step 8 can be removed (or reduced to only cover edge cases if any remain).

## Why Platform-Level

- The injected `Current Date & Time` in the system prompt is the first thing the agent sees — if it's wrong, prompt-level overrides are fighting upstream
- Prompt-level controls are inherently fragile (agent has to remember to run them)
- Single source of truth: timezone lives in config, not scattered across prompts and scripts