### PR TITLE
feat: Pass Claude Code credentials into devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
     }
   },
   "onCreateCommand": "bash .devcontainer/setup-user.sh \"${localEnv:USER}\"",
-  "initializeCommand": "gh auth token > .devcontainer/.gh-token 2>/dev/null || true",
+  "initializeCommand": "bash .devcontainer/init-host-credentials.sh",
   "postCreateCommand": "bash .devcontainer/post-create.sh && bash .githooks/install-hooks.sh",
   "postStartCommand": "bash .devcontainer/fix-dns-order.sh && sudo chown -R \"$(id -u):$(id -g)\" /workspaces 2>/dev/null || true",
   "mounts": [],

--- a/.devcontainer/init-host-credentials.sh
+++ b/.devcontainer/init-host-credentials.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Runs on the HOST before the devcontainer starts.
+# Extracts credentials from host keychain/CLI and writes them to files
+# that postCreateCommand will consume inside the container.
+# All token files are gitignored and deleted after use.
+
+set -e
+cd "$(dirname "$0")"
+
+# GitHub CLI token
+gh auth token > .gh-token 2>/dev/null || true
+
+# Claude Code OAuth credentials (macOS keychain → full JSON with refresh token)
+if command -v security &>/dev/null; then
+    security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null \
+        > .claude-credentials 2>/dev/null || true
+fi

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -16,3 +16,17 @@ if [ -s "$REPO_TOKEN_FILE" ]; then
 else
   echo "Warning: No gh token found; gh CLI credentials not available."
 fi
+
+# Set up Claude Code credentials from host keychain (written by initializeCommand)
+# Claude Code reads ~/.claude/.credentials.json on Linux (no keychain available)
+CLAUDE_CRED_FILE="$REPO_ROOT/.devcontainer/.claude-credentials"
+if [ -s "$CLAUDE_CRED_FILE" ]; then
+  echo "Setting up Claude Code credentials..."
+  mkdir -p "$HOME/.claude"
+  cp "$CLAUDE_CRED_FILE" "$HOME/.claude/.credentials.json"
+  chmod 600 "$HOME/.claude/.credentials.json"
+  echo "Claude Code credentials configured."
+  rm -f "$CLAUDE_CRED_FILE"
+else
+  echo "Warning: No Claude credentials found; Claude Code credentials not available."
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ security-updates.log
 
 # Devcontainer secrets (written by initializeCommand, consumed by postCreateCommand)
 .devcontainer/.gh-token
+.devcontainer/.claude-credentials
 
 # Devcontainer SSH config (environment-specific)
 .devcontainer/known_hosts


### PR DESCRIPTION
## Summary
- Adds `init-host-credentials.sh` that runs on the host before container start, extracting both gh and Claude Code OAuth credentials from the macOS keychain
- Updates `post-create.sh` to install the Claude credentials into `~/.claude/.credentials.json` inside the container, then deletes the temp file
- Consolidates the existing gh token extraction into the same init script
- Gitignores the `.claude-credentials` temp file

## Test plan
- [ ] Rebuild devcontainer on macOS with Claude Code authenticated — verify `claude` works inside container without re-auth
- [ ] Rebuild on a machine without Claude Code — verify graceful fallback warning
- [ ] Confirm `.claude-credentials` temp file is deleted after container creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)