### PR TITLE
Expand docs-review prompt scope with missing relationships and check categories

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1265,12 +1265,34 @@ jobs:
                  (e.g., task-lifecycle.md states should match architecture.md data flow)
                - **AGENTS.md / CLAUDE.md**: Do project instructions still accurately describe
                  the system after this PR?
+               - **Terminology consistency**: Are terms, field names, and enum values
+                 (status, work_type, energy_required) used consistently across docs?
+               - **Numeric constant consistency**: Do shared thresholds (urgency ranges,
+                 step counts, timer values, score ranges) agree across all docs?
+               - **docs/index.md completeness**: Does it list all docs accurately?
 
             Key doc relationships to check:
             - docs/architecture.md <-> docs/task-lifecycle.md (system design vs task states)
             - docs/ai-prompts.md <-> docs/user-interactions.md (prompt behavior vs interaction patterns)
             - docs/user-preferences.md <-> docs/reward-system.md (personalization vs rewards)
+            - docs/notion-schema.md <-> docs/task-lifecycle.md (field definitions vs lifecycle states)
+            - docs/notion-schema.md <-> docs/user-preferences.md (preferences schema vs behavior)
+            - docs/task-lifecycle.md <-> docs/user-interactions.md (state machine vs conversation flows)
+            - docs/reward-system.md <-> docs/task-lifecycle.md (reward triggers vs lifecycle phases)
+            - design/adhd-priorities.md <-> docs/ai-prompts.md (ADHD constraints vs prompt implementation)
             - AGENTS.md <-> docs/ (project instructions vs spec files)
+
+            Source of truth: When field names, status values, or database structure
+            conflict between docs, treat docs/notion-schema.md as canonical. Other
+            docs that reference these values must agree with it.
+
+            Pay special attention to docs/ai-prompts.md — it is the core system
+            specification. Any PR that changes agent behavior must be checked against
+            the prompt architecture defined there.
+
+            Blocking vs non-blocking: A contradiction between docs that would cause
+            the agent to receive conflicting instructions is blocking. A missing
+            update to an example or diagram is non-blocking.
 
             **INLINE COMMENTS:** Where a doc issue is tied to a specific line, also leave
             an inline PR review comment on that line.


### PR DESCRIPTION
## Summary

Improves the documentation consistency review bot prompt in the CI pipeline to catch more classes of inconsistencies across the spec docs.

### Changes made

1. **Added 5 missing cross-doc relationships** — notion-schema <-> task-lifecycle, notion-schema <-> user-preferences, task-lifecycle <-> user-interactions, reward-system <-> task-lifecycle, and adhd-priorities <-> ai-prompts. These pairs frequently reference each other but were not being checked.

2. **Added 3 new check categories** — terminology consistency (field names, enum values), numeric constant consistency (thresholds, ranges, timer values), and docs/index.md completeness. These catch drift that the existing categories miss.

3. **Added source-of-truth directive** — Establishes docs/notion-schema.md as canonical for field names, status values, and database structure. Highlights docs/ai-prompts.md as the core system spec requiring special attention.

4. **Added blocking vs non-blocking classification** — Gives the reviewer clear guidance: conflicting agent instructions are blocking, stale examples/diagrams are non-blocking.

## Test plan
- [ ] Verify YAML is valid and the workflow file parses correctly
- [ ] Confirm the docs-review job still runs successfully on a test PR
- [ ] Check that the new relationship pairs and check categories appear in the reviewer's prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)