### PR TITLE
Prevent duplicate PRs from Claude pipeline

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -6,7 +6,7 @@ on:
   pull_request_review_comment:
     types: [created]
   issues:
-    types: [opened, assigned]
+    types: [opened]
   pull_request_review:
     types: [submitted]
 
@@ -275,6 +275,9 @@ jobs:
             - Never use \`git push --no-verify\`
 
             Complete the user's request. If you make changes, create a branch, commit them, and open a PR.
+            BEFORE creating a new PR, check if one already exists for this issue:
+              gh pr list --state open --search 'Resolves #${ISSUE_NUMBER} OR Fixes #${ISSUE_NUMBER} OR Closes #${ISSUE_NUMBER}'
+            If a PR already exists, push changes to that PR's branch instead of creating a new one.
             Reply to the user using: gh issue comment ${ISSUE_NUMBER} --body 'YOUR_RESPONSE'"
             fi
 
@@ -327,7 +330,24 @@ jobs:
       - name: Create gh config directory for devcontainer mount
         run: mkdir -p ~/.config/gh
 
+      - name: Check for existing PR
+        id: check-existing
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ISSUE_NUM=${{ github.event.issue.number }}
+          # Search for open PRs whose body contains "Resolves #N", "Fixes #N", or "Closes #N"
+          EXISTING=$(gh pr list --state open --search "Resolves #${ISSUE_NUM} OR Fixes #${ISSUE_NUM} OR Closes #${ISSUE_NUM}" --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "PR #${EXISTING} already targets issue #${ISSUE_NUM}, skipping"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "No existing PR found for issue #${ISSUE_NUM}"
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Label issue as claude-started
+        if: steps.check-existing.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -337,6 +357,7 @@ jobs:
           gh issue edit ${{ github.event.issue.number }} --add-label "claude-started" --repo ${{ github.repository }}
 
       - name: Log in to GHCR
+        if: steps.check-existing.outputs.skip != 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -345,6 +366,7 @@ jobs:
 
       # Note: GH_TOKEN uses WORKFLOW_PAT because PRs created with GITHUB_TOKEN don't trigger workflows
       - name: Resolve issue in devcontainer
+        if: steps.check-existing.outputs.skip != 'true'
         uses: devcontainers/ci@v0.3
         with:
           imageName: ${{ env.DEVCONTAINER_IMAGE }}


### PR DESCRIPTION
## Summary
- Closed duplicate PRs #38 and #39 (keeping #41 as the correct one for issue #37)
- Removed `assigned` event trigger from `issues` — it was firing a second `resolve-issue` run whenever an issue was assigned, duplicating the `opened` trigger
- Added a `check-existing` step to `resolve-issue` that searches for open PRs already referencing the issue and skips the entire job if one exists
- Added a prompt instruction to the `claude` job telling it to check for and reuse existing PR branches instead of creating new ones

## Test plan
- [ ] Open a new issue — verify only one PR is created
- [ ] Assign the issue — verify no second PR is created
- [ ] Comment `@claude` on an issue that already has a PR — verify Claude pushes to the existing branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)