### PR TITLE
Disable web search and fetch in OpenClaw template

### DIFF
--- a/setup/openclaw.json.template
+++ b/setup/openclaw.json.template
@@ -67,11 +67,10 @@
   "tools": {
     "web": {
       "search": {
-        "enabled": true,
-        "apiKey": "{{WEB_SEARCH_API_KEY}}"
+        "enabled": false
       },
       "fetch": {
-        "enabled": true
+        "enabled": false
       }
     }
   },


### PR DESCRIPTION
Resolves #121

## Summary
- disable `tools.web.search` by default in `setup/openclaw.json.template`
- disable `tools.web.fetch` by default in `setup/openclaw.json.template`
- remove the unused `WEB_SEARCH_API_KEY` placeholder from the default template

## Test Plan
- `shellcheck scripts/*.sh`
- `yamllint .github/workflows/*.yml` *(currently fails on pre-existing workflow lint issues unrelated to this change)*
- `jq empty setup/openclaw.json.template`

Generated with Codex