### PR TITLE
fix: Add reopened trigger to resolve-issue pipeline

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -6,7 +6,7 @@ on:
   pull_request_review_comment:
     types: [created]
   issues:
-    types: [opened]
+    types: [opened, reopened]
   pull_request_review:
     types: [submitted]
 
@@ -331,7 +331,7 @@ jobs:
     needs: [authorize, build-devcontainer]
     if: |
       needs.authorize.outputs.authorized == 'true' &&
-      github.event_name == 'issues' && github.event.action == 'opened'
+      github.event_name == 'issues' && (github.event.action == 'opened' || github.event.action == 'reopened')
     runs-on: [self-hosted, homelab]
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Add `reopened` to the issues event trigger so closing/reopening an issue retriggers the resolve-issue pipeline
- Update the `resolve-issue` job's `if` condition to match both `opened` and `reopened` actions

## Test plan
- [ ] Close and reopen issue #97 after merge to verify the pipeline triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)