### PR TITLE
Support @codex as trigger keyword in Claude Code workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -91,9 +91,9 @@ jobs:
       needs.authorize.outputs.authorized == 'true' &&
       (
         (github.event_name == 'issues') ||
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+        (github.event_name == 'issue_comment' && (contains(github.event.comment.body, '@claude') || contains(github.event.comment.body, '@codex'))) ||
+        (github.event_name == 'pull_request_review_comment' && (contains(github.event.comment.body, '@claude') || contains(github.event.comment.body, '@codex'))) ||
+        (github.event_name == 'pull_request_review' && (contains(github.event.review.body, '@claude') || contains(github.event.review.body, '@codex')))
       )
     runs-on: [self-hosted, homelab]
     permissions:
@@ -125,10 +125,10 @@ jobs:
     needs: [authorize, build-devcontainer]
     if: |
       needs.authorize.outputs.authorized == 'true' &&
-      ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))))
+      ((github.event_name == 'issue_comment' && (contains(github.event.comment.body, '@claude') || contains(github.event.comment.body, '@codex'))) ||
+      (github.event_name == 'pull_request_review_comment' && (contains(github.event.comment.body, '@claude') || contains(github.event.comment.body, '@codex'))) ||
+      (github.event_name == 'pull_request_review' && (contains(github.event.review.body, '@claude') || contains(github.event.review.body, '@codex'))) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude') || contains(github.event.issue.body, '@codex') || contains(github.event.issue.title, '@codex'))))
     runs-on: [self-hosted, homelab]
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Updated all `contains(X, '@claude')` conditions in `.github/workflows/claude.yml` to also match `@codex` using `(contains(X, '@claude') || contains(X, '@codex'))` pattern
- Applies to both the `build-devcontainer` and `claude` job conditions
- Covers comment body, review body, issue body, and issue title triggers

## Test plan
- [ ] Verify workflow triggers on a comment containing `@codex`
- [ ] Verify workflow still triggers on a comment containing `@claude`
- [ ] Verify workflow does not trigger on unrelated comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)