### PR TITLE
Add tmux to devcontainer for worktree support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Python for YAML validation and scripting
     python3-pip python3-yaml \
     # Utilities
-    bc curl jq \
+    bc curl jq tmux \
     && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub CLI


### PR DESCRIPTION
## Summary
- Adds `tmux` to the devcontainer apt-get install block to support git worktree workflows

## Test plan
- [ ] Rebuild devcontainer and verify `tmux` is available
- [ ] Confirm existing tools (bc, curl, jq, shellcheck) still install correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)