### PR TITLE
fix: Replace broken gh config bind mount with token-based auth

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,11 +10,10 @@
     }
   },
   "onCreateCommand": "bash .devcontainer/setup-user.sh \"${localEnv:USER}\"",
-  "postCreateCommand": "bash .githooks/install-hooks.sh",
+  "initializeCommand": "gh auth token > .devcontainer/.gh-token 2>/dev/null || true",
+  "postCreateCommand": "bash .devcontainer/post-create.sh && bash .githooks/install-hooks.sh",
   "postStartCommand": "bash .devcontainer/fix-dns-order.sh && sudo chown -R \"$(id -u):$(id -g)\" /workspaces 2>/dev/null || true",
-  "mounts": [
-    "source=${localEnv:HOME}/.config/gh,target=/tmp/gh-config,type=bind"
-  ],
+  "mounts": [],
   "remoteEnv": {},
   "customizations": {
     "vscode": {

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Post-create setup for devcontainer.
+# Called via postCreateCommand in devcontainer.json.
+set -e
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Set up gh CLI credentials from host token (written by initializeCommand)
+REPO_TOKEN_FILE="$REPO_ROOT/.devcontainer/.gh-token"
+if [ -s "$REPO_TOKEN_FILE" ]; then
+  echo "Setting up GitHub CLI credentials..."
+  GH_TOKEN=$(cat "$REPO_TOKEN_FILE")
+  echo "$GH_TOKEN" | gh auth login --with-token 2>/dev/null &&
+    echo "gh auth configured." || echo "Warning: gh auth login failed."
+  rm -f "$REPO_TOKEN_FILE"
+else
+  echo "Warning: No gh token found; gh CLI credentials not available."
+fi

--- a/.devcontainer/setup-user.sh
+++ b/.devcontainer/setup-user.sh
@@ -74,11 +74,4 @@ fi
 # Fix ownership of copied files
 chown -R "$TARGET_USER":"$TARGET_GROUP" /home/"$TARGET_USER"
 
-# Set up gh config symlink if the mount exists
-if [ -d /tmp/gh-config ]; then
-    mkdir -p /home/"$TARGET_USER"/.config
-    ln -sf /tmp/gh-config /home/"$TARGET_USER"/.config/gh
-    chown -h "$TARGET_USER":"$TARGET_GROUP" /home/"$TARGET_USER"/.config/gh
-fi
-
 echo "User $TARGET_USER created successfully."

--- a/.github/workflows/claude-diagnose-workflow-failure.yml
+++ b/.github/workflows/claude-diagnose-workflow-failure.yml
@@ -136,9 +136,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create gh config directory for devcontainer mount
-        run: mkdir -p ~/.config/gh
-
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -176,9 +176,6 @@ jobs:
           token: ${{ secrets.WORKFLOW_PAT }}  # PAT required to push workflow file changes
           ref: ${{ steps.pr-context.outputs.is_pr == 'true' && steps.pr-context.outputs.pr_head_ref || github.ref }}
 
-      - name: Create gh config directory for devcontainer mount
-        run: mkdir -p ~/.config/gh
-
       - name: Extract comment body
         id: comment
         env:
@@ -349,9 +346,6 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.WORKFLOW_PAT }}  # PAT required to push workflow file changes
-
-      - name: Create gh config directory for devcontainer mount
-        run: mkdir -p ~/.config/gh
 
       - name: Check for existing PR
         id: check-existing

--- a/.github/workflows/review-coverage-evaluator.yml
+++ b/.github/workflows/review-coverage-evaluator.yml
@@ -90,9 +90,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create gh config directory for devcontainer mount
-        run: mkdir -p ~/.config/gh
-
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,14 @@ rewards/
 state.json
 security-updates.log
 
+# Devcontainer secrets (written by initializeCommand, consumed by postCreateCommand)
+.devcontainer/.gh-token
+
+# Devcontainer SSH config (environment-specific)
+.devcontainer/known_hosts
+.devcontainer/ssh_config
+.devcontainer/setup-ssh.sh
+
 # Editor/IDE
 .idea/
 .vscode/


### PR DESCRIPTION
## Summary
- Replace bind-mounted `~/.config/gh` with `initializeCommand` token extraction + `postCreateCommand` token consumption
- Remove dead gh config symlink logic from `setup-user.sh`
- Remove 4 unnecessary "Create gh config directory for devcontainer mount" steps from CI workflows
- Gitignore devcontainer SSH config files and `.gh-token`

Adopted from https://github.com/NickBorgers/home-automation/pull/916

## Test plan
- [ ] Rebuild devcontainer locally, verify `gh auth status` succeeds
- [ ] Verify CI workflows still pass (they use `GH_TOKEN` env var, unaffected by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)