### PR TITLE
Add git hooks and Mermaid rendering linter

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,6 +9,7 @@
       "moby": "false"
     }
   },
+  "postCreateCommand": "bash .githooks/install-hooks.sh",
   "postStartCommand": "bash .devcontainer/fix-dns-order.sh",
   "mounts": [
     "source=${localEnv:HOME}/.config/gh,target=/home/vscode/.config/gh,type=bind"

--- a/.githooks/install-hooks.sh
+++ b/.githooks/install-hooks.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Install git hooks by pointing core.hooksPath to .githooks/
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+git config core.hooksPath "$REPO_ROOT/.githooks"
+echo "Git hooks installed (core.hooksPath set to .githooks/)"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Pre-commit hook: validates staged files by category.
+# Install with: bash .githooks/install-hooks.sh
+
+set -euo pipefail
+
+# Get staged files (added, copied, modified — not deleted)
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
+
+if [ -z "$STAGED_FILES" ]; then
+  exit 0
+fi
+
+FAILED=0
+
+# --- Scripts: shellcheck ---
+SCRIPT_FILES=$(echo "$STAGED_FILES" | grep '^scripts/.*\.sh$' || true)
+if [ -n "$SCRIPT_FILES" ]; then
+  echo "Running shellcheck on staged scripts..."
+  if ! echo "$SCRIPT_FILES" | xargs shellcheck; then
+    FAILED=1
+  fi
+fi
+
+# --- Docs: mermaid rendering lint + mermaid syntax validation ---
+DOC_FILES=$(echo "$STAGED_FILES" | grep -E '^(docs/|design/|README\.md|AGENTS\.md)' | grep '\.md$' || true)
+if [ -n "$DOC_FILES" ]; then
+  echo "Running Mermaid rendering lint on staged docs..."
+  # shellcheck disable=SC2086
+  if ! bash scripts/lint-mermaid-rendering.sh $DOC_FILES; then
+    FAILED=1
+  fi
+
+  echo "Running Mermaid syntax validation on staged docs..."
+  # shellcheck disable=SC2086
+  if ! bash scripts/validate-mermaid.sh $DOC_FILES; then
+    FAILED=1
+  fi
+fi
+
+# --- Workflows: yamllint ---
+WORKFLOW_FILES=$(echo "$STAGED_FILES" | grep '^\.github/workflows/.*\.yml$' || true)
+if [ -n "$WORKFLOW_FILES" ]; then
+  if command -v yamllint &> /dev/null; then
+    echo "Running yamllint on staged workflows..."
+    if ! echo "$WORKFLOW_FILES" | xargs yamllint -d "{extends: default, rules: {line-length: disable, truthy: disable, comments-indentation: disable}}"; then
+      FAILED=1
+    fi
+  else
+    echo "WARNING: yamllint not installed, skipping workflow validation"
+  fi
+fi
+
+if [ "$FAILED" -ne 0 ]; then
+  echo ""
+  echo "Pre-commit checks failed. Fix the issues above before committing."
+  exit 1
+fi

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -126,6 +126,16 @@ jobs:
       - name: Install Mermaid validation dependencies
         run: npm install -g mermaid@11 jsdom@25 dompurify@3
 
+      - name: Lint Mermaid diagrams for rendering issues
+        run: |
+          CHANGED_FILES="${{ needs.changes.outputs.docs_files }}"
+          if [ -n "$CHANGED_FILES" ]; then
+            # shellcheck disable=SC2086
+            ./scripts/lint-mermaid-rendering.sh $CHANGED_FILES
+          else
+            echo "No changed doc files to lint"
+          fi
+
       - name: Validate Mermaid diagrams in changed files
         run: |
           # Only validate Mermaid diagrams in files changed by this PR

--- a/scripts/lint-mermaid-rendering.sh
+++ b/scripts/lint-mermaid-rendering.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Lint Mermaid diagrams for known rendering issues that mermaid.parse() won't catch.
+# Checks for over-escaped HTML entities inside mermaid code blocks.
+#
+# Usage: lint-mermaid-rendering.sh [file-or-dir...]
+# Accepts markdown files and/or directories (searched recursively).
+# Defaults to docs/ and design/ if no arguments specified.
+
+set -euo pipefail
+
+ARGS=()
+if [ $# -gt 0 ]; then
+  ARGS=("$@")
+else
+  ARGS=(docs/ design/)
+fi
+
+# Separate files and directories
+FILES=()
+DIRS=()
+for arg in "${ARGS[@]}"; do
+  if [ -f "$arg" ]; then
+    FILES+=("$arg")
+  elif [ -d "$arg" ]; then
+    DIRS+=("$arg")
+  else
+    echo "WARNING: $arg is not a file or directory, skipping"
+  fi
+done
+
+ERRORS=0
+CHECKED=0
+
+# Check a single markdown file for rendering issues in mermaid blocks
+check_file() {
+  local mdfile="$1"
+  local in_mermaid=0
+  local line_num=0
+  local block_num=0
+
+  while IFS= read -r line; do
+    line_num=$((line_num + 1))
+
+    if [[ "$line" =~ ^\`\`\`mermaid ]]; then
+      in_mermaid=1
+      block_num=$((block_num + 1))
+      continue
+    fi
+
+    if [[ $in_mermaid -eq 1 && "$line" =~ ^\`\`\` ]]; then
+      in_mermaid=0
+      continue
+    fi
+
+    if [[ $in_mermaid -eq 1 ]]; then
+      # Check for over-escaped HTML angle brackets
+      # #lt; and #gt; indicate double-escaping (should be <br/> not #lt;br/#gt;)
+      if echo "$line" | grep -qE '#lt;|#gt;'; then
+        echo "ERROR: Over-escaped HTML entity in $mdfile:$line_num (mermaid block #$block_num)"
+        echo "  $line"
+        echo "  Hint: Use <br/> directly, not #lt;br/#gt;"
+        echo ""
+        ERRORS=$((ERRORS + 1))
+      fi
+    fi
+  done < "$mdfile"
+
+  if [[ $block_num -gt 0 ]]; then
+    CHECKED=$((CHECKED + block_num))
+  fi
+}
+
+# Process individual files passed as arguments
+for mdfile in "${FILES[@]}"; do
+  [[ "$mdfile" == *.md ]] || continue
+  check_file "$mdfile"
+done
+
+# Find markdown files in directories
+for dir in "${DIRS[@]}"; do
+  [ -d "$dir" ] || continue
+  while IFS= read -r -d '' mdfile; do
+    check_file "$mdfile"
+  done < <(find "$dir" -name '*.md' -print0)
+done
+
+echo "Checked $CHECKED Mermaid block(s) for rendering issues"
+if [ "$ERRORS" -gt 0 ]; then
+  echo "$ERRORS rendering issue(s) found"
+  exit 1
+fi
+echo "No rendering issues found"


### PR DESCRIPTION
## Summary

- **New `scripts/lint-mermaid-rendering.sh`** — grep-based linter that catches over-escaped HTML entities (`#lt;`, `#gt;`) inside mermaid code blocks, which `mermaid.parse()` doesn't detect but render as literal text
- **New `.githooks/pre-commit`** — runs shellcheck on scripts, mermaid linting on docs, and yamllint on workflows (only for staged files)
- **New `.githooks/install-hooks.sh`** — sets `core.hooksPath` to `.githooks/`, auto-installed via devcontainer `postCreateCommand`
- **CI addition** — rendering linter added to the `doc-validation` job in `pr-tests.yml`

Prevents issues like #60's `#lt;br/#gt;` over-escaping from reaching CI.

## Test plan

- [x] `shellcheck` passes on all three new scripts
- [x] `install-hooks.sh` sets hooks path correctly
- [x] Rendering linter catches `#lt;br/#gt;` in mermaid blocks
- [x] Rendering linter passes `<br/>` and `#quot;` (valid usage)
- [x] Existing docs pass: `./scripts/lint-mermaid-rendering.sh docs/ design/` (132 blocks, no issues)
- [x] Pre-commit hook ran successfully on the commit itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)