### PR TITLE
Migrate CI to self-hosted homelab runners

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -37,5 +37,4 @@ RUN npm install -g mermaid@11 jsdom@25 dompurify@3
 # Install yamllint for workflow validation
 RUN pip3 install --break-system-packages yamllint
 
-USER vscode
-WORKDIR /home/vscode
+USER root

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,13 +9,15 @@
       "moby": "false"
     }
   },
+  "onCreateCommand": "bash .devcontainer/setup-user.sh \"${localEnv:USER}\"",
   "postCreateCommand": "bash .githooks/install-hooks.sh",
   "postStartCommand": "bash .devcontainer/fix-dns-order.sh",
   "mounts": [
-    "source=${localEnv:HOME}/.config/gh,target=/home/vscode/.config/gh,type=bind",
-    "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind",
-    "source=${localEnv:HOME}/.codex,target=/home/vscode/.codex,type=bind"
+    "source=${localEnv:HOME}/.config/gh,target=/tmp/gh-config,type=bind"
   ],
+  "remoteEnv": {
+    "CLAUDE_CODE_OAUTH_TOKEN": "${localEnv:CLAUDE_CODE_OAUTH_TOKEN}"
+  },
   "customizations": {
     "vscode": {
       "extensions": [
@@ -23,5 +25,6 @@
       ]
     }
   },
+  "updateRemoteUserUID": true,
   "remoteUser": "vscode"
 }

--- a/.devcontainer/setup-user.sh
+++ b/.devcontainer/setup-user.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Creates the host user inside the container so the devcontainer runs
+# as the same identity as the host. Called via onCreateCommand.
+#
+# When the host user is not "vscode" (e.g., CI runner user "ci-runner"),
+# this script creates the user with a matching UID/GID derived from
+# workspace file ownership, and copies Claude Code config from the
+# pre-built vscode user.
+#
+# Runs as root (Dockerfile ends with USER root to allow this).
+set -e
+
+TARGET_USER="${1:-vscode}"
+
+# If target user already exists, nothing to do
+if id "$TARGET_USER" &>/dev/null; then
+    echo "User $TARGET_USER already exists, skipping creation."
+    exit 0
+fi
+
+# Detect host UID/GID from workspace file ownership
+WORKSPACE="/workspaces/hide-my-list"
+if [ -d "$WORKSPACE" ]; then
+    TARGET_UID=$(stat -c '%u' "$WORKSPACE")
+    TARGET_GID=$(stat -c '%g' "$WORKSPACE")
+else
+    # Fallback to 1000:1000 (standard devcontainer UID)
+    TARGET_UID=1000
+    TARGET_GID=1000
+fi
+
+# Refuse to create root user — Claude Code requires non-root
+if [ "$TARGET_UID" = "0" ]; then
+    echo "ERROR: Host UID is 0 (root). Claude Code requires a non-root user."
+    echo "Set a non-root user in your CI runner or devcontainer configuration."
+    exit 1
+fi
+
+echo "Creating user $TARGET_USER (UID=$TARGET_UID, GID=$TARGET_GID)..."
+
+# If the target UID is already owned by another user (e.g., vscode has UID 1000),
+# skip creation — remoteUser + updateRemoteUserUID handles UID mapping.
+EXISTING_USER=$(getent passwd "$TARGET_UID" | cut -d: -f1)
+if [ -n "$EXISTING_USER" ] && [ "$EXISTING_USER" != "$TARGET_USER" ]; then
+    echo "UID $TARGET_UID already belongs to '$EXISTING_USER'. Skipping user creation."
+    echo "The devcontainer will run as '$EXISTING_USER' with updateRemoteUserUID handling UID mapping."
+    exit 0
+fi
+
+# Create group if GID doesn't already exist
+if ! getent group "$TARGET_GID" &>/dev/null; then
+    groupadd --gid "$TARGET_GID" "$TARGET_USER"
+fi
+
+# Get the group name for the target GID
+TARGET_GROUP=$(getent group "$TARGET_GID" | cut -d: -f1)
+
+# Create user with matching UID/GID
+useradd -m -s /bin/bash -u "$TARGET_UID" -g "$TARGET_GID" "$TARGET_USER"
+
+# Grant passwordless sudo (standard for devcontainer users)
+echo "$TARGET_USER ALL=(ALL) NOPASSWD:ALL" | tee /etc/sudoers.d/"$TARGET_USER" > /dev/null
+chmod 0440 /etc/sudoers.d/"$TARGET_USER"
+
+# Copy Claude Code config from pre-built vscode user
+if [ -d /home/vscode/.claude ]; then
+    cp -r /home/vscode/.claude /home/"$TARGET_USER"/.claude 2>/dev/null || true
+fi
+if [ -d /home/vscode/.cache ]; then
+    cp -r /home/vscode/.cache /home/"$TARGET_USER"/.cache 2>/dev/null || true
+fi
+
+# Fix ownership of copied files
+chown -R "$TARGET_USER":"$TARGET_GROUP" /home/"$TARGET_USER"
+
+# Set up gh config symlink if the mount exists
+if [ -d /tmp/gh-config ]; then
+    mkdir -p /home/"$TARGET_USER"/.config
+    ln -sf /tmp/gh-config /home/"$TARGET_USER"/.config/gh
+    chown -h "$TARGET_USER":"$TARGET_GROUP" /home/"$TARGET_USER"/.config/gh
+fi
+
+echo "User $TARGET_USER created successfully."

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -331,7 +331,7 @@ jobs:
   # SECURITY: Always build from main branch, NEVER from PR branches
   # This prevents malicious Dockerfile modifications from being used to build the container
   build-devcontainer:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, homelab]
     needs: get-context
     if: |
       needs.get-context.outputs.pr_number != '' &&
