### PR TITLE
Fix Codex workflow multiline body handling

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -194,27 +194,6 @@ jobs:
           token: ${{ secrets.WORKFLOW_PAT }}  # PAT required to push workflow file changes
           ref: ${{ steps.pr-context.outputs.is_pr == 'true' && steps.pr-context.outputs.pr_head_ref || github.ref }}
 
-      - name: Extract comment body
-        id: comment
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          COMMENT_BODY: ${{ github.event.comment.body }}
-          REVIEW_BODY: ${{ github.event.review.body }}
-          ISSUE_BODY: ${{ github.event.issue.body }}
-        run: |
-          # Use environment variables to avoid shell escaping issues with special characters
-          echo "body<<EOF" >> $GITHUB_OUTPUT
-          if [ "$EVENT_NAME" = "issue_comment" ]; then
-            echo "$COMMENT_BODY" >> $GITHUB_OUTPUT
-          elif [ "$EVENT_NAME" = "pull_request_review_comment" ]; then
-            echo "$COMMENT_BODY" >> $GITHUB_OUTPUT
-          elif [ "$EVENT_NAME" = "pull_request_review" ]; then
-            echo "$REVIEW_BODY" >> $GITHUB_OUTPUT
-          else
-            echo "$ISSUE_BODY" >> $GITHUB_OUTPUT
-          fi
-          echo "EOF" >> $GITHUB_OUTPUT
-
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -233,13 +212,37 @@ jobs:
           env: |
             OPENAI_API_KEY=fake-key
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
-            COMMENT_BODY=${{ steps.comment.outputs.body }}
+            EVENT_NAME=${{ github.event_name }}
+            COMMENT_ID=${{ github.event.comment.id || '' }}
             ISSUE_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
             REPO=${{ github.repository }}
+            REVIEW_ID=${{ github.event.review.id || '' }}
             IS_PR=${{ steps.pr-context.outputs.is_pr }}
             PR_HEAD_REF=${{ steps.pr-context.outputs.pr_head_ref }}
           runCmd: |
             source .devcontainer/configure-codex.sh
+
+            # Fetch the request body inside the container so arbitrary multiline user
+            # content never gets injected into devcontainers/ci's env input format.
+            REQUEST_BODY=""
+            case "$EVENT_NAME" in
+              issue_comment)
+                REQUEST_BODY=$(gh api repos/${REPO}/issues/comments/${COMMENT_ID} --jq '.body // ""')
+                ;;
+              pull_request_review_comment)
+                REQUEST_BODY=$(gh api repos/${REPO}/pulls/comments/${COMMENT_ID} --jq '.body // ""')
+                ;;
+              pull_request_review)
+                REQUEST_BODY=$(gh api repos/${REPO}/pulls/${ISSUE_NUMBER}/reviews/${REVIEW_ID} --jq '.body // ""')
+                ;;
+              issues)
+                REQUEST_BODY=$(gh api repos/${REPO}/issues/${ISSUE_NUMBER} --jq '.body // ""')
+                ;;
+              *)
+                echo "Unsupported event type: $EVENT_NAME" >&2
+                exit 1
+                ;;
+            esac
 
             # Build the prompt based on whether this is a PR or issue comment
             # Instead of fetching all context inline, instruct Codex to read it via gh CLI.
@@ -247,7 +250,7 @@ jobs:
             if [ "$IS_PR" = "true" ]; then
               PROMPT="You are an autonomous agent responding to a request on PR #${ISSUE_NUMBER} in ${REPO}.
 
-            The user said: ${COMMENT_BODY}
+            The user said: ${REQUEST_BODY}
 
             YOUR TASK: IMPLEMENT the requested changes. Do NOT just provide review comments or suggestions.
 
@@ -273,7 +276,7 @@ jobs:
             else
               PROMPT="You are responding to a request in ${REPO} issue #${ISSUE_NUMBER}.
 
-            The user said: ${COMMENT_BODY}
+            The user said: ${REQUEST_BODY}
 
             WORKFLOW:
             1. Read the user's request carefully


### PR DESCRIPTION
Resolves #172

## Summary
- stop passing raw issue/comment bodies through `devcontainers/ci` `with.env`
- pass only event metadata into the container and fetch the body with `gh api` inside `runCmd`
- preserve the existing prompt-building flow for issue comments, PR review comments, PR reviews, and issues while avoiding multiline env parsing failures

## Test Plan
- run `shellcheck scripts/*.sh`
- run `yamllint .github/workflows/*.yml` and confirm the repo-wide pre-existing workflow lint backlog is unchanged aside from the touched file still parsing
- run `python3 - <<'PY'
import yaml
with open('.github/workflows/codex.yml', 'r', encoding='utf-8') as f:
    yaml.safe_load(f)
print('codex.yml parses')
PY`
- verify local markdown `.md` links resolve from `README.md` and `docs/*.md`

Generated with Codex