### PR TITLE
Declare devcontainer platform for Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -119,6 +119,7 @@ jobs:
         with:
           imageName: ${{ env.DEVCONTAINER_IMAGE }}
           cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
+          platform: linux/amd64
           push: always
 
   claude:
@@ -227,6 +228,7 @@ jobs:
         with:
           imageName: ${{ env.DEVCONTAINER_IMAGE }}
           cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
+          platform: linux/amd64
           push: never
           env: |
             OPENAI_API_KEY=fake-key


### PR DESCRIPTION
Resolves #147

## Summary
- add linux/amd64 platform input to the devcontainer build step so docker push includes platform metadata
- mirror the same platform input for the devcontainer runtime step so the cache and manifest stay consistent

## Test Plan
- shellcheck scripts/*.sh
- yamllint .github/workflows/claude.yml (fails: existing 80+ char lines in workflow prior to this change)
- yamllint .github/workflows/*.yml (fails: repository workflows exceed the 80 character lint rule pre-change)

Generated with Codex