### PR TITLE
Fix PR comments: use WORKFLOW_PAT for GH_TOKEN in devcontainers

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -438,7 +438,7 @@ jobs:
           push: never
           env: |
             ANTHROPIC_API_KEY=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-            GH_TOKEN=${{ github.token }}
+            GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
             PR_TITLE=${{ needs.get-context.outputs.pr_title }}
             PR_BODY_B64=${{ needs.get-context.outputs.pr_body_b64 }}
@@ -677,7 +677,7 @@ jobs:
           push: never
           env: |
             ANTHROPIC_API_KEY=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-            GH_TOKEN=${{ github.token }}
+            GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
             PR_TITLE=${{ needs.get-context.outputs.pr_title }}
             PR_BODY_B64=${{ needs.get-context.outputs.pr_body_b64 }}
@@ -801,7 +801,7 @@ jobs:
           push: never
           env: |
             ANTHROPIC_API_KEY=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-            GH_TOKEN=${{ github.token }}
+            GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
             HEAD_REF=${{ needs.get-context.outputs.head_ref }}
           runCmd: |
@@ -903,7 +903,7 @@ jobs:
           push: never
           env: |
             ANTHROPIC_API_KEY=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-            GH_TOKEN=${{ github.token }}
+            GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
             PR_TITLE=${{ needs.get-context.outputs.pr_title }}
             PR_BODY_B64=${{ needs.get-context.outputs.pr_body_b64 }}
@@ -1069,7 +1069,7 @@ jobs:
           push: never
           env: |
             ANTHROPIC_API_KEY=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-            GH_TOKEN=${{ github.token }}
+            GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
             PR_TITLE=${{ needs.get-context.outputs.pr_title }}
             HEAD_REF=${{ needs.get-context.outputs.head_ref }}
@@ -1195,7 +1195,7 @@ jobs:
           push: never
           env: |
             ANTHROPIC_API_KEY=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-            GH_TOKEN=${{ github.token }}
+            GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
             PR_TITLE=${{ needs.get-context.outputs.pr_title }}
             HEAD_REF=${{ needs.get-context.outputs.head_ref }}
@@ -1333,7 +1333,7 @@ jobs:
           push: never
           env: |
             ANTHROPIC_API_KEY=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-            GH_TOKEN=${{ github.token }}
+            GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
             HEAD_REF=${{ needs.get-context.outputs.head_ref }}
             DESIGN_REVIEW_RESULT=${{ needs.design-review.result }}

--- a/.github/workflows/claude-diagnose-workflow-failure.yml
+++ b/.github/workflows/claude-diagnose-workflow-failure.yml
@@ -154,7 +154,7 @@ jobs:
           push: never
           env: |
             ANTHROPIC_API_KEY=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-            GH_TOKEN=${{ github.token }}
+            GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             WORKFLOW_NAME=${{ needs.check-failure.outputs.workflow_name }}
             RUN_ID=${{ needs.check-failure.outputs.run_id }}
             RUN_URL=${{ needs.check-failure.outputs.run_url }}

--- a/.github/workflows/review-coverage-evaluator.yml
+++ b/.github/workflows/review-coverage-evaluator.yml
@@ -108,7 +108,7 @@ jobs:
           push: never
           env: |
             ANTHROPIC_API_KEY=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-            GH_TOKEN=${{ github.token }}
+            GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-pr-context.outputs.pr_number }}
             REPO=${{ github.repository }}
           runCmd: |


### PR DESCRIPTION
## Summary
- Replace `github.token` with `secrets.WORKFLOW_PAT` for `GH_TOKEN` in all devcontainer `env:` blocks (9 occurrences across 3 files)
- `github.token` doesn't work for `gh pr comment` inside `devcontainers/ci@v0.3` on self-hosted runners — review agents ran successfully but posted zero comments to PRs
- Matches the pattern used in home-automation repo, where all review jobs use `WORKFLOW_PAT`

## Test plan
- [ ] Merge this PR
- [ ] Re-run Claude Code Review for PRs #88 and #89
- [ ] Confirm review comments actually appear on those PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)