### PR TITLE
Document cron-based reminder and pipeline flows

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,13 +28,13 @@ One feature which makes OpenClaw interesting is the fact it can change itself, a
 
 GitHub has been chosen as the tool for facilitating this, and that means we need access for OpenClaw to open PRs and pull changes.
 
-### Webhook — [A] only
+### Cron-driven reminder flow — [BC] configuration
 
-The webhook listener ([`scripts/webhook-signal.sh`](scripts/webhook-signal.sh)) receives CI/CD notifications from the network **[A]**, but that's all it does. It immediately discards all request data (`exec 0</dev/null`) and writes a self-generated Unix timestamp to a signal file. It has no access to credentials **[B]** and makes no external calls **[C]**. There's nothing to exploit because nothing is read.
+The reminder path now runs through OpenClaw durable cron. The `reminder-check` job triggers the agent, which runs [`scripts/check-reminders.sh`](scripts/check-reminders.sh), queries Notion using `.env` credentials **[B]**, and writes a local `.reminder-signal` handoff file **[C]** for the same agent session to deliver. It processes no untrusted network input **[A]** — only reminder records the agent created in Notion. This is a safe **[BC]** configuration.
 
-### Reminder daemon — [BC] configuration
+### Cron-driven GitHub polling — [AC] configuration
 
-The reminder daemon ([`scripts/reminder-daemon.sh`](scripts/reminder-daemon.sh) + [`scripts/check-reminders.sh`](scripts/check-reminders.sh)) sources `.env` credentials **[B]** and queries Notion plus writes a local signal file **[C]**, but processes no untrusted input **[A]** — it only reads structured data from Notion that was created by the agent itself. This is a safe **[BC]** configuration.
+GitHub status checks now use the durable `pipeline-monitor` cron job plus [`scripts/check-github-status.sh`](scripts/check-github-status.sh). That flow reads untrusted GitHub content **[A]** and can surface follow-up messages or PR activity **[C]**, but it has no access to infrastructure secrets beyond the optional repo-scoped GitHub token and no Notion credentials **[B]**. Removing the inbound webhook means there is no longer an externally reachable listener on the host.
 
 ### CI/CD review agents — [AC] configuration
 
