### PR TITLE
Harden trusted Codex config in review workflows

### DIFF
--- a/.devcontainer/configure-codex.sh
+++ b/.devcontainer/configure-codex.sh
@@ -16,16 +16,43 @@ mkdir -p "$HOME/.codex"
 # backends without requiring code changes. These defaults reflect the current
 # shared LiteLLM proxy deployment used in CI.
 CODEX_MODEL_DEFAULT="gpt-5.4"
+CODEX_SUPPORTED_MODELS_DEFAULT="gpt-5.4"
 CODEX_MODEL_PROVIDER_DEFAULT="litellm"
 CODEX_MODEL_PROVIDER_NAME_DEFAULT="LiteLLM"
 CODEX_MODEL_BASE_URL_DEFAULT="https://llm.featherback-mermaid.ts.net/v1"
 CODEX_MODEL_ENV_KEY_DEFAULT="OPENAI_API_KEY"
 
 CODEX_MODEL="${CODEX_MODEL:-$CODEX_MODEL_DEFAULT}"
+CODEX_SUPPORTED_MODELS="${CODEX_SUPPORTED_MODELS:-$CODEX_SUPPORTED_MODELS_DEFAULT}"
 CODEX_MODEL_PROVIDER="${CODEX_MODEL_PROVIDER:-$CODEX_MODEL_PROVIDER_DEFAULT}"
 CODEX_MODEL_PROVIDER_NAME="${CODEX_MODEL_PROVIDER_NAME:-$CODEX_MODEL_PROVIDER_NAME_DEFAULT}"
 CODEX_MODEL_BASE_URL="${CODEX_MODEL_BASE_URL:-$CODEX_MODEL_BASE_URL_DEFAULT}"
 CODEX_MODEL_ENV_KEY="${CODEX_MODEL_ENV_KEY:-$CODEX_MODEL_ENV_KEY_DEFAULT}"
+
+case " $CODEX_SUPPORTED_MODELS " in
+  *" $CODEX_MODEL "*) ;;
+  *)
+    echo "ERROR: Unsupported Codex model \"$CODEX_MODEL\". Allowed models for this environment: $CODEX_SUPPORTED_MODELS" >&2
+    exit 1
+    ;;
+esac
+
+export CODEX_MODEL
+export CODEX_SUPPORTED_MODELS
+export CODEX_MODEL_PROVIDER
+export CODEX_MODEL_PROVIDER_NAME
+export CODEX_MODEL_BASE_URL
+export CODEX_MODEL_ENV_KEY
+
+codex_with_trusted_config() {
+  codex \
+    -c "model=\"$CODEX_MODEL\"" \
+    -c "model_provider=\"$CODEX_MODEL_PROVIDER\"" \
+    -c "model_providers.${CODEX_MODEL_PROVIDER}.name=\"$CODEX_MODEL_PROVIDER_NAME\"" \
+    -c "model_providers.${CODEX_MODEL_PROVIDER}.base_url=\"$CODEX_MODEL_BASE_URL\"" \
+    -c "model_providers.${CODEX_MODEL_PROVIDER}.env_key=\"$CODEX_MODEL_ENV_KEY\"" \
+    "$@"
+}
 
 # Write Codex CLI configuration with the selected provider.
 cat > "$HOME/.codex/config.toml" <<EOF

--- a/.github/actions/reviewer-setup/action.yml
+++ b/.github/actions/reviewer-setup/action.yml
@@ -106,6 +106,16 @@ runs:
       shell: bash
       run: git pull origin ${{ inputs.head_ref }} || true
 
+    - name: Checkout trusted Codex config from main
+      if: steps.verify-tests.outputs.verified == 'true'
+      uses: actions/checkout@v4
+      with:
+        ref: main
+        fetch-depth: 1
+        sparse-checkout: |
+          .devcontainer/configure-codex.sh
+        path: .workflow-trusted
+
     - name: Create directories for devcontainer mounts
       if: steps.verify-tests.outputs.verified == 'true'
       shell: bash

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -55,6 +55,7 @@ concurrency:
 env:
   # Note: must be lowercase for Docker compatibility
   DEVCONTAINER_IMAGE: ghcr.io/nickborgersprobably/hide-my-list-devcontainer
+  TRUSTED_CODEX_CONFIG_PATH: .workflow-trusted/.devcontainer/configure-codex.sh
 
 jobs:
   # Extract PR and Issue context from workflow_run or workflow_dispatch event
@@ -359,6 +360,15 @@ jobs:
       - name: Create directories for devcontainer mounts
         run: mkdir -p ~/.config/gh ~/.claude ~/.codex
 
+      - name: Checkout trusted Codex config from main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 1
+          sparse-checkout: |
+            .devcontainer/configure-codex.sh
+          path: .workflow-trusted
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -464,10 +474,10 @@ jobs:
             PR_BODY=$(echo "$PR_BODY_B64" | base64 -d 2>/dev/null || echo "")
             ISSUE_BODY=$(echo "$ISSUE_BODY_B64" | base64 -d 2>/dev/null || echo "")
 
-            source .devcontainer/configure-codex.sh
+            source "${TRUSTED_CODEX_CONFIG_PATH}"
 
             # Run Codex to fix test failures
-            timeout 30m codex exec \
+            timeout 30m codex_with_trusted_config exec \
               --json \
               --dangerously-bypass-approvals-and-sandbox \
               "You are fixing CI test failures for PR #${PR_NUMBER} in ${REPO}.
@@ -716,9 +726,9 @@ jobs:
               SPEC_CHECK_DIRECTIVE="If a future diff touches spec-critical files, run this checklist and block the PR until contradictions are resolved."
             fi
 
