### PR TITLE
feat: Post-merge daemon script change detection

### DIFF
--- a/.github/workflows/post-merge-daemon-check.yml
+++ b/.github/workflows/post-merge-daemon-check.yml
@@ -67,10 +67,9 @@ jobs:
         if: steps.detect.outputs.found == 'true' && steps.find-pr.outputs.pr_number != ''
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.find-pr.outputs.pr_number }}
+          SUMMARY: ${{ steps.detect.outputs.summary }}
         run: |
-          PR_NUMBER="${{ steps.find-pr.outputs.pr_number }}"
-          SUMMARY="${{ steps.detect.outputs.summary }}"
-
           gh pr comment "$PR_NUMBER" --body "$(cat <<EOF
           ## Daemon Script Changes Detected
 


### PR DESCRIPTION
Resolves #97

## Summary
- Adds a lightweight GitHub Actions workflow (`post-merge-daemon-check.yml`) that detects new or modified daemon scripts after merges to main
- Only triggers when files in `scripts/` change (path filter), avoiding unnecessary runs
- Compares HEAD with its parent commit to identify daemon script additions/modifications
- Posts a summary comment on the merged PR when daemon changes are found, so the agent can be made aware

## Why
The old approach had the agent read git diffs on every heartbeat cycle to detect daemon script changes. This was expensive in tokens and only relevant after PR merges. This workflow moves that detection to a one-time post-merge check in CI.

## Test plan
- [ ] Verify workflow triggers on push to main when `scripts/` files change
- [ ] Verify workflow does NOT trigger when non-script files change (path filter)
- [ ] Verify daemon script detection correctly identifies additions vs modifications
- [ ] Verify PR comment is posted with accurate change summary

Generated with Claude Code