### PR TITLE
Fix #44: Simplify FirstStep into reward trigger within Active state

### DIFF
--- a/docs/ai-prompts.md
+++ b/docs/ai-prompts.md
@@ -1329,8 +1329,7 @@ stateDiagram-v2
     Selection --> Selection: Task rejected
     Selection --> Idle: No suitable task
 
-    Active --> FirstStep: First sub-step done + reward
-    FirstStep --> Active: Continue working
+    Active --> Active: First sub-step done + reward
     Active --> Idle: Task completed + celebration
     Active --> Selection: Task abandoned
     Active --> CheckingIn: Timer expires

--- a/docs/reward-system.md
+++ b/docs/reward-system.md
@@ -103,6 +103,10 @@ flowchart TB
     Deliver --> Outing
 ```
 
+> **Note:** All initiation-phase triggers (Task Started, First Step Done, Resumed After Break)
+> fire as reward events within the **Active** conversation state — they are not separate
+> conversation states. See the conversation state diagram in `ai-prompts.md`.
+
 ---
 
 ## System-Generated Rewards


### PR DESCRIPTION
Resolves #44

## Summary
- Collapsed the transient `FirstStep` conversation state into a self-transition on `Active` in the state diagram (`ai-prompts.md`), removing a state whose only transition was back to `Active`
- Added a clarifying note in `reward-system.md` that initiation-phase reward triggers (Task Started, First Step Done, Resumed After Break) fire as events within the Active conversation state, not as separate states
- The first-step reward behavior is fully preserved — it now fires as a reward trigger event during the Active state rather than requiring a state transition

## Test Plan
- [ ] Verify the mermaid state diagram in `ai-prompts.md` renders correctly with the `Active --> Active` self-transition
- [ ] Verify the clarifying note in `reward-system.md` renders correctly
- [ ] Confirm no other docs reference `FirstStep` as a conversation state

Generated with Claude Code