@@ -381,7 +381,7 @@ jobs:
       needs.get-context.outputs.author_authorized == 'true' &&
       needs.get-context.outputs.tests_passed == 'false' &&
       needs.get-context.outputs.fix_attempts < 3
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, homelab]
     permissions:
       contents: write
       pull-requests: write
@@ -645,7 +645,7 @@ jobs:
       needs.get-context.outputs.reviews_already_passed != 'true' &&
       needs.get-context.outputs.author_authorized == 'true' &&
       needs.get-context.outputs.tests_passed == 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, homelab]
     permissions:
       contents: read
       pull-requests: write
@@ -811,7 +811,7 @@ jobs:
       needs.get-context.outputs.author_authorized == 'true' &&
       needs.get-context.outputs.docs_only != 'true' &&
       needs.get-context.outputs.tests_passed == 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, homelab]
     permissions:
       contents: read
       pull-requests: write
@@ -955,7 +955,7 @@ jobs:
       needs.get-context.outputs.author_authorized == 'true' &&
       needs.get-context.outputs.config_only != 'true' &&
       needs.get-context.outputs.tests_passed == 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, homelab]
     permissions:
       contents: read
       pull-requests: write
@@ -1163,7 +1163,7 @@ jobs:
       needs.get-context.outputs.reviews_already_passed != 'true' &&
       needs.get-context.outputs.author_authorized == 'true' &&
       needs.get-context.outputs.tests_passed == 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, homelab]
     permissions:
       contents: read
       pull-requests: write
@@ -1329,7 +1329,7 @@ jobs:
       needs.get-context.outputs.reviews_already_passed != 'true' &&
       needs.get-context.outputs.author_authorized == 'true' &&
       needs.get-context.outputs.tests_passed == 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, homelab]
     outputs:
       decision: ${{ steps.parse-decision.outputs.decision }}
     permissions:
@@ -1504,7 +1504,7 @@ jobs:
   # Aggregator job - use this as the required check for branch protection
   all-reviews-passed:
     name: All Required Agent Reviews
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, homelab]
     needs: [get-context, build-devcontainer, fix-test-failures, design-review, security-review, psych-review, docs-review, merge-decision]
     if: always()
     permissions:

--- a/.github/workflows/claude-diagnose-workflow-failure.yml
+++ b/.github/workflows/claude-diagnose-workflow-failure.yml
@@ -93,7 +93,7 @@ jobs:
 
   # Build devcontainer for Claude
   build-devcontainer:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, homelab]
     needs: check-failure
     if: needs.check-failure.outputs.should_diagnose == 'true'
     permissions:
@@ -123,7 +123,7 @@ jobs:
   diagnose-failure:
     needs: [check-failure, build-devcontainer]
     if: needs.check-failure.outputs.should_diagnose == 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, homelab]
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -81,7 +81,7 @@ jobs:
   build-devcontainer:
     needs: authorize
     if: needs.authorize.outputs.authorized == 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, homelab]
     permissions:
       contents: read
       packages: write
@@ -112,7 +112,7 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))))
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, homelab]
     permissions:
       contents: write
       pull-requests: write
