### PR TITLE
Slim down design review and add docs consistency reviewer

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1151,7 +1151,6 @@ jobs:
           path: psych-review-output.jsonl
           retention-days: 7
 
-  # Final decision maker - synthesizes all reviews and makes go/no-go call
   # Documentation consistency reviewer - ensures docs remain coherent and non-contradictory
   docs-review:
     needs: [get-context, build-devcontainer]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,10 +41,11 @@ From `docs/ai-prompts.md`:
 ## Review pipeline
 
 PRs are reviewed by a multi-agent Claude Code pipeline:
-1. Design Review — validates intent fulfillment, design quality, and doc consistency
+1. Design Review — validates intent fulfillment and design quality
 2. Security & Infrastructure Review — script safety, credential handling, workflow permissions
 3. Psych Research Review — validates against ADHD clinical research
-4. Merge Decision — synthesizes all reviews into GO/NO-GO
+4. Documentation Consistency Review — checks docs for contradictions, stale references, and cross-doc consistency
+5. Merge Decision — synthesizes all reviews into GO/NO-GO
 
 ## When making changes
 


### PR DESCRIPTION
## Summary
- **Design review prompt**: Rewritten to match staff-engineer tone (direct, selective, no praise paragraphs). Adds scope check. Removes verbose evaluation criteria.
- **Docs-review agent**: New parallel read-only reviewer that checks all docs for contradictions, stale references, missing coverage, and cross-doc consistency after PR changes
- **Merge-decision**: Updated to include docs-review results and apply doc fixes described by the docs reviewer
- **Inline comments**: All reviewers encouraged to leave inline PR comments on specific lines

Builds on PR #70 (read-only reviewers). Design review verbosity reduction inspired by [home-automation-wtf](https://github.com/NickBorgers/home-automation-wtf) reference repo.

## Test plan
- [ ] Verify design review comments are shorter and more direct
- [ ] Verify docs-review runs in parallel with other reviewers
- [ ] Verify merge-decision reads and applies doc updates from docs-review
- [ ] Verify inline review comments appear on PRs where appropriate

🤖 Generated with [Claude Code](https://claude.com/claude-code)