### PR TITLE
fix: Eliminate duplicate PR Tests runs on claude/** branches

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -15,9 +15,6 @@ on:
       - main
       - master
       - '**'
-  push:
-    branches:
-      - 'claude/**'
   workflow_dispatch:
     inputs:
       ref:


### PR DESCRIPTION
## Summary
- Removed the `push` trigger for `claude/**` branches from `pr-tests.yml`
- The `pull_request` trigger (matching all branches via `'**'`) already covers these PRs, making the `push` trigger redundant
- The duplicate runs cause `cancel-in-progress` to kill the first run, leaving a stale failed check on PRs

## Test plan
- [ ] Push a commit to an open PR on a `claude/**` branch
- [ ] Confirm only one PR Tests workflow run fires (not two)
- [ ] Confirm no stale failed checks appear on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)