@@ -322,7 +322,7 @@ jobs:
     if: |
       needs.authorize.outputs.authorized == 'true' &&
       github.event_name == 'issues' && github.event.action == 'opened'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, homelab]
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -6,6 +6,7 @@ name: PR Tests
 # Security model:
 # - READ-ONLY permissions (contents: read, pull-requests: read)
 # - No secrets exposed to PR builds
+# - Fork PRs are blocked from running on self-hosted runners
 # - External PRs get tests but NOT Claude reviews (handled by claude-code-review.yml)
 
 on:
@@ -28,10 +29,14 @@ permissions:
   contents: read
   pull-requests: read
 
+env:
+  DEVCONTAINER_IMAGE: ghcr.io/nickborgersprobably/hide-my-list-devcontainer
+
 jobs:
   changes:
     name: Detect Changes
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, homelab]
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     outputs:
       scripts: ${{ steps.filter.outputs.scripts }}
       docs: ${{ steps.filter.outputs.docs }}
@@ -57,117 +62,176 @@ jobs:
             workflows:
               - '.github/workflows/**'
 
+  # Build devcontainer from main branch for security
+  build-devcontainer:
+    runs-on: [self-hosted, homelab]
+    needs: changes
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      # SECURITY: Checkout main branch, NOT the PR branch
+      - name: Checkout main branch (security measure)
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push devcontainer
+        uses: devcontainers/ci@v0.3
+        continue-on-error: true
+        with:
+          imageName: ${{ env.DEVCONTAINER_IMAGE }}
+          cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
+          push: always
+
   script-validation:
     name: Script Validation
-    needs: changes
-    if: needs.changes.outputs.scripts == 'true'
-    runs-on: ubuntu-latest
+    needs: [changes, build-devcontainer]
+    if: >-
+      needs.changes.outputs.scripts == 'true' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: [self-hosted, homelab]
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install shellcheck
-        run: sudo apt-get install -y shellcheck
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Lint shell scripts
-        run: |
-          find scripts/ -name '*.sh' -exec shellcheck {} +
+      - name: Run script validation in devcontainer
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: ${{ env.DEVCONTAINER_IMAGE }}
+          cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
+          push: never
+          runCmd: |
+            echo "=== Linting shell scripts ==="
+            find scripts/ -name '*.sh' -exec shellcheck {} +
 
-      - name: Check script permissions
-        run: |
-          find scripts/ -name '*.sh' | while read f; do
-            if [ ! -x "$f" ]; then
-              echo "ERROR: $f is not executable"
-              exit 1
-            fi
-          done
-          echo "All scripts have execute permission"
+            echo "=== Checking script permissions ==="
+            find scripts/ -name '*.sh' | while read f; do
+              if [ ! -x "$f" ]; then
+                echo "ERROR: $f is not executable"
+                exit 1
+              fi
+            done
+            echo "All scripts have execute permission"
 
   doc-validation:
     name: Documentation Validation
-    needs: changes
-    if: needs.changes.outputs.docs == 'true'
-    runs-on: ubuntu-latest
+    needs: [changes, build-devcontainer]
+    if: >-
+      needs.changes.outputs.docs == 'true' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: [self-hosted, homelab]
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Check for broken internal links
-        run: |
-          ERRORS=0
-          # Check markdown files for internal links and verify targets exist
-          find docs/ design/ -name '*.md' | while read f; do
-            # Extract relative links like [text](./file.md) or [text](../docs/file.md)
-            grep -oP '\[.*?\]\(\K[^)]+' "$f" 2>/dev/null | grep -v '^http' | while read link; do
-              # Resolve relative to the file's directory
-              dir=$(dirname "$f")
-              target="$dir/$link"
-              # Strip anchors
-              target=$(echo "$target" | cut -d'#' -f1)
-              if [ -n "$target" ] && [ ! -e "$target" ]; then
-                echo "BROKEN LINK in $f: $link (resolved to $target)"
-                ERRORS=$((ERRORS + 1))
-              fi
-            done
-          done
-          if [ "$ERRORS" -gt 0 ]; then
-            echo "$ERRORS broken links found"
-            exit 1
-          fi
-          echo "No broken internal links found"
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
         with:
