### PR TITLE
fix: Set TERM and LANG for proper CLI rendering in tmux

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,10 @@
   "postCreateCommand": "bash .devcontainer/post-create.sh && bash .githooks/install-hooks.sh",
   "postStartCommand": "bash .devcontainer/fix-dns-order.sh && sudo chown -R \"$(id -u):$(id -g)\" /workspaces 2>/dev/null || true",
   "mounts": [],
-  "remoteEnv": {},
+  "remoteEnv": {
+    "TERM": "xterm-256color",
+    "LANG": "en_US.UTF-8"
+  },
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -5,6 +5,12 @@ set -e
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
+# Configure tmux to use xterm-256color so CLI tools (e.g. Claude Code) render correctly
+cat > "$HOME/.tmux.conf" << 'TMUXEOF'
+set -g default-terminal "xterm-256color"
+set-environment -g LANG en_US.UTF-8
+TMUXEOF
+
 # Set up gh CLI credentials from host token (written by initializeCommand)
 REPO_TOKEN_FILE="$REPO_ROOT/.devcontainer/.gh-token"
 if [ -s "$REPO_TOKEN_FILE" ]; then


### PR DESCRIPTION
## Summary
- Add `TERM=xterm-256color` and `LANG=en_US.UTF-8` to `remoteEnv` in devcontainer.json
- Add `~/.tmux.conf` provisioning in post-create.sh so tmux sessions inherit correct TERM and LANG
- Fixes Unicode rendering issues in CLI tools (e.g. Claude Code) when launched via `dcs` (tmux)

## Test plan
- [x] Verified `TERM=xterm-256color` and `LANG=en_US.UTF-8` inside tmux sessions
- [x] Verified Claude Code renders correctly when launched via tmux

🤖 Generated with [Claude Code](https://claude.com/claude-code)