### PR TITLE
Fix: PR reopen bypasses review gate

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1457,6 +1457,15 @@ jobs:
 
           failed=false
 
+          # PR reopen only resets the label — the real reviews come from
+          # the workflow_run trigger once PR Tests complete.  Exit with
+          # failure so this run does NOT satisfy the branch-protection
+          # check before actual reviews have run.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "PR reopened — waiting for PR Tests to trigger the real review run"
+            exit 1
+          fi
+
           # Check if we have a valid PR
           if [ -z "${{ needs.get-context.outputs.pr_number }}" ]; then
             echo "No PR found for this workflow run - skipping reviews"


### PR DESCRIPTION
## Summary
- When a PR is closed and reopened, the `pull_request: reopened` trigger runs the review workflow with `tests_passed=false`
- All review jobs get skipped, but `check_result()` treats `skipped` as `success`
- The `All Required Agent Reviews` job exits 0, satisfying branch protection **before any actual reviews run**
- This means the PR becomes mergeable immediately after reopen, with no GO/NO-GO decision

## Fix
- Fail early in `all-reviews-passed` when `github.event_name == 'pull_request'`
- The reopen path only needs to reset the `agent-reviews-passed` label (already handled by `get-context`)
- The real reviews come from the `workflow_run` trigger after PR Tests complete

## Test plan
- [ ] Close and reopen a PR
- [ ] Verify `All Required Agent Reviews` check shows as failed (not success)
- [ ] Verify the `workflow_run`-triggered review run still posts reviews and passes the check

🤖 Generated with [Claude Code](https://claude.com/claude-code)