### PR TITLE
Align TOOLS enum values with notion schema

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -14,13 +14,16 @@
 - Completed At, Started At, Is Reminder, Remind At, Reminder Status
 
 ### Status Values
-- pending, in_progress, completed, has_subtasks
+- Pending, In Progress, Completed, Has Subtasks
 
 ### Work Type Values
-- focus, creative, social, independent
+- Focus, Creative, Social, Independent
 
 ### Energy Values
-- high, medium, low
+- High, Medium, Low
+
+### Reminder Status Values
+- pending, sent, missed
 
 ## State File
 


### PR DESCRIPTION
Resolves #123

## Summary
- align status, work type, and energy enum casing in TOOLS.md with docs/notion-schema.md
- add reminder property names to the TOOLS.md Notion property reference

## Test Plan
- shellcheck scripts/*.sh
- yamllint .github/workflows/*.yml # fails: existing line-length and truthy warnings

Generated with Codex
