### PR TITLE
Handle stale PR refs in Codex workflow

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -82,78 +82,18 @@ jobs:
               ;;
           esac
 
-  # Build and cache devcontainer image first
-  # Only build when a downstream job (codex or resolve-issue) will actually run.
-  # Without this gate, every PR review comment triggers a wasted devcontainer build.
-  build-devcontainer:
+  preflight:
     needs: authorize
-    if: |
-      needs.authorize.outputs.authorized == 'true' &&
-      (
-        (github.event_name == 'issues') ||
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@codex')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@codex')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@codex'))
-      )
-    runs-on: [self-hosted, homelab]
-    permissions:
-      contents: read
-      packages: write
-
+    if: needs.authorize.outputs.authorized == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      is_pr: ${{ steps.pr-context.outputs.is_pr }}
+      pr_number: ${{ steps.pr-context.outputs.pr_number }}
+      pr_head_ref: ${{ steps.pr-context.outputs.pr_head_ref }}
+      should_run: ${{ steps.pr-context.outputs.should_run }}
+      skip_reason: ${{ steps.pr-context.outputs.skip_reason }}
+      checkout_ref: ${{ steps.pr-context.outputs.checkout_ref }}
     steps:
-      # SECURITY: Checkout main branch, NOT the PR branch
-      - name: Checkout main branch (security measure)
-        uses: actions/checkout@v4
-        with:
-          ref: main
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push devcontainer
-        uses: devcontainers/ci@v0.3
-        with:
-          imageName: ${{ env.DEVCONTAINER_IMAGE }}
-          cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
-          platform: linux/amd64
-          push: always
-
-  codex:
-    needs: [authorize, build-devcontainer]
-    if: |
-      needs.authorize.outputs.authorized == 'true' &&
-      ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@codex')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@codex')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@codex')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@codex') || contains(github.event.issue.title, '@codex'))))
-    runs-on: [self-hosted, homelab]
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      id-token: write
-      actions: read
-      packages: read
-
-    steps:
-      - name: Add eyes reaction to acknowledge comment
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if [ "${{ github.event_name }}" = "issue_comment" ]; then
-            gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
-              -f content='eyes' || echo "Warning: reaction failed"
-          elif [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
-            gh api repos/${{ github.repository }}/pulls/comments/${{ github.event.comment.id }}/reactions \
-              -f content='eyes' || echo "Warning: reaction failed"
-          elif [ "${{ github.event_name }}" = "pull_request_review" ]; then
-            echo "Note: GitHub API does not support reactions on PR reviews"
-          fi
-
       - name: Get PR context
         id: pr-context
         env:
@@ -212,22 +152,89 @@ jobs:
           echo "checkout_ref=$CHECKOUT_REF" >> $GITHUB_OUTPUT
           echo "Detected: IS_PR=$IS_PR, PR_NUMBER=$PR_NUMBER, PR_HEAD_REF=$PR_HEAD_REF, SHOULD_RUN=$SHOULD_RUN, CHECKOUT_REF=$CHECKOUT_REF"
 
-      - name: Skip inactive PR invocation
-        if: steps.pr-context.outputs.should_run != 'true'
+  # Build and cache devcontainer image first
+  # Only build when a downstream job (codex or resolve-issue) will actually run.
+  # Without this gate, every PR review comment triggers a wasted devcontainer build.
+  build-devcontainer:
+    needs: [authorize, preflight]
+    if: |
+      needs.authorize.outputs.authorized == 'true' &&
+      needs.preflight.outputs.should_run == 'true' &&
+      (
+        (github.event_name == 'issues') ||
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@codex')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@codex')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@codex'))
+      )
+    runs-on: [self-hosted, homelab]
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      # SECURITY: Checkout main branch, NOT the PR branch
+      - name: Checkout main branch (security measure)
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push devcontainer
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: ${{ env.DEVCONTAINER_IMAGE }}
+          cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
+          platform: linux/amd64
+          push: always
+
+  codex:
+    needs: [authorize, preflight, build-devcontainer]
+    if: |
+      needs.authorize.outputs.authorized == 'true' &&
+      needs.preflight.outputs.should_run == 'true' &&
+      ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@codex')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@codex')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@codex')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@codex') || contains(github.event.issue.title, '@codex'))))
+    runs-on: [self-hosted, homelab]
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+      packages: read
+
+    steps:
+      - name: Add eyes reaction to acknowledge comment
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          echo "Skipping Codex run: ${{ steps.pr-context.outputs.skip_reason }}"
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+              -f content='eyes' || echo "Warning: reaction failed"
+          elif [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
+            gh api repos/${{ github.repository }}/pulls/comments/${{ github.event.comment.id }}/reactions \
+              -f content='eyes' || echo "Warning: reaction failed"
+          elif [ "${{ github.event_name }}" = "pull_request_review" ]; then
+            echo "Note: GitHub API does not support reactions on PR reviews"
+          fi
 
       - name: Checkout repository
-        if: steps.pr-context.outputs.should_run == 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.WORKFLOW_PAT }}  # PAT required to push workflow file changes
-          ref: ${{ steps.pr-context.outputs.checkout_ref }}
+          ref: ${{ needs.preflight.outputs.checkout_ref }}
 
       - name: Extract comment body
         id: comment
