### PR TITLE
Fix reminder-daemon.sh orphaning on container restart

### DIFF
--- a/scripts/reminder-daemon.sh
+++ b/scripts/reminder-daemon.sh
@@ -70,6 +70,7 @@ if [[ "$RUN_ONCE" == false ]]; then
     fi
     echo "$$" > "$PID_FILE"
     trap 'rm -f "$PID_FILE"' EXIT
+    trap 'rm -f "$PID_FILE"; exit 0' SIGTERM SIGINT
 fi
 
 if [[ ! -x "$CHECK_SCRIPT" ]]; then


### PR DESCRIPTION
Resolves #107

## Summary
- Added `SIGTERM`/`SIGINT` signal handler to `scripts/reminder-daemon.sh` so the daemon cleans up its PID file and exits cleanly when the container is stopped
- Previously only `EXIT` was trapped, causing child processes to orphan and accumulate across container restarts

## Test Plan
- Verify `shellcheck scripts/reminder-daemon.sh` passes clean
- Start the daemon, send `SIGTERM` (`kill <pid>`), confirm PID file is removed and process exits
- Start the daemon, send `SIGINT` (Ctrl+C), confirm same cleanup behavior
- Restart scenario: start daemon, kill with SIGTERM, start again — should not report "already running"

Generated with Claude Code