-            source .devcontainer/configure-codex.sh
+            source "${TRUSTED_CODEX_CONFIG_PATH}"
 
-            timeout 30m codex exec \
+            timeout 30m codex_with_trusted_config exec \
               --json \
               --dangerously-bypass-approvals-and-sandbox \
               "You are a DESIGN REVIEW specialist for PR #${PR_NUMBER} in ${REPO}.
@@ -837,9 +847,9 @@ jobs:
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
             HEAD_REF=${{ needs.get-context.outputs.head_ref }}
           runCmd: |
-            source .devcontainer/configure-codex.sh
+            source "${TRUSTED_CODEX_CONFIG_PATH}"
 
-            timeout 30m codex exec \
+            timeout 30m codex_with_trusted_config exec \
               --json \
               --dangerously-bypass-approvals-and-sandbox \
               "You are a SECURITY and INFRASTRUCTURE specialist reviewing PR #${PR_NUMBER}.
@@ -949,9 +959,9 @@ jobs:
             PR_BODY=$(echo "$PR_BODY_B64" | base64 -d 2>/dev/null || echo "")
             ISSUE_BODY=$(echo "$ISSUE_BODY_B64" | base64 -d 2>/dev/null || echo "")
 
-            source .devcontainer/configure-codex.sh
+            source "${TRUSTED_CODEX_CONFIG_PATH}"
 
-            timeout 30m codex exec \
+            timeout 30m codex_with_trusted_config exec \
               --json \
               --dangerously-bypass-approvals-and-sandbox \
               "You are a PSYCHOLOGICAL RESEARCH EVIDENCE reviewer for PR #${PR_NUMBER} in ${REPO}.
@@ -1107,9 +1117,9 @@ jobs:
             HEAD_REF=${{ needs.get-context.outputs.head_ref }}
             REPO=${{ github.repository }}
           runCmd: |
-            source .devcontainer/configure-codex.sh
+            source "${TRUSTED_CODEX_CONFIG_PATH}"
 
-            timeout 30m codex exec \
+            timeout 30m codex_with_trusted_config exec \
               --json \
               --dangerously-bypass-approvals-and-sandbox \
               "You are a DOCUMENTATION CONSISTENCY reviewer for PR #${PR_NUMBER} in ${REPO}.
@@ -1233,9 +1243,9 @@ jobs:
             HEAD_REF=${{ needs.get-context.outputs.head_ref }}
             REPO=${{ github.repository }}
           runCmd: |
-            source .devcontainer/configure-codex.sh
+            source "${TRUSTED_CODEX_CONFIG_PATH}"
 
-            timeout 30m codex exec \
+            timeout 30m codex_with_trusted_config exec \
               --json \
               --dangerously-bypass-approvals-and-sandbox \
               "You are a PROMPT ENGINEERING reviewer for PR #${PR_NUMBER} in ${REPO}.
@@ -1374,9 +1384,9 @@ jobs:
             DOCS_REVIEW_RESULT=${{ needs.docs-review.result }}
             PROMPT_REVIEW_RESULT=${{ needs.prompt-review.result }}
           runCmd: |
-            source .devcontainer/configure-codex.sh
+            source "${TRUSTED_CODEX_CONFIG_PATH}"
 
-            timeout 30m codex exec \
+            timeout 30m codex_with_trusted_config exec \
               --json \
               --dangerously-bypass-approvals-and-sandbox \
               "You are the FINAL DECISION MAKER for PR #${PR_NUMBER}.

--- a/setup/README.md
+++ b/setup/README.md
@@ -64,6 +64,7 @@
 | `OPENAI_API_KEY` | No | For AI-generated reward images |
 | `GITHUB_PAT` | No | GitHub personal access token for higher rate limits |
 | `CODEX_MODEL` | No | Overrides the Codex CLI model (defaults to `gpt-5.4` for the shared LiteLLM proxy) |
+| `CODEX_SUPPORTED_MODELS` | No | Space-separated allowlist for workflow/local Codex model validation (defaults to `gpt-5.4`) |
 
 Advanced overrides for self-hosted LiteLLM setups are also supported:
 
@@ -73,6 +74,8 @@ Advanced overrides for self-hosted LiteLLM setups are also supported:
 - `CODEX_MODEL_ENV_KEY` (defaults to `OPENAI_API_KEY`)
 
 Set these before running the devcontainer bootstrap if your environment differs from the default proxy.
+
+GitHub review workflows always load the trusted Codex bootstrap script from `main` and force those settings onto `codex exec`, so PR branches cannot change the review model or provider mid-run.
 
 ## Cron Jobs
 


### PR DESCRIPTION
Resolves #161

## Summary
- load the Codex bootstrap script for review jobs from `main` instead of the PR checkout
- force trusted Codex model/provider settings onto every review and auto-fix `codex exec` invocation
- add an allowlist preflight for supported Codex models and document the workflow behavior

## Test Plan
- `shellcheck scripts/*.sh`
- `shellcheck .devcontainer/configure-codex.sh`
- `yamllint .github/workflows/*.yml` (currently reports pre-existing repo-wide style violations in untouched workflow files)
- `yamllint -d "{extends: default, rules: {document-start: disable, truthy: disable, line-length: disable}}" .github/workflows/claude-code-review.yml .github/actions/reviewer-setup/action.yml`
- `python3 - <<"PY"
import yaml
for path in [
    ".github/workflows/claude-code-review.yml",
    ".github/actions/reviewer-setup/action.yml",
]:
    with open(path, "r", encoding="utf-8") as f:
        yaml.safe_load(f)
    print(f"parsed: {path}")
PY`
- `git diff --check`

Generated with Codex