### PR TITLE
Align reminder signal documentation flow

### DIFF
--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -2,16 +2,17 @@
 
 ## Checks (in order)
 
-### 1. Reminder Signal
+### 1. Stranded Reminder Signal
 - Check `.reminder-signal`
-- If exists: read it, send each reminder to the user, update Notion status to "sent", delete the signal file
+- This file is the reminder handoff written by `scripts/check-reminders.sh`
+- If it still exists when heartbeat runs, treat it as undelivered reminder work: read it, send each reminder to the user, update Notion status to `sent` or `missed` based on the file, then delete the signal file
 
 ### 2. Cron Job Health
 Verify that durable cron jobs are registered. If any are missing, re-register them.
 
 | Job | Schedule | Action |
 |-----|----------|--------|
-| reminder-check | `*/5 * * * *` | Run `scripts/check-reminders.sh`, deliver due reminders, update Notion |
+| reminder-check | `*/5 * * * *` | Run `scripts/check-reminders.sh`; if it writes `.reminder-signal`, read it, deliver reminders, update Notion, delete the file |
 | pipeline-monitor | `*/2 * * * *` | Run `scripts/check-github-status.sh`, report actionable changes |
 
 To check: use CronList. If a job is missing (7-day auto-expiry), re-create it with CronCreate (durable: true) using the schedule and prompt from `setup/cron/`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,11 +30,11 @@ GitHub has been chosen as the tool for facilitating this, and that means we need
 
 ### Webhook — [A] only
 
-The webhook listener ([`scripts/webhook-signal.sh`](scripts/webhook-signal.sh)) receives CI/CD notifications from the network **[A]**, but that's all it does. It immediately discards all request data (`exec 0</dev/null`) and writes a self-generated Unix timestamp to a signal file. It has no access to credentials **[B]** and makes no external calls **[C]**. There's nothing to exploit because nothing is read.
+The former webhook listener (`scripts/webhook-signal.sh`, now replaced by cron-based pipeline monitoring) received CI/CD notifications from the network **[A]**, but that was all it did. It immediately discarded all request data (`exec 0</dev/null`) and wrote a self-generated Unix timestamp to a signal file. It had no access to credentials **[B]** and made no external calls **[C]**. There was little to exploit because nothing was read.
 
-### Reminder daemon — [BC] configuration
+### Reminder delivery flow — [BC] configuration
 
-The reminder daemon ([`scripts/reminder-daemon.sh`](scripts/reminder-daemon.sh) + [`scripts/check-reminders.sh`](scripts/check-reminders.sh)) sources `.env` credentials **[B]** and queries Notion plus writes a local signal file **[C]**, but processes no untrusted input **[A]** — it only reads structured data from Notion that was created by the agent itself. This is a safe **[BC]** configuration.
+The reminder flow ([`scripts/check-reminders.sh`](scripts/check-reminders.sh) plus the OpenClaw `reminder-check` cron prompt) sources `.env` credentials **[B]**, queries Notion, and writes a local signal file **[C]**, but processes no untrusted input **[A]** — it only reads structured data from Notion that was created by the agent itself. This is a safe **[BC]** configuration.
 
 ### CI/CD review agents — [AC] configuration
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -217,7 +217,7 @@ sequenceDiagram
 1. During task intake, the AI detects reminder-style language (e.g., "remind me at 6pm PT to call Sarah") and sets `is_reminder = true`, `remind_at` (full ISO 8601 with timezone), and `reminder_status = pending`.
 2. A durable cron job (`reminder-check`) runs every 5 minutes via OpenClaw's native scheduling.
 3. The cron job triggers the agent to run `scripts/check-reminders.sh`, which queries Notion for pending reminders where `remind_at <= now`.
-4. If due reminders are found, the agent delivers them directly to the user via the active messaging channel and marks them as `sent` in Notion.
+4. If due reminders are found, `check-reminders.sh` writes `.reminder-signal`; the same cron-driven agent session reads that file, delivers the reminders, marks them as `sent` or `missed` in Notion, and deletes the handoff file.
 5. Reminders more than 15 minutes past due are flagged as `missed` but still delivered with a note.
 6. The cron job only fires when the agent is idle — it won't interrupt the user mid-task, which is better for ADHD focus.
 

--- a/docs/notion-schema.md
+++ b/docs/notion-schema.md
@@ -463,7 +463,7 @@ Boolean flag indicating this task is a time-specific reminder rather than a norm
 
 ### RemindAt (date)
 
