### PR TITLE
Use verified PR SHA for reviewer checkouts

### DIFF
--- a/.github/actions/reviewer-setup/action.yml
+++ b/.github/actions/reviewer-setup/action.yml
@@ -8,6 +8,10 @@ inputs:
   head_ref:
     description: 'PR branch name'
     required: true
+  head_sha:
+    description: 'Immutable PR head commit SHA'
+    required: false
+    default: ''
   head_repo:
     description: 'PR repository (owner/repo)'
     required: true
@@ -39,9 +43,10 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github_token }}
+        INPUT_HEAD_SHA: ${{ inputs.head_sha }}
       run: |
         # Compare PR Tests against the current PR head so reviewers never run on stale code.
-        export HEAD_SHA=$(gh api repos/${{ inputs.repository }}/pulls/${{ inputs.pr_number }} --jq '.head.sha')
+        export HEAD_SHA="${INPUT_HEAD_SHA:-$(gh api repos/${{ inputs.repository }}/pulls/${{ inputs.pr_number }} --jq '.head.sha')}"
         echo "Checking PR Tests status for commit $HEAD_SHA"
 
         get_run_json() {
@@ -96,15 +101,20 @@ runs:
       if: steps.verify-tests.outputs.verified == 'true'
       uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.head_ref }}
+        ref: ${{ inputs.head_sha != '' && inputs.head_sha || inputs.head_ref }}
         repository: ${{ inputs.head_repo }}
         fetch-depth: 0
         token: ${{ inputs.checkout_token != '' && inputs.checkout_token || inputs.github_token }}
 
-    - name: Pull latest changes
+    - name: Confirm checked out commit
       if: steps.verify-tests.outputs.verified == 'true'
       shell: bash
-      run: git pull origin ${{ inputs.head_ref }} || true
+      run: |
+        echo "Checked out commit: $(git rev-parse HEAD)"
+        if [ -n "${{ inputs.head_sha }}" ] && [ "$(git rev-parse HEAD)" != "${{ inputs.head_sha }}" ]; then
+          echo "Expected checkout to match verified PR head SHA"
+          exit 1
+        fi
 
     - name: Create directories for devcontainer mounts
       if: steps.verify-tests.outputs.verified == 'true'

--- a/.github/workflows/codex-code-review.yml
+++ b/.github/workflows/codex-code-review.yml
@@ -68,6 +68,7 @@ jobs:
       pr_title: ${{ steps.get-pr.outputs.pr_title }}
       pr_body_b64: ${{ steps.get-pr.outputs.pr_body_b64 }}
       head_ref: ${{ steps.get-pr.outputs.head_ref }}
+      head_sha: ${{ steps.get-pr.outputs.head_sha }}
       head_repo: ${{ steps.get-pr.outputs.head_repo }}
       # Draft PR status - used to skip auto-fix pipeline for TDD workflows
       is_draft: ${{ steps.get-pr.outputs.is_draft }}
@@ -153,11 +154,13 @@ jobs:
               const prBodyB64 = Buffer.from(pr.body || '').toString('base64');
               core.setOutput('pr_body_b64', prBodyB64);
               core.setOutput('head_ref', pr.head.ref);
+              core.setOutput('head_sha', pr.head.sha);
               core.setOutput('head_repo', pr.head.repo.full_name);
               core.setOutput('is_draft', pr.draft ? 'true' : 'false');
             } else {
               console.log('No open PR found for this workflow run');
               core.setOutput('pr_number', '');
+              core.setOutput('head_sha', '');
               core.setOutput('is_draft', 'false');
             }
 
@@ -668,6 +671,7 @@ jobs:
         with:
           pr_number: ${{ needs.get-context.outputs.pr_number }}
           head_ref: ${{ needs.get-context.outputs.head_ref }}
+          head_sha: ${{ needs.get-context.outputs.head_sha }}
           head_repo: ${{ needs.get-context.outputs.head_repo }}
           github_token: ${{ github.token }}
           repository: ${{ github.repository }}
@@ -819,6 +823,7 @@ jobs:
         with:
           pr_number: ${{ needs.get-context.outputs.pr_number }}
           head_ref: ${{ needs.get-context.outputs.head_ref }}
+          head_sha: ${{ needs.get-context.outputs.head_sha }}
           head_repo: ${{ needs.get-context.outputs.head_repo }}
           github_token: ${{ github.token }}
           repository: ${{ github.repository }}
@@ -921,6 +926,7 @@ jobs:
         with:
           pr_number: ${{ needs.get-context.outputs.pr_number }}
           head_ref: ${{ needs.get-context.outputs.head_ref }}
+          head_sha: ${{ needs.get-context.outputs.head_sha }}
           head_repo: ${{ needs.get-context.outputs.head_repo }}
           github_token: ${{ github.token }}
           repository: ${{ github.repository }}
@@ -1087,6 +1093,7 @@ jobs:
         with:
           pr_number: ${{ needs.get-context.outputs.pr_number }}
           head_ref: ${{ needs.get-context.outputs.head_ref }}
+          head_sha: ${{ needs.get-context.outputs.head_sha }}
           head_repo: ${{ needs.get-context.outputs.head_repo }}
           github_token: ${{ github.token }}
           repository: ${{ github.repository }}
@@ -1213,6 +1220,7 @@ jobs:
         with:
           pr_number: ${{ needs.get-context.outputs.pr_number }}
           head_ref: ${{ needs.get-context.outputs.head_ref }}
+          head_sha: ${{ needs.get-context.outputs.head_sha }}
           head_repo: ${{ needs.get-context.outputs.head_repo }}
           github_token: ${{ github.token }}
           repository: ${{ github.repository }}
@@ -1350,6 +1358,7 @@ jobs:
         with:
           pr_number: ${{ needs.get-context.outputs.pr_number }}
           head_ref: ${{ needs.get-context.outputs.head_ref }}
+          head_sha: ${{ needs.get-context.outputs.head_sha }}
           head_repo: ${{ needs.get-context.outputs.head_repo }}
           github_token: ${{ github.token }}
           repository: ${{ github.repository }}


### PR DESCRIPTION
Resolves #185

## Summary
- thread the PR head SHA out of `get-context` and into every `reviewer-setup` call
- make `reviewer-setup` verify and check out the immutable PR head SHA instead of the mutable branch name
- replace the post-checkout branch pull with a commit verification step so merged or deleted branches do not break reviewer jobs after PR Tests already passed

## Test Plan
- `shellcheck scripts/*.sh`
- `yamllint .github/workflows/*.yml` (shows pre-existing repo-wide style violations; no new syntax issue from this fix)
- `python3 - <<'PY'`
  `import yaml`
  `yaml.safe_load(open(".github/workflows/codex-code-review.yml"))`
  `yaml.safe_load(open(".github/actions/reviewer-setup/action.yml"))`
  `PY`
- `git diff --check`

Generated with Codex