### PR TITLE
Fetch Codex comment bodies via GitHub API

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -194,27 +194,6 @@ jobs:
           token: ${{ secrets.WORKFLOW_PAT }}  # PAT required to push workflow file changes
           ref: ${{ steps.pr-context.outputs.is_pr == 'true' && steps.pr-context.outputs.pr_head_ref || github.ref }}
 
-      - name: Extract comment body
-        id: comment
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          COMMENT_BODY: ${{ github.event.comment.body }}
-          REVIEW_BODY: ${{ github.event.review.body }}
-          ISSUE_BODY: ${{ github.event.issue.body }}
-        run: |
-          # Use environment variables to avoid shell escaping issues with special characters
-          echo "body<<EOF" >> $GITHUB_OUTPUT
-          if [ "$EVENT_NAME" = "issue_comment" ]; then
-            echo "$COMMENT_BODY" >> $GITHUB_OUTPUT
-          elif [ "$EVENT_NAME" = "pull_request_review_comment" ]; then
-            echo "$COMMENT_BODY" >> $GITHUB_OUTPUT
-          elif [ "$EVENT_NAME" = "pull_request_review" ]; then
-            echo "$REVIEW_BODY" >> $GITHUB_OUTPUT
-          else
-            echo "$ISSUE_BODY" >> $GITHUB_OUTPUT
-          fi
-          echo "EOF" >> $GITHUB_OUTPUT
-
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -233,13 +212,38 @@ jobs:
           env: |
             OPENAI_API_KEY=fake-key
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
-            COMMENT_BODY=${{ steps.comment.outputs.body }}
+            EVENT_NAME=${{ github.event_name }}
+            COMMENT_ID=${{ github.event.comment.id }}
+            REVIEW_ID=${{ github.event.review.id }}
             ISSUE_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
             REPO=${{ github.repository }}
             IS_PR=${{ steps.pr-context.outputs.is_pr }}
             PR_HEAD_REF=${{ steps.pr-context.outputs.pr_head_ref }}
           runCmd: |
             source .devcontainer/configure-codex.sh
+
+            fetch_event_body() {
+              case "$EVENT_NAME" in
+                issue_comment)
+                  gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" --jq '.body // ""'
+                  ;;
+                pull_request_review_comment)
+                  gh api "repos/${REPO}/pulls/comments/${COMMENT_ID}" --jq '.body // ""'
+                  ;;
+                pull_request_review)
+                  gh api "repos/${REPO}/pulls/${ISSUE_NUMBER}/reviews/${REVIEW_ID}" --jq '.body // ""'
+                  ;;
+                issues)
+                  gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" --jq '.body // ""'
+                  ;;
+                *)
+                  echo "Unsupported event type: ${EVENT_NAME}" >&2
+                  return 1
+                  ;;
+              esac
+            }
+
+            COMMENT_BODY="$(fetch_event_body)"
 
             # Build the prompt based on whether this is a PR or issue comment
             # Instead of fetching all context inline, instruct Codex to read it via gh CLI.


### PR DESCRIPTION
Resolves #173

## Summary
- remove the workflow step that exported raw multi-line comment/review/issue bodies through GitHub outputs
- pass only safe event identifiers (`EVENT_NAME`, `COMMENT_ID`, `REVIEW_ID`, `ISSUE_NUMBER`) into the devcontainer job
- fetch the triggering body inside the container with `gh api` before building the Codex prompt

## Test Plan
- run `shellcheck scripts/*.sh`
- run `yamllint .github/workflows/*.yml` (currently reports existing repo-wide line-length/document-start/truthy violations outside this change)
- run `yamllint -d {extends: default, rules: {document-start: disable, truthy: disable, line-length: disable}} .github/workflows/codex.yml`
- run `git diff --check`

Generated with Codex