-The wall-clock time at which the reminder should fire. Stored as a full ISO 8601 timestamp with timezone offset so the reminder daemon can compare against the current time.
+The wall-clock time at which the reminder should fire. Stored as a full ISO 8601 timestamp with timezone offset so the scheduled reminder check can compare against the current time.
 
 ```
 Format: ISO 8601 with timezone (e.g., 2025-01-04T18:00:00-06:00)
@@ -471,7 +471,7 @@ Format: ISO 8601 with timezone (e.g., 2025-01-04T18:00:00-06:00)
 
 **Set when:** Task is created with `is_reminder = true`. The AI parses the user's time reference (including timezone like "6pm PT" or "3pm CT") and converts it to a full ISO 8601 timestamp.
 
-**Used by:** The `check-reminders.sh` script (invoked by `reminder-daemon.sh`), which queries for pending reminders where `remind_at` is within the current check window.
+**Used by:** The `check-reminders.sh` script (invoked by the `reminder-check` durable cron job), which queries for pending reminders and writes `.reminder-signal` when `remind_at` is due.
 
 ---
 

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -57,7 +57,7 @@ OpenClaw provides `CronCreate` for scheduling recurring agent prompts. With `dur
 **Why this is better than daemons:**
 - No PID files, no silent death, no orphaned processes
 - OpenClaw manages the scheduling; failures are visible in the session
-- Reminder delivery happens in agent context — the agent can send Signal messages directly instead of writing to a signal file and hoping the heartbeat picks it up
+- Reminder delivery still happens in agent context, but `scripts/check-reminders.sh` hands due reminders to the cron prompt through `.reminder-signal` instead of relying on a long-running daemon
 - Cron only fires when the REPL is idle, which is actually better for ADHD — it won't interrupt the user mid-task
 
 **The 7-day expiry problem:** Recurring cron jobs auto-expire after 7 days. The heartbeat catches this and re-registers. This is a platform constraint we work around rather than a feature we chose.

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -929,7 +929,7 @@ The reward system scales celebrations based on achievement significance:
 
 ## Phase 7: Scheduled Reminder Delivery
 
-Reminder tasks follow a separate lifecycle from normal tasks. They are not surfaced through task selection — instead, the reminder daemon delivers them proactively at the specified time.
+Reminder tasks follow a separate lifecycle from normal tasks. They are not surfaced through task selection — instead, the durable `reminder-check` cron job delivers them proactively at the specified time.
 
 ```mermaid
 flowchart TD
@@ -938,10 +938,11 @@ flowchart TD
     Parse --> Save[Save to Notion with is_reminder=true]
 
     Save --> Wait[Task waits in Notion]
-    Wait --> Daemon[reminder-daemon.sh polls every 5 min]
-    Daemon --> Due{remind_at <= now?}
+    Wait --> Cron[reminder-check cron runs every 5 min]
+    Cron --> Due{remind_at <= now?}
     Due -->|No| Wait
-    Due -->|Yes| Late{>15 min past due?}
+    Due -->|Yes| Signal[check-reminders.sh writes .reminder-signal]
+    Signal --> Late{>15 min past due?}
 
     Late -->|No| Send[Deliver reminder]
     Late -->|Yes| SendMissed[Deliver with apology]
@@ -957,7 +958,7 @@ flowchart TD
 
 | Property | Normal Task | Reminder Task |
 |----------|-------------|---------------|
-| Selection | User requests → AI suggests | Reminder daemon delivers at remind_at |
+| Selection | User requests → AI suggests | `reminder-check` cron surfaces `.reminder-signal` at `remind_at` |
 | Lifecycle | Pending → In Progress → Completed | Pending → Sent/Missed → Completed |
 | Check-ins | Timer-based follow-ups | None (single delivery) |
 | Rejection | User can reject suggestion | N/A (delivered once) |

--- a/docs/user-interactions.md
+++ b/docs/user-interactions.md
@@ -762,20 +762,22 @@ Reminders are tasks with a specific wall-clock delivery time. Unlike check-ins (
 
 ```mermaid
 sequenceDiagram
-    participant Daemon as reminder-daemon.sh
+    participant Cron as OpenClaw cron
     participant Scr as check-reminders.sh
     participant Notion as Notion API
     participant Signal as Signal File
     participant Agent as OpenClaw Agent
     participant User
 
