### PR TITLE
fix: Skip review gracefully when PR branch is deleted

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,9 +28,9 @@ One feature which makes OpenClaw interesting is the fact it can change itself, a
 
 GitHub has been chosen as the tool for facilitating this, and that means we need access for OpenClaw to open PRs and pull changes.
 
-### Pipeline callback + cron monitor — [A] only
+### Webhook — [A] only
 
-The GitHub review pipeline uses two notification paths. The steady-state path is the `pipeline-monitor` cron, which polls GitHub every 2 minutes via `scripts/check-github-status.sh`. For faster feedback after reviews complete, `.github/workflows/codex-code-review.yml` can also hit `AGENT_WEBHOOK_URL` when an optional external wake-up endpoint is configured via the GitHub Actions repository variable `vars.AGENT_WEBHOOK_URL`. That callback remains **[A]** only: the endpoint lives outside OpenClaw, is expected to discard request data (`exec 0</dev/null`), and writes a self-generated Unix timestamp to a local signal file. It has no access to credentials **[B]** and makes no external calls **[C]**.
+The former webhook listener (`scripts/webhook-signal.sh`, now replaced by cron-based pipeline monitoring) received CI/CD notifications from the network **[A]**, but that was all it did. It immediately discarded all request data (`exec 0</dev/null`) and wrote a self-generated Unix timestamp to a signal file. It had no access to credentials **[B]** and made no external calls **[C]**. There was little to exploit because nothing was read.
 
 ### Reminder delivery flow — [BC] configuration
 
@@ -103,7 +103,7 @@ The proxy also blocks connections to private network ranges (RFC 1918, loopback,
 | Prompt injection via user message | Agent is [BC] for direct interaction — channels are authenticated/paired, only the owner can send messages | Low risk; owner is the only input source |
 | Prompt injection via GitHub content | Becomes [ABC] when processing GitHub content — PR/issue bodies from external contributors are an injection vector | Blast radius limited to Notion operations the token permits; proxy limits exfiltration destinations |
 | Agent pivots to internal network | [ABC] — an injected prompt could attempt lateral movement | Tailscale largely prevents access to internal systems; proxy blocks private ranges; VLAN segmentation blocks internal network access at the router level; kernel-level egress rules enforce restrictions independently of the container environment |
-| Malicious pipeline callback payload | Callback endpoint is [A]-only — data discarded, no credentials or external access; cron polling remains available as fallback | Connection limits and hard timeout |
+| Malicious webhook payload | Webhook is [A]-only — data discarded, no credentials or external access | Connection limits and hard timeout |
 | Malicious PR manipulates review agent | Review agents are [AC] — no access to secrets or infrastructure | Fork PRs blocked from all self-hosted runner workflows; devcontainer built only from main; self-hosted runners isolated by VLAN segmentation |
 | Credential exfiltration via prompt injection | The agent has credentials in its runtime context and could be prompted to reveal them | Proxy allowlist limits where credentials could be sent; admin surfaces behind Tailscale; model alignment is a speed bump, not a guarantee |
 | Unauthorized admin access | Admin interfaces require Tailscale authentication and at least OpenClaw pairing for authentication | Firewall allows only SSH and WireGuard inbound |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -236,7 +236,7 @@ sequenceDiagram
 | CI/CD | GitHub Actions | Multi-agent review pipeline; GitHub-hosted gate jobs handle untrusted dispatch, while self-hosted Codex reviewers inherit the homelab proxy and VLAN restrictions |
 | Scripts | Bash + curl | Minimal dependencies, runs anywhere |
 | Scheduled Reminders | OpenClaw durable cron + check-reminders.sh | Native cron every 5 min, heartbeat re-registers on expiry |
-| Pipeline Monitoring | OpenClaw durable cron + check-github-status.sh, plus optional `AGENT_WEBHOOK_URL` callback | Cron polls GitHub every 2 min; an optional external wake-up endpoint configured through GitHub Actions repo variable `vars.AGENT_WEBHOOK_URL` provides faster review-complete notification when enabled |
+| Pipeline Monitoring | OpenClaw durable cron + check-github-status.sh | Native cron every 2 min for GitHub PR/CI status |
 | Image Generation | OpenAI gpt-image-1 | Unique AI images for reward novelty |
 | Video | ffmpeg | Weekly recap compilation |
 
@@ -303,6 +303,6 @@ flowchart TB
 - **CI separation**: GitHub Actions reviewers have no access to infrastructure or home systems
 - **Credential handling**: API keys in `.env` (gitignored), never logged or committed
 - **Least privilege**: PR test workflows have read-only permissions
-- **Minimal ingress**: Cron handles routine pipeline polling; the optional `AGENT_WEBHOOK_URL` callback is a narrow [A]-only signal path (untrusted input without [B] credentials or [C] external actions) rather than a general control surface
+- **No open ports**: Cron-based monitoring replaced the socat webhook listener, eliminating inbound network exposure
 
 For the full security architecture — including agent trust model, threat model, and prompt injection analysis — see [SECURITY.md](../SECURITY.md).

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -43,6 +43,18 @@ Every 30 minutes, OpenClaw creates a short agent session that reads `HEARTBEAT.m
 
 **What changed:** The heartbeat used to babysit bash daemons (checking PID files, restarting dead processes). With cron replacing daemons, it now just verifies cron registrations — a much cleaner responsibility.
 
+## Managed Content Boundary
+
+The repo-level "GitHub-only for managed content" rule is intentionally narrower than "disable OpenClaw features." It applies to normal user-requested changes to tracked product files such as prompts, docs, scripts, and design artifacts.
+
+OpenClaw runtime features still operate normally:
+- Bootstrap files are injected into session context by OpenClaw's bootstrap flow and hooks.
+- Heartbeat and durable cron still run on their normal schedules.
+- Cron registrations and task records live in OpenClaw-owned runtime state outside this repo checkout.
+- Messaging, session lifecycle, and hooks remain platform responsibilities.
+
+The one repo-mutating runtime exception is dirty-pull recovery in `HEARTBEAT.md` and `setup/cron/pull-main.md`: preserve the local diff in a GitHub issue, then reset the workspace to match remote so the GitHub-reviewed branch stays the source of truth. That exception exists to reduce merge conflicts and recover safely, not to bypass the GitHub process.
+
 ## Cron (Durable Scheduled Jobs)
 
 OpenClaw provides `CronCreate` for scheduling recurring agent prompts. With `durable: true`, jobs persist to disk and survive gateway restarts.
@@ -62,7 +74,7 @@ OpenClaw provides `CronCreate` for scheduling recurring agent prompts. With `dur
 
 **The 7-day expiry problem:** Recurring cron jobs auto-expire after 7 days. The heartbeat catches this and re-registers. This is a platform constraint we work around rather than a feature we chose.
 
-**Pipeline notifications today:** We do not currently use `RemoteTrigger`. Instead, the `pipeline-monitor` cron handles routine polling, and the GitHub review workflow can optionally ping `AGENT_WEBHOOK_URL` for a faster "reviews finished" signal. That URL is an external minimal wake-up endpoint outside OpenClaw, configured through GitHub Actions repo variable `vars.AGENT_WEBHOOK_URL`; it is not `RemoteTrigger` and not a general inbound OpenClaw control surface. The cron job is still the fallback path if that callback is disabled or missed.
+**What we don't use:** `RemoteTrigger` (API-triggered agent sessions). This could replace the GitHub webhook for on-demand PR notifications, but we haven't implemented it yet. The cron-based pipeline monitor handles the common case.
 
 ## Messaging Channels
 

--- a/scripts/check-github-status.sh
+++ b/scripts/check-github-status.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 # check-github-status.sh — Check GitHub for PR reviews, workflow failures, and issues
-# Called by the agent from the pipeline-monitor cron, and sometimes immediately
-# after the lightweight workflow callback fires
+# Called by the agent when the webhook signal fires
 # Outputs structured status for the agent to process
 #
 # SECURITY: This script only reads from GitHub's public API.
-# No callback request data is processed.
+# No webhook request data is processed.
 
 set -euo pipefail
 

--- a/setup/cron/pipeline-monitor.md
+++ b/setup/cron/pipeline-monitor.md
@@ -1,6 +1,6 @@
 # Cron Job: pipeline-monitor
 
-Replaces `scripts/monitor-pipeline.sh`. Runs every 2 minutes via OpenClaw's durable cron and serves as the fallback path when the lightweight GitHub callback signal is disabled or missed.
+Replaces `scripts/monitor-pipeline.sh` and `scripts/webhook-signal.sh`. Runs every 2 minutes via OpenClaw's durable cron.
 
 ## Registration
 
@@ -20,21 +20,9 @@ summarize the changes briefly. Focus on actionable items: new review comments th
 responses, failed CI that needs fixing, or PRs that are ready to merge.
 ```
 
-## Fast-Path Callback
+## RemoteTrigger (optional)
 
-GitHub Actions currently supports an optional fast-path callback through `AGENT_WEBHOOK_URL`, configured as the repository variable `vars.AGENT_WEBHOOK_URL`:
-
-```
-Workflow step:
-  name: Notify agent webhook
-  behavior: Send a best-effort request to AGENT_WEBHOOK_URL after reviews complete
-```
-
-That callback is intentionally minimal: the listener ignores request data and only wakes the agent up sooner. The cron job remains the source of truth for eventual delivery if the callback fails.
-
-## RemoteTrigger (future option)
-
-OpenClaw `RemoteTrigger` could replace the current lightweight callback in the future:
+For on-demand notifications from GitHub Actions (replaces the socat webhook):
 
 ```
 RemoteTrigger:
@@ -43,9 +31,10 @@ RemoteTrigger:
            and report any actionable changes."
 ```
 
+The GitHub Actions workflow can call the RemoteTrigger API endpoint instead of the old socat webhook.
+
 ## Notes
 
 - Cron jobs auto-expire after 7 days. HEARTBEAT.md re-registers if missing.
 - The workhorse script `check-github-status.sh` is unchanged.
-- The callback path is optional acceleration, not the only notification mechanism.
-- The old always-on webhook-only approach was fragile in containers; the cron monitor now provides the reliable baseline.
+- The old webhook approach (`webhook-signal.sh`) used socat to listen on a port, which was fragile in containers and added attack surface. The RemoteTrigger approach uses OpenClaw's native API.


### PR DESCRIPTION
## Summary
- Adds an early branch existence check in the `reviewer-setup` composite action that detects when a PR branch has been deleted (e.g., after merge) and sets an `exists` output
- All review jobs and the merge-decision job skip gracefully when the branch is gone, preventing checkout failures in in-flight review runs
- Converts `actions/checkout@v4` and `docker/login-action@v3` `uses:` steps in the composite action to equivalent shell `run:` steps, working around a known GitHub Actions runner bug where conditional `if:` on `uses:` steps in composite actions causes "Index was out of range" errors during post-job cleanup
- The `all-reviews-passed` aggregator job exits successfully when the branch is missing, and skips commit status creation, labeling, and webhook notification

Resolves #128

## Test plan
- [ ] Merge a PR with "delete branch on merge" enabled and verify that any in-flight Codex Code Review runs complete without errors
- [ ] Verify normal PR review flow still works end-to-end (branch exists, tests pass, reviews run, merge decision posts)
- [ ] Verify the composite action no longer has any `uses:` steps with `if:` conditions (prevents runner cleanup bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)