@@ -85,10 +85,11 @@ A Squid proxy enforces a domain allowlist. If the agent (or anything else on the
 
 The proxy also blocks connections to private network ranges (RFC 1918, loopback, link-local, and the overlay subnet itself) to prevent DNS rebinding attacks. Caching is disabled, `forwarded_for` headers are stripped, and the version string is suppressed.
 
-### Webhook hardening
+### Inbound exposure reduction
 
-- Connections capped at 2 concurrent (`socat max-children=2`) with a 3-second hard timeout
-- Exposed via Tailscale Funnel on a separate port from the control UI
+- No webhook listener, `socat` process, or public/Tailscale Funnel port for GitHub notifications
+- OpenClaw durable cron polls GitHub and reminders from inside the existing agent sandbox
+- Heartbeat re-registers cron jobs after OpenClaw's 7-day durable-cron expiry, so reliability no longer depends on long-lived bash daemons
 
 ### Configuration hardening
 
@@ -103,7 +104,7 @@ The proxy also blocks connections to private network ranges (RFC 1918, loopback,
 | Prompt injection via user message | Agent is [BC] for direct interaction — channels are authenticated/paired, only the owner can send messages | Low risk; owner is the only input source |
 | Prompt injection via GitHub content | Becomes [ABC] when processing GitHub content — PR/issue bodies from external contributors are an injection vector | Blast radius limited to Notion operations the token permits; proxy limits exfiltration destinations |
 | Agent pivots to internal network | [ABC] — an injected prompt could attempt lateral movement | Tailscale largely prevents access to internal systems; proxy blocks private ranges; VLAN segmentation blocks internal network access at the router level |
-| Malicious webhook payload | Webhook is [A]-only — data discarded, no credentials or external access | Connection limits and hard timeout |
+| Malicious inbound webhook payload | Eliminated — there is no inbound webhook listener anymore | Cron polling removed that attack surface entirely |
 | Malicious PR manipulates review agent | Review agents are [AC] — no access to secrets or infrastructure | Fork PRs blocked from all self-hosted runner workflows; devcontainer built only from main; self-hosted runners isolated by VLAN segmentation |
 | Credential exfiltration via prompt injection | The agent has credentials in its runtime context and could be prompted to reveal them | Proxy allowlist limits where credentials could be sent; admin surfaces behind Tailscale; model alignment is a speed bump, not a guarantee |
 | Unauthorized admin access | Admin interfaces require Tailscale authentication and at least OpenClaw pairing for authentication | Firewall allows only WireGuard inbound |

--- a/docs/notion-schema.md
+++ b/docs/notion-schema.md
@@ -463,7 +463,7 @@ Boolean flag indicating this task is a time-specific reminder rather than a norm
 
 ### RemindAt (date)
 
-The wall-clock time at which the reminder should fire. Stored as a full ISO 8601 timestamp with timezone offset so the reminder daemon can compare against the current time.
+The wall-clock time at which the reminder should fire. Stored as a full ISO 8601 timestamp with timezone offset so the cron-driven reminder check can compare against the current time.
 
 ```
 Format: ISO 8601 with timezone (e.g., 2025-01-04T18:00:00-06:00)
@@ -471,7 +471,7 @@ Format: ISO 8601 with timezone (e.g., 2025-01-04T18:00:00-06:00)
 
 **Set when:** Task is created with `is_reminder = true`. The AI parses the user's time reference (including timezone like "6pm PT" or "3pm CT") and converts it to a full ISO 8601 timestamp.
 
-**Used by:** The `check-reminders.sh` script (invoked by `reminder-daemon.sh`), which queries for pending reminders where `remind_at` is within the current check window.
+**Used by:** The `check-reminders.sh` script, which the durable `reminder-check` cron job runs every 5 minutes before handing due reminders to the agent via `.reminder-signal`.
 
 ---
 

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -929,7 +929,7 @@ The reward system scales celebrations based on achievement significance:
 
 ## Phase 7: Scheduled Reminder Delivery
 
-Reminder tasks follow a separate lifecycle from normal tasks. They are not surfaced through task selection — instead, the reminder daemon delivers them proactively at the specified time.
+Reminder tasks follow a separate lifecycle from normal tasks. They are not surfaced through task selection — instead, the durable cron job `reminder-check` runs `scripts/check-reminders.sh`, writes `.reminder-signal`, and the agent delivers due reminders at the specified time.
 
 ```mermaid
 flowchart TD
@@ -938,8 +938,8 @@ flowchart TD
     Parse --> Save[Save to Notion with is_reminder=true]
 
     Save --> Wait[Task waits in Notion]
-    Wait --> Daemon[reminder-daemon.sh polls every 5 min]
-    Daemon --> Due{remind_at <= now?}
+    Wait --> Cron[reminder-check cron runs check-reminders.sh]
+    Cron --> Due{remind_at <= now?}
     Due -->|No| Wait
     Due -->|Yes| Late{>15 min past due?}
 
@@ -957,7 +957,7 @@ flowchart TD
 
 | Property | Normal Task | Reminder Task |
 |----------|-------------|---------------|
-| Selection | User requests → AI suggests | Reminder daemon delivers at remind_at |
+| Selection | User requests → AI suggests | `reminder-check` cron fires at remind_at |
 | Lifecycle | Pending → In Progress → Completed | Pending → Sent/Missed → Completed |
 | Check-ins | Timer-based follow-ups | None (single delivery) |
 | Rejection | User can reject suggestion | N/A (delivered once) |

--- a/docs/user-interactions.md
+++ b/docs/user-interactions.md
@@ -762,14 +762,15 @@ Reminders are tasks with a specific wall-clock delivery time. Unlike check-ins (
 
 ```mermaid
 sequenceDiagram
-    participant Daemon as reminder-daemon.sh
+    participant Cron as reminder-check cron
     participant Scr as check-reminders.sh
     participant Notion as Notion API
     participant Signal as Signal File
     participant Agent as OpenClaw Agent
     participant User
 
-    Daemon->>Scr: Trigger every 5 minutes
+    Cron->>Agent: Trigger reminder-check session
+    Agent->>Scr: Run check-reminders.sh
     Scr->>Notion: Query due reminders (remind_at <= now)
     Notion-->>Scr: Due reminder tasks
     Scr->>Signal: Write .reminder-signal

--- a/scripts/check-github-status.sh
+++ b/scripts/check-github-status.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # check-github-status.sh — Check GitHub for PR reviews, workflow failures, and issues
-# Called by the agent when the webhook signal fires
+# Called by the agent when the pipeline-monitor cron job fires
 # Outputs structured status for the agent to process
 #
 # SECURITY: This script only reads from GitHub's public API.

--- a/scripts/check-reminders.sh
+++ b/scripts/check-reminders.sh
@@ -11,7 +11,7 @@
 # delivery, so stale signal entries are cleared automatically once the agent
 # updates Notion.
 #
-# Designed to run via reminder-daemon.sh (default: every 5 minutes).
+# Designed to run from the durable reminder-check cron job (five-minute cadence).
 # The agent checks for the signal file and delivers reminders to the user
 # through the active messaging surface.
 #


### PR DESCRIPTION
Resolves #116

## Summary
- document reminder delivery via durable reminder-check cron, check-reminders.sh, and .reminder-signal handoff
- replace webhook/daemon references in security threat model with pipeline-monitor cron polling
- update diagrams and script headers so they match the current cron-driven architecture

## Test Plan
- shellcheck scripts/*.sh
- yamllint .github/workflows/*.yml (fails: repo-wide pre-existing line-length violations)

Generated with Codex