### PR TITLE
fix: Tighten docs_only to not skip security review on behavioral .md files

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -320,8 +320,11 @@ jobs:
             if [[ "$file" == scripts/* ]] || [[ "$file" == docs/* ]] || [[ "$file" == design/* ]] || [[ "$file" == *.md ]]; then
               CONFIG_ONLY="false"
             fi
-            # docs_only: true when all changed files are *.md, docs/*, or design/*
-            if [[ "$file" != *.md ]] && [[ "$file" != docs/* ]] && [[ "$file" != design/* ]]; then
+            # docs_only: true when all changed files are inert documentation
+            # In this agentic system, most .md files ARE the application (prompts,
+            # cron jobs, agent identity, behavior specs). Only design/* (research
+            # principles) and README.md files are truly non-behavioral.
+            if [[ "$file" != design/* ]] && [[ "$(basename "$file")" != "README.md" ]]; then
               DOCS_ONLY="false"
             fi
           done <<< "$FILES"


### PR DESCRIPTION
## Summary
- The `docs_only` file classification in the review pipeline treated **all** `.md` files as inert documentation, causing the security reviewer to be skipped for changes to behavioral `.md` files like cron prompts, agent specs, and behavior docs
- Narrowed `docs_only=true` to only apply when all changed files are in `design/*` (research principles) or are `README.md` files — everything else now triggers security review
- Identified from PR #134 where `setup/cron/reminder-check.md` (a cron prompt that calls `notion-cli.sh`) bypassed security review entirely

## Context

Per AGENTS.md: *"These docs are not documentation about a separate system — they are the system specification. Changing a doc changes how the agent behaves."*

Files affected by this classification change (now trigger security review):
- `setup/cron/*.md` — cron job prompts that execute scripts
- `SOUL.md`, `TOOLS.md`, `HEARTBEAT.md`, `IDENTITY.md` — agent identity/capabilities
- `docs/ai-prompts.md`, `docs/reward-system.md`, etc. — behavior specifications
- Any root-level `.md` that isn't `README.md`

Files that still skip security review (truly inert):
- `design/*` — ADHD research principles
- `**/README.md` — repository documentation

## Test plan
- shellcheck scripts/*.sh
- yamllint .github/workflows/*.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)