-    Daemon->>Scr: Trigger every 5 minutes
+    Cron->>Scr: Trigger reminder-check every 5 minutes
     Scr->>Notion: Query due reminders (remind_at <= now)
     Notion-->>Scr: Due reminder tasks
     Scr->>Signal: Write .reminder-signal
-    Agent->>Signal: Detect signal file
+    Cron->>Agent: Continue cron prompt
+    Agent->>Signal: Read .reminder-signal
     Agent->>User: Deliver reminder
     Agent->>Notion: Update reminder_status → sent/missed
+    Agent->>Signal: Delete .reminder-signal
 ```
 
 ### Reminder Delivery Messages

--- a/scripts/check-reminders.sh
+++ b/scripts/check-reminders.sh
@@ -11,9 +11,11 @@
 # delivery, so stale signal entries are cleared automatically once the agent
 # updates Notion.
 #
-# Designed to run via reminder-daemon.sh (default: every 5 minutes).
-# The agent checks for the signal file and delivers reminders to the user
-# through the active messaging surface.
+# Designed to run via the durable `reminder-check` cron prompt (every 5
+# minutes). The script writes a handoff file, and the agent session that ran it
+# reads that file to deliver reminders through the active messaging surface.
+# Heartbeat can also recover a stranded handoff file if a prior delivery did
+# not complete.
 #
 # SECURITY PROPERTIES:
 #   - Uses the same .env credential loading as notion-cli.sh

--- a/setup/README.md
+++ b/setup/README.md
@@ -70,7 +70,7 @@ The agent uses OpenClaw's durable cron system instead of bash daemons:
 
 | Job | Schedule | Purpose |
 |-----|----------|---------|
-| reminder-check | Every 5 min | Poll Notion for due reminders, deliver to user |
+| reminder-check | Every 5 min | Poll Notion for due reminders, write `.reminder-signal`, deliver to user |
 | pipeline-monitor | Every 2 min | Check GitHub for PR/CI status changes |
 | heartbeat (built-in) | Every 30 min | System health, cron re-registration |
 

--- a/setup/cron/heartbeat-check.md
+++ b/setup/cron/heartbeat-check.md
@@ -15,7 +15,7 @@ The heartbeat is not a cron job we create — it's a built-in OpenClaw feature c
 
 Every 30 minutes, OpenClaw runs the agent with `HEARTBEAT.md` as context. The agent performs the checks defined in `HEARTBEAT.md`:
 
-1. Check for pending reminder signals
+1. Check for stranded `.reminder-signal` reminder handoffs
 2. Verify cron jobs are registered (re-register if expired)
 3. Test Notion connectivity
 4. Verify environment is intact

--- a/setup/cron/reminder-check.md
+++ b/setup/cron/reminder-check.md
@@ -14,8 +14,9 @@ CronCreate:
 ## Prompt
 
 ```
-Run scripts/check-reminders.sh. If .reminder-signal exists afterward, read it and
-deliver each reminder to the user:
+Run scripts/check-reminders.sh. That script writes .reminder-signal as the
+handoff file for any due reminders. If .reminder-signal exists afterward, read
+it and deliver each reminder to the user:
 - On-time reminders: casual delivery ("Hey, time to [task]")
 - Missed reminders (>15 min late): note the delay but don't shame ("This was due a bit
   ago — [task]")
@@ -28,4 +29,4 @@ Delete .reminder-signal after all reminders are delivered.
 
 - Cron jobs auto-expire after 7 days. HEARTBEAT.md re-registers if missing.
 - Cron only fires when the REPL is idle. If the user is mid-conversation, reminders queue and deliver when the conversation pauses. For ADHD this is better — interrupting mid-task is harmful.
-- The workhorse script `check-reminders.sh` is unchanged from the daemon era.
+- `check-reminders.sh` only queries Notion and writes the handoff file; the cron prompt is what actually delivers the reminder.


### PR DESCRIPTION
Resolves #118

## Summary
- clarify across behavior docs that `reminder-check` still writes and consumes `.reminder-signal`
- teach HEARTBEAT and cron docs to treat the signal file as the durable handoff
- refresh security and script commentary to reflect the cron-driven reminder flow

## Test Plan
- shellcheck scripts/*.sh
- yamllint .github/workflows/*.yml (fails due to existing line-length violations)

Generated with Codex