### PR TITLE
Fix devcontainer bind mount failures for ~/.claude and ~/.codex

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -416,8 +416,8 @@ jobs:
 
           echo "Marked as fix attempt $NEXT_ATTEMPT"
 
-      - name: Create gh config directory for devcontainer mount
-        run: mkdir -p ~/.config/gh
+      - name: Create directories for devcontainer mounts
+        run: mkdir -p ~/.config/gh ~/.claude ~/.codex
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -695,9 +695,9 @@ jobs:
         if: steps.verify-tests.outputs.verified == 'true'
         run: git pull origin ${{ needs.get-context.outputs.head_ref }} || true
 
-      - name: Create gh config directory for devcontainer mount
+      - name: Create directories for devcontainer mounts
         if: steps.verify-tests.outputs.verified == 'true'
-        run: mkdir -p ~/.config/gh
+        run: mkdir -p ~/.config/gh ~/.claude ~/.codex
 
       - name: Log in to GHCR
         if: steps.verify-tests.outputs.verified == 'true'
@@ -861,9 +861,9 @@ jobs:
         if: steps.verify-tests.outputs.verified == 'true'
         run: git pull origin ${{ needs.get-context.outputs.head_ref }} || true
 
-      - name: Create gh config directory for devcontainer mount
+      - name: Create directories for devcontainer mounts
         if: steps.verify-tests.outputs.verified == 'true'
-        run: mkdir -p ~/.config/gh
+        run: mkdir -p ~/.config/gh ~/.claude ~/.codex
 
       - name: Log in to GHCR
         if: steps.verify-tests.outputs.verified == 'true'
@@ -1005,9 +1005,9 @@ jobs:
         if: steps.verify-tests.outputs.verified == 'true'
         run: git pull origin ${{ needs.get-context.outputs.head_ref }} || true
 
-      - name: Create gh config directory for devcontainer mount
+      - name: Create directories for devcontainer mounts
         if: steps.verify-tests.outputs.verified == 'true'
-        run: mkdir -p ~/.config/gh
+        run: mkdir -p ~/.config/gh ~/.claude ~/.codex
 
       - name: Log in to GHCR
         if: steps.verify-tests.outputs.verified == 'true'
@@ -1211,9 +1211,9 @@ jobs:
         if: steps.verify-tests.outputs.verified == 'true'
         run: git pull origin ${{ needs.get-context.outputs.head_ref }} || true
 
-      - name: Create gh config directory for devcontainer mount
+      - name: Create directories for devcontainer mounts
         if: steps.verify-tests.outputs.verified == 'true'
-        run: mkdir -p ~/.config/gh
+        run: mkdir -p ~/.config/gh ~/.claude ~/.codex
 
       - name: Log in to GHCR
         if: steps.verify-tests.outputs.verified == 'true'
@@ -1358,9 +1358,9 @@ jobs:
         if: steps.verify-tests.outputs.verified == 'true'
         run: git pull origin ${{ needs.get-context.outputs.head_ref }} || true
 
-      - name: Create gh config directory for devcontainer mount
+      - name: Create directories for devcontainer mounts
         if: steps.verify-tests.outputs.verified == 'true'
-        run: mkdir -p ~/.config/gh
+        run: mkdir -p ~/.config/gh ~/.claude ~/.codex
 
       - name: Log in to GHCR
         if: steps.verify-tests.outputs.verified == 'true'


### PR DESCRIPTION
## Summary
- All 6 review jobs in the Claude Code Review workflow fail because Docker requires bind mount source paths to exist on the host
- The `mkdir -p` step only created `~/.config/gh`, but the devcontainer also mounts `~/.claude` and `~/.codex`
- Updated all 6 occurrences to create all three directories before the devcontainer launches

Closes #75

## Test plan
- [ ] Verify the Claude Code Review workflow completes successfully on this PR (the workflow runs its own devcontainer steps)
- [ ] Confirm no `bind source path does not exist` errors in job logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)