### PR TITLE
Add mkdir step to build-devcontainer job

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -350,6 +350,9 @@ jobs:
         with:
           ref: main
 
+      - name: Create directories for devcontainer mounts
+        run: mkdir -p ~/.config/gh ~/.claude ~/.codex
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Summary
- The `build-devcontainer` job was the only `devcontainers/ci` job missing the `mkdir -p ~/.config/gh ~/.claude ~/.codex` step added in PR #77
- Without this, the build job could fail on bind mount errors once PR #74 merges (which adds `~/.claude` and `~/.codex` mounts to `devcontainer.json`)
- Consistent with all other jobs that already have this step

Closes #76

## Test plan
- [ ] Verify `build-devcontainer` job succeeds in CI with the new step
- [ ] Confirm no regressions in downstream review jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)