### PR TITLE
fix: Stop wasted devcontainer builds and add concurrency groups

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -59,8 +59,10 @@ RUN curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused https://claude.ai/i
 # Without hasCompletedOnboarding, Claude enters onboarding wizard in --print mode
 RUN echo '{"hasCompletedOnboarding": true}' > /home/vscode/.claude.json
 
-# Codex CLI is installed at container runtime (post-create) so devcontainer rebuilds
-# stay fast even when its installer changes upstream.
+# Install Codex CLI (baked into image to avoid runtime download on every CI run)
+RUN curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused \
+    "https://github.com/openai/codex/releases/download/rust-v${CODEX_CLI_VERSION}/install.sh" \
+    | sh -s -- "${CODEX_CLI_VERSION}"
 
 # Switch back to root so onCreateCommand can create users dynamically.
 # The devcontainer's remoteUser setting ensures all commands run as the correct

--- a/.devcontainer/configure-codex.sh
+++ b/.devcontainer/configure-codex.sh
@@ -2,30 +2,12 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-DEVCONTAINER_DOCKERFILE="$SCRIPT_DIR/Dockerfile"
-
-get_arg_version() {
-  local arg_name=$1
-  local value
-  value=$(grep -oP "ARG ${arg_name}=\\K[^[:space:]]+" "$DEVCONTAINER_DOCKERFILE" | tail -n 1 || true)
-  if [ -z "$value" ]; then
-    echo "Failed to read ${arg_name} from ${DEVCONTAINER_DOCKERFILE}" >&2
-    exit 1
-  fi
-  printf '%s\n' "$value"
-}
-
-CODEX_CLI_VERSION="$(get_arg_version CODEX_CLI_VERSION)"
-
 export PATH="$HOME/.local/bin:$PATH"
 
-# Fallback: install codex if not already present (e.g., if post-create.sh
-# was skipped or if devcontainer features wiped the install).
+# Codex CLI is baked into the devcontainer image. Verify it's available.
 if ! command -v codex &>/dev/null; then
-  echo "codex not found, installing..."
-  curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused "https://github.com/openai/codex/releases/download/rust-v${CODEX_CLI_VERSION}/install.sh" \
-    | sh -s -- "${CODEX_CLI_VERSION}"
+  echo "ERROR: codex not found — expected it baked into the devcontainer image" >&2
+  exit 1
 fi
 
 mkdir -p "$HOME/.codex"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -78,23 +78,15 @@ get_arg_version() {
     printf '%s\n' "$value"
 }
 
-echo "Installing AI coding assistants..."
 export PATH="$HOME/.local/bin:$PATH"
 
+# Codex CLI is baked into the devcontainer image.
+# Verify the expected version is present.
 CODEX_CLI_VERSION="$(get_arg_version CODEX_CLI_VERSION)"
-
-# Install/update Codex via official installer
-install_codex() {
-    echo "Installing Codex CLI ${CODEX_CLI_VERSION}..."
-    curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused "https://github.com/openai/codex/releases/download/rust-v${CODEX_CLI_VERSION}/install.sh" \
-        | sh -s -- "${CODEX_CLI_VERSION}"
-}
-
 CURRENT_CODEX_VERSION="$(codex --version 2>/dev/null | awk '{print $2}' || true)"
 if [ "$CURRENT_CODEX_VERSION" != "$CODEX_CLI_VERSION" ]; then
-    install_codex
-else
-    echo "Codex CLI already at ${CURRENT_CODEX_VERSION}, skipping install."
+    echo "Warning: Codex CLI version mismatch (have: ${CURRENT_CODEX_VERSION}, want: ${CODEX_CLI_VERSION})"
+    echo "Rebuilding the devcontainer image should fix this."
 fi
 
 bash "$SCRIPT_DIR/configure-codex.sh"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,6 +14,11 @@ on:
 # Authorization checks are implemented to prevent prompt injection from untrusted users.
 # Only repository collaborators, members, and owners can trigger Claude.
 
+# Prevent duplicate runs for the same issue/PR. New runs cancel in-progress ones.
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 env:
   # Note: must be lowercase for Docker compatibility
   DEVCONTAINER_IMAGE: ghcr.io/nickborgersprobably/hide-my-list-devcontainer
@@ -78,9 +83,18 @@ jobs:
           esac
 
   # Build and cache devcontainer image first
+  # Only build when a downstream job (claude or resolve-issue) will actually run.
+  # Without this gate, every PR review comment triggers a wasted devcontainer build.
   build-devcontainer:
     needs: authorize
-    if: needs.authorize.outputs.authorized == 'true'
+    if: |
+      needs.authorize.outputs.authorized == 'true' &&
+      (
+        (github.event_name == 'issues') ||
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+      )
     runs-on: [self-hosted, homelab]
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- **Gate `build-devcontainer` on downstream filters** — PR review comments without `@claude` no longer trigger a devcontainer build that gets thrown away. This was the main cause of the queue flooding.
- **Add workflow-level concurrency group** keyed by issue/PR number with `cancel-in-progress: true` to prevent duplicate runs from piling up.
- **Bake Codex CLI into the Dockerfile** — eliminates the runtime download on every CI run. `configure-codex.sh` now just verifies it's present and writes config.

## Context
Every PR review comment from the multi-agent review pipeline was triggering `authorize` → `build-devcontainer` → skip `claude` (no `@claude`). With 10+ review comments on a single PR plus 11 new issues opened simultaneously, this created 30+ queued runs on the self-hosted runner, blocking actual resolve-issue work from proceeding.

## Test plan
- [ ] Verify a new issue triggers `build-devcontainer` → `resolve-issue` as before
- [ ] Verify a PR review comment **without** `@claude` skips `build-devcontainer` entirely
- [ ] Verify a PR comment **with** `@claude` still triggers `build-devcontainer` → `claude`
- [ ] Verify concurrency: opening two issues rapidly cancels the first run's in-progress work
- [ ] Verify Codex CLI is available inside the devcontainer (baked into image)

🤖 Generated with [Claude Code](https://claude.com/claude-code)