-          node-version: '20'
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Mermaid validation dependencies
-        run: npm install -g mermaid@11 jsdom@25 dompurify@3
+      - name: Run doc validation in devcontainer
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: ${{ env.DEVCONTAINER_IMAGE }}
+          cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
+          push: never
+          env: |
+            CHANGED_FILES=${{ needs.changes.outputs.docs_files }}
+          runCmd: |
+            echo "=== Checking for broken internal links ==="
+            ERRORS=0
+            # Check markdown files for internal links and verify targets exist
+            find docs/ design/ -name '*.md' | while read f; do
+              # Extract relative links like [text](./file.md) or [text](../docs/file.md)
+              grep -oP '\[.*?\]\(\K[^)]+' "$f" 2>/dev/null | grep -v '^http' | while read link; do
+                # Resolve relative to the file's directory
+                dir=$(dirname "$f")
+                target="$dir/$link"
+                # Strip anchors
+                target=$(echo "$target" | cut -d'#' -f1)
+                if [ -n "$target" ] && [ ! -e "$target" ]; then
+                  echo "BROKEN LINK in $f: $link (resolved to $target)"
+                  ERRORS=$((ERRORS + 1))
+                fi
+              done
+            done
+            if [ "$ERRORS" -gt 0 ]; then
+              echo "$ERRORS broken links found"
+              exit 1
+            fi
+            echo "No broken internal links found"
 
-      - name: Lint Mermaid diagrams for rendering issues
-        run: |
-          CHANGED_FILES="${{ needs.changes.outputs.docs_files }}"
-          if [ -n "$CHANGED_FILES" ]; then
-            # shellcheck disable=SC2086
-            ./scripts/lint-mermaid-rendering.sh $CHANGED_FILES
-          else
-            echo "No changed doc files to lint"
-          fi
+            echo "=== Linting Mermaid diagrams ==="
+            if [ -n "$CHANGED_FILES" ]; then
+              # shellcheck disable=SC2086
+              ./scripts/lint-mermaid-rendering.sh $CHANGED_FILES
+            else
+              echo "No changed doc files to lint"
+            fi
 
-      - name: Validate Mermaid diagrams in changed files
-        run: |
-          # Only validate Mermaid diagrams in files changed by this PR
-          CHANGED_FILES="${{ needs.changes.outputs.docs_files }}"
-          if [ -n "$CHANGED_FILES" ]; then
-            # shellcheck disable=SC2086
-            ./scripts/validate-mermaid.sh $CHANGED_FILES
-          else
-            echo "No changed doc files to validate"
-          fi
+            echo "=== Validating Mermaid diagrams ==="
+            if [ -n "$CHANGED_FILES" ]; then
+              # shellcheck disable=SC2086
+              ./scripts/validate-mermaid.sh $CHANGED_FILES
+            else
+              echo "No changed doc files to validate"
+            fi
 
   workflow-validation:
     name: Workflow YAML Validation
-    needs: changes
-    if: needs.changes.outputs.workflows == 'true'
-    runs-on: ubuntu-latest
+    needs: [changes, build-devcontainer]
+    if: >-
+      needs.changes.outputs.workflows == 'true' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: [self-hosted, homelab]
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Validate workflow YAML syntax
-        run: |
-          pip install yamllint
-          yamllint -d "{extends: default, rules: {line-length: disable, truthy: disable, comments-indentation: disable}}" \
-            .github/workflows/*.yml
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run workflow validation in devcontainer
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: ${{ env.DEVCONTAINER_IMAGE }}
+          cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
+          push: never
+          runCmd: |
+            yamllint -d "{extends: default, rules: {line-length: disable, truthy: disable, comments-indentation: disable}}" \
+              .github/workflows/*.yml
 
   all-tests-passed:
     name: All Required Tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, homelab]
     needs: [changes, script-validation, doc-validation, workflow-validation]
-    if: always()
+    if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
 
     steps:
       - name: Check test results

--- a/.github/workflows/review-coverage-evaluator.yml
+++ b/.github/workflows/review-coverage-evaluator.yml
@@ -49,7 +49,7 @@ jobs:
 
   # Build and cache devcontainer image (same pattern as other workflows)
   build-devcontainer:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, homelab]
     needs: get-pr-context
     if: needs.get-pr-context.outputs.pr_number != ''
     permissions:
@@ -78,7 +78,7 @@ jobs:
   evaluate-coverage:
     needs: [get-pr-context, build-devcontainer]
     if: needs.get-pr-context.outputs.pr_number != ''
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, homelab]
     permissions:
       contents: read
       issues: write

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,9 +41,10 @@ The reminder daemon ([`scripts/reminder-daemon.sh`](scripts/reminder-daemon.sh) 
 PR review agents process untrusted code **[A]** and write PR comments **[C]**, but have no access to infrastructure secrets or Notion credentials **[B]**. Workflows use only repo-scoped GitHub token permissions (contents/pull-requests/issues write for posting reviews); no infrastructure secrets or Notion credentials are available. This is a safe [AC] configuration — even if a malicious PR manipulated a review agent, there's no sensitive data to exfiltrate.
 
 Additional CI/CD controls:
-- Fork PRs are blocked from triggering Claude Code reviews (author must be a collaborator/member/owner)
+- Fork PRs are blocked from triggering workflows on self-hosted runners (all workflows check `github.event.pull_request.head.repo.full_name == github.repository`; Claude Code reviews additionally require the author to be a collaborator/member/owner)
 - The devcontainer image is built only from the main branch, never from PR branches
-- Review agents run on standard GitHub Actions runners with no infrastructure credentials
+- Review agents run on self-hosted homelab runners with no infrastructure credentials; runners are isolated by the same VLAN segmentation and proxy controls as the main agent host
+- Security gate jobs (`authorize`, `get-context`, `check-failure`, `get-pr-context`) remain on `ubuntu-latest` to process untrusted input before dispatching to self-hosted runners
 
 ### Prompt injection risk
 
@@ -103,7 +104,7 @@ The proxy also blocks connections to private network ranges (RFC 1918, loopback,
 | Prompt injection via GitHub content | Becomes [ABC] when processing GitHub content — PR/issue bodies from external contributors are an injection vector | Blast radius limited to Notion operations the token permits; proxy limits exfiltration destinations |
 | Agent pivots to internal network | [ABC] — an injected prompt could attempt lateral movement | Tailscale largely prevents access to internal systems; proxy blocks private ranges; VLAN segmentation blocks internal network access at the router level |
 | Malicious webhook payload | Webhook is [A]-only — data discarded, no credentials or external access | Connection limits and hard timeout |
-| Malicious PR manipulates review agent | Review agents are [AC] — no access to secrets or infrastructure | Fork PRs blocked; devcontainer built only from main |
+| Malicious PR manipulates review agent | Review agents are [AC] — no access to secrets or infrastructure | Fork PRs blocked from all self-hosted runner workflows; devcontainer built only from main; self-hosted runners isolated by VLAN segmentation |
 | Credential exfiltration via prompt injection | The agent has credentials in its runtime context and could be prompted to reveal them | Proxy allowlist limits where credentials could be sent; admin surfaces behind Tailscale; model alignment is a speed bump, not a guarantee |
 | Unauthorized admin access | Admin interfaces require Tailscale authentication and at least OpenClaw pairing for authentication | Firewall allows only WireGuard inbound |
 


### PR DESCRIPTION
## Summary

- Migrates all applicable GitHub Actions workflow jobs from `ubuntu-latest` to `[self-hosted, homelab]` runners
- Adds fork PR blocking to `pr-tests.yml` as a critical security prerequisite for self-hosted runners
- Wraps pr-tests validation jobs in devcontainer for runner environment compatibility
- Adds `setup-user.sh` for host UID/GID matching (adapted from home-automation pattern)
- Updates devcontainer config: `onCreateCommand`, `updateRemoteUserUID`, gh config mount to `/tmp/gh-config`, `remoteEnv` for OAuth token
- Updates `SECURITY.md` to document self-hosted runner trust model and VLAN isolation

**Security model preserved:** Security gate jobs (`authorize`, `get-context`, `check-failure`, `get-pr-context`) remain on `ubuntu-latest`. Fork PRs are blocked from all self-hosted runner workflows. Devcontainer is built only from `main`.

**Not migrated:** `pages.yml` (requires GitHub Pages infrastructure), `docker-build-push.yml` (disabled).

## Test plan

- [ ] Fork protection: Fork PR should be blocked from running pr-tests on self-hosted runners
- [ ] Devcontainer: `setup-user.sh` runs successfully in CI logs; Claude Code runs as non-root
- [ ] Runner labels: All migrated jobs show `[self-hosted, homelab]` in Actions UI
- [ ] Security gates: `authorize` and `get-context` jobs still show `ubuntu-latest`
- [ ] pr-tests in devcontainer: shellcheck, yamllint, mermaid validation pass inside devcontainer
- [ ] Full review pipeline: PR triggers the complete review cycle on self-hosted runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)