### PR TITLE
Clarify that docs ARE the system in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,18 +9,20 @@ An ADHD-informed task manager where users never see their task list. The AI hand
 - **Runtime**: OpenClaw agent (no standalone server)
 - **Storage**: Notion database via API
 - **Scripts**: `scripts/` directory contains Notion CLI helpers and infrastructure tooling
-- **Docs**: `docs/` contains architecture, prompt design, and research documentation
+- **Docs**: `docs/` defines the system — prompt architecture, interaction patterns, and behavior specs that the agent executes
 - **Design**: `design/` contains ADHD-informed design priorities and principles
 
 ## Key files
 
+These docs are not documentation about a separate system — they are the system specification. Changing a doc changes how the agent behaves.
+
 - `docs/ai-prompts.md` — The prompt architecture. This is the core of the application.
-- `docs/architecture.md` — System design and data flow
+- `docs/architecture.md` — System design and data flow specification
 - `docs/task-lifecycle.md` — Task states: Pending → In Progress → Completed (with rejection/breakdown flows)
 - `docs/notion-schema.md` — Notion database schema
-- `docs/user-interactions.md` — Conversation patterns and intent detection
-- `docs/user-preferences.md` — Personalization system
-- `docs/reward-system.md` — Multi-channel reward mechanics
+- `docs/user-interactions.md` — Conversation patterns and intent detection rules
+- `docs/user-preferences.md` — Personalization behavior spec
+- `docs/reward-system.md` — Multi-channel reward behavior spec
 - `design/adhd-priorities.md` — Core design principles grounded in ADHD research
 - `scripts/notion-cli.sh` — Notion API helper for task CRUD operations
 - `scripts/webhook-signal.sh` — Minimal webhook receiver for CI/CD notifications
@@ -43,13 +45,13 @@ PRs are reviewed by a multi-agent Claude Code pipeline:
 2. Code Review — code quality, error handling, safety
 3. Test Review — test coverage and quality
 4. Concurrency Review — thread safety and async correctness
-5. Documentation Review — keeps docs in sync with changes
+5. Documentation Review — validates spec files are consistent and complete
 6. Psych Research Review — validates against ADHD clinical research
 7. Merge Decision — synthesizes all reviews into GO/NO-GO
 
 ## When making changes
 
-- Update relevant docs when changing behavior
+- Docs define agent behavior — changing a doc IS changing the system
 - The psych reviewer will validate user-facing changes against ADHD research
 - Infrastructure/CI changes skip the psych review automatically
 - All changes go through PR with the full review pipeline

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

- Reframes AGENTS.md language so agents understand `docs/` contains the system specification the agent executes, not secondary documentation about a separate system
- Changes file descriptions from passive ("contains", "Personalization system") to prescriptive ("defines the system", "behavior spec", "rules")
- Adds explicit preamble: "These docs are not documentation about a separate system — they are the system specification"
- Adds CLAUDE.md entry point that references AGENTS.md

## Test plan

- [ ] Read final AGENTS.md and confirm the "docs = system" message is clear without being repetitive
- [ ] Verify no CI workflow step names were broken (only descriptions changed, not step names)
- [ ] Confirm CLAUDE.md correctly points to AGENTS.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)