### PR TITLE
Fix reviewer setup post-step failure in code review workflow

### DIFF
--- a/.github/actions/reviewer-setup/action.yml
+++ b/.github/actions/reviewer-setup/action.yml
@@ -137,10 +137,3 @@ runs:
         printf '%s' "$GHCR_PASSWORD" | docker login ghcr.io \
           --username "$GHCR_USERNAME" \
           --password-stdin
-
-    - name: Log out of GHCR
-      if: steps.verify-tests.outputs.verified == 'true'
-      shell: bash
-      run: |
-        # Ensure cached GHCR credentials are cleared on persistent runners.
-        docker logout ghcr.io >/dev/null 2>&1 || echo "GHCR logout skipped: no active session"

--- a/.github/workflows/codex-code-review.yml
+++ b/.github/workflows/codex-code-review.yml
@@ -791,6 +791,12 @@ jobs:
           path: /tmp/design-review-output.jsonl
           retention-days: 7
 
+      - name: Log out of GHCR
+        if: always() && steps.setup.outputs.verified == 'true'
+        run: |
+          # Clear cached GHCR credentials only after all image pulls in the job are finished.
+          docker logout ghcr.io >/dev/null 2>&1 || echo "GHCR logout skipped: no active session"
+
   # Security and infrastructure specialist - runs in parallel with design and psych
   security-review:
     needs: [get-context, build-devcontainer]
@@ -892,6 +898,12 @@ jobs:
           name: security-review-output
           path: /tmp/security-review-output.jsonl
           retention-days: 7
+
+      - name: Log out of GHCR
+        if: always() && steps.setup.outputs.verified == 'true'
+        run: |
+          # Clear cached GHCR credentials only after all image pulls in the job are finished.
+          docker logout ghcr.io >/dev/null 2>&1 || echo "GHCR logout skipped: no active session"
 
   # Psychological research evidence reviewer - validates features against ADHD research literature
   psych-review:
@@ -1060,6 +1072,12 @@ jobs:
           path: /tmp/psych-review-output.jsonl
           retention-days: 7
 
+      - name: Log out of GHCR
+        if: always() && steps.setup.outputs.verified == 'true'
+        run: |
+          # Clear cached GHCR credentials only after all image pulls in the job are finished.
+          docker logout ghcr.io >/dev/null 2>&1 || echo "GHCR logout skipped: no active session"
+
   # Documentation consistency reviewer - ensures docs remain coherent and non-contradictory
   docs-review:
     needs: [get-context, build-devcontainer]
@@ -1184,6 +1202,12 @@ jobs:
           name: docs-review-output
           path: /tmp/docs-review-output.jsonl
           retention-days: 7
+
+      - name: Log out of GHCR
+        if: always() && steps.setup.outputs.verified == 'true'
+        run: |
+          # Clear cached GHCR credentials only after all image pulls in the job are finished.
+          docker logout ghcr.io >/dev/null 2>&1 || echo "GHCR logout skipped: no active session"
 
   # Prompt engineering reviewer - validates prompt clarity, constraints, and cross-prompt consistency
   prompt-review:
@@ -1320,6 +1344,12 @@ jobs:
           path: /tmp/prompt-review-output.jsonl
           retention-days: 7
 
+      - name: Log out of GHCR
+        if: always() && steps.setup.outputs.verified == 'true'
+        run: |
+          # Clear cached GHCR credentials only after all image pulls in the job are finished.
+          docker logout ghcr.io >/dev/null 2>&1 || echo "GHCR logout skipped: no active session"
+
   # Final decision maker - synthesizes all reviews and makes go/no-go call
   merge-decision:
     needs: [get-context, build-devcontainer, design-review, security-review, psych-review, docs-review, prompt-review]
@@ -1432,6 +1462,12 @@ jobs:
           name: merge-decision-output
           path: /tmp/merge-decision-output.jsonl
           retention-days: 7
+
+      - name: Log out of GHCR
+        if: always() && steps.setup.outputs.verified == 'true'
+        run: |
+          # Clear cached GHCR credentials only after all image pulls in the job are finished.
+          docker logout ghcr.io >/dev/null 2>&1 || echo "GHCR logout skipped: no active session"
 
       - name: Parse merge decision from PR comments
         id: parse-decision


### PR DESCRIPTION
Resolves #192

## Summary
Refactored `.github/actions/reviewer-setup/action.yml` to avoid nested `uses:` steps that register post-job cleanup inside the composite action.

Replaced the in-action `actions/checkout@v4` step with a shell-based `git fetch` + `git checkout` flow using a temporary `GIT_ASKPASS` helper so checkout credentials are not persisted in `.git/config` on the self-hosted runner.

Replaced the in-action `docker/login-action@v3` step with a shell-based `docker login` so the composite action no longer registers the failing post-login cleanup hook.

## Test Plan
- `shellcheck scripts/*.sh`
- `yamllint .github/workflows/*.yml`  
  Note: this currently reports many pre-existing line-length and document-start violations in tracked workflow files unrelated to this fix.
- `yamllint .github/actions/reviewer-setup/action.yml`  
  Note: this file also has pre-existing line-length/document-start style violations; no new YAML parse issues were introduced.
- Temporary clone sanity check for the replacement checkout flow using `git fetch` + `git checkout`
- Basic local markdown link check across `README.md`, `docs/`, `design/`, and top-level agent docs

Generated with Codex