### PR TITLE
Remove issue number from resolve-issue PR title template

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -427,7 +427,7 @@ jobs:
             BRANCH NAMING: Use \`claude/issue-${ISSUE_NUMBER}\` as the branch name.
 
             PR CREATION:
-            gh pr create --title 'Fix #${ISSUE_NUMBER}: <brief description>' \\
+            gh pr create --title '<brief description of what this PR accomplishes>' \\
               --assignee NickBorgers \\
               --body 'Resolves #${ISSUE_NUMBER}
 


### PR DESCRIPTION
Resolves #72

## Summary
- Changed the PR title template in the `resolve-issue` workflow from `'Fix #${ISSUE_NUMBER}: <brief description>'` to `'<brief description of what this PR accomplishes>'`
- The issue linkage is preserved via `Resolves #N` in the PR body, which is the correct place for it

## Test Plan
- Trigger the resolve-issue workflow on a test issue and verify the generated PR title describes the change rather than referencing the issue number

Generated with Claude Code