-        if: steps.pr-context.outputs.should_run == 'true'
         env:
           EVENT_NAME: ${{ github.event_name }}
           COMMENT_BODY: ${{ github.event.comment.body }}
@@ -248,7 +255,6 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Log in to GHCR
-        if: steps.pr-context.outputs.should_run == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -257,7 +263,6 @@ jobs:
 
       # Note: GH_TOKEN uses WORKFLOW_PAT because PRs created with GITHUB_TOKEN don't trigger workflows
       - name: Run Codex in devcontainer
-        if: steps.pr-context.outputs.should_run == 'true'
         uses: devcontainers/ci@v0.3
         with:
           imageName: ${{ env.DEVCONTAINER_IMAGE }}
@@ -270,8 +275,8 @@ jobs:
             COMMENT_BODY=${{ steps.comment.outputs.body }}
             ISSUE_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
             REPO=${{ github.repository }}
-            IS_PR=${{ steps.pr-context.outputs.is_pr }}
-            PR_HEAD_REF=${{ steps.pr-context.outputs.pr_head_ref }}
+            IS_PR=${{ needs.preflight.outputs.is_pr }}
+            PR_HEAD_REF=${{ needs.preflight.outputs.pr_head_ref }}
           runCmd: |
             source .devcontainer/configure-codex.sh
 
@@ -339,7 +344,7 @@ jobs:
 
       - name: Upload Codex conversation log
         uses: actions/upload-artifact@v4
-        if: always() && steps.pr-context.outputs.should_run == 'true'
+        if: always() && needs.preflight.outputs.should_run == 'true'
         continue-on-error: true
         with:
           name: codex-conversation-log


### PR DESCRIPTION
Resolves #169

## Summary
- fetch current PR state before checkout for PR-backed Codex invocations
- skip Codex execution when the referenced PR is closed, merged, or missing its head branch
- use a resolved checkout ref output instead of blindly checking out the PR head ref

## Test Plan
- `shellcheck scripts/*.sh`
- `yamllint .github/workflows/*.yml` (currently reports many pre-existing repo-wide style violations unrelated to this change)
- `yamllint -d {extends: default, rules: {line-length: disable, truthy: disable, document-start: disable}} .github/workflows/codex.yml`
- verified `gh api repos/NickBorgersProbably/hide-my-list/git/matching-refs/heads/<branch>` returns `true` for an existing slash-delimited branch and `false` for a missing branch
- checked internal docs links under `docs/` and `design/`

Generated with Codex