### PR TITLE
Add spec checklist to design review prompt

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -699,6 +699,20 @@ jobs:
               ISSUE_COMMENTS=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" --jq '.[] | "---\n**\(.user.login)** commented at \(.created_at):\n\(.body)\n"' 2>/dev/null | head -c 50000 || echo "")
             fi
 
+            git fetch origin main >/dev/null 2>&1 || true
+            CHANGED_FILES=$(git diff --name-only origin/main...HEAD || echo "")
+            SPEC_FILES=$(echo "$CHANGED_FILES" | grep -E '^(AGENTS\.md|SOUL\.md|TOOLS\.md|HEARTBEAT\.md|docs/.*\.md|setup/cron/.*|scripts/.*)' || true)
+
+            if [ -n "$SPEC_FILES" ]; then
+              SPEC_PASS_REQUIRED="true"
+              SPEC_FILES_BULLETS=$(echo "$SPEC_FILES" | sed 's/^/- /')
+              SPEC_CHECK_DIRECTIVE="The diff touches spec-critical files. You must run the checklist below and treat unresolved contradictions as BLOCKING."
+            else
+              SPEC_PASS_REQUIRED="false"
+              SPEC_FILES_BULLETS="(none)"
+              SPEC_CHECK_DIRECTIVE="If a future diff touches spec-critical files, run this checklist and block the PR until contradictions are resolved."
+            fi
+
             source .devcontainer/configure-codex.sh
 
             timeout 30m codex exec \
@@ -723,6 +737,11 @@ jobs:
             Issue Comments (additional context/requirements):
             ${ISSUE_COMMENTS}
 
+            Changed spec-critical files:
+            ${SPEC_FILES_BULLETS}
+
+            Docs-as-spec consistency required: ${SPEC_PASS_REQUIRED}
+
             **YOUR TASK:**
             1. Read the issue/PR description to understand the problem being solved.
             2. Examine the code changes (\`git diff origin/main...HEAD\`).
@@ -732,9 +751,17 @@ jobs:
                  significant code beyond what the title implies, flag as blocking scope creep.
                - State explicitly: \"Scope check: PASS\" or \"Scope check: FAIL — [reason]\"
             5. Evaluate design decisions: could a simpler approach work? Flag over-engineering as blocking.
+            6. When docs-as-spec consistency is required, follow the checklist below.
 
             Reference docs/architecture.md for system design context.
             Do NOT push any changes. This is a read-only review.
+
+            **DOCS-AS-SPEC CONSISTENCY CHECKLIST**
+            ${SPEC_CHECK_DIRECTIVE}
+            Checklist (complete each item when SPEC required):
+            1. Identify the canonical sources for each changed behavior (docs/ai-prompts.md, docs/task-lifecycle.md, docs/notion-schema.md, AGENTS.md, HEARTBEAT.md, TOOLS.md, setup/cron/*.md, and the runtime scripts/config they reference).
+            2. Cross-check every changed behavior claim against those canonical sources and the actual runtime scripts/config (e.g., reminder cron flows, state transitions, Notion property values).
+            3. Treat contradictions or drift across docs/scripts as BLOCKING. Call them out explicitly with the conflicting sources.
 
             **INLINE COMMENTS:** Where a concern is tied to a specific line of code, also leave
             an inline PR review comment on that line. Use inline comments for localized feedback

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,7 +148,7 @@ Log significant interactions, preference learning, and any issues.
 ## Review Pipeline
 
 PRs are reviewed by a multi-agent Codex pipeline:
-1. Design Review — validates intent fulfillment and design quality
+1. Design Review — validates intent fulfillment and design quality, and runs a docs-as-spec consistency check whenever spec-critical files change
 2. Security & Infrastructure Review — script safety, credential handling, workflow permissions
 3. Psych Research Review — validates against ADHD clinical research
 4. Prompt Engineering Review — validates prompt clarity, constraints, and cross-prompt consistency


### PR DESCRIPTION
Resolves #126

## Summary
- detect spec-critical file changes in the design review workflow
- require a docs-as-spec consistency checklist and surface the affected files in the prompt
- document the new review responsibility in AGENTS.md

## Test Plan
- shellcheck scripts/*.sh
- yamllint .github/workflows/*.yml (fails: repository-wide line-length violations; unchanged by this PR)

Generated with Codex