### PR TITLE
Fix Codex model configuration for LiteLLM

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,1 +1,1 @@
-model = "gpt-5-codex"
+model = "gpt-5.3-codex"

--- a/.devcontainer/configure-codex.sh
+++ b/.devcontainer/configure-codex.sh
@@ -34,7 +34,7 @@ mkdir -p "$HOME/.codex"
 # OPENAI_API_KEY is set to a placeholder in devcontainer.json because
 # the LiteLLM proxy doesn't require authentication.
 cat > "$HOME/.codex/config.toml" <<'EOF'
-model = "gpt-5-codex"
+model = "gpt-5.3-codex"
 model_provider = "litellm"
 
 [model_providers.litellm]


### PR DESCRIPTION
Resolves #138

## Summary
- switch configure-codex.sh to request gpt-5.3-codex so the LiteLLM proxy accepts the run
- align the repo-level .codex/config.toml with the same model identifier

## Test Plan
- shellcheck scripts/*.sh
- yamllint .github/workflows/*.yml (fails: pre-existing line-length violations across workflows)

Generated with Codex