### PR TITLE
Fix run-devcontainer script path inside container

### DIFF
--- a/.github/actions/run-devcontainer/action.yml
+++ b/.github/actions/run-devcontainer/action.yml
@@ -101,4 +101,4 @@ runs:
           --workspace-folder "$WORKSPACE" \
           --override-config "$OVERRIDE_CONFIG" \
           "${REMOTE_ENV_ARGS[@]}" \
-          bash -lc "bash './$SCRIPT_NAME'"
+          bash -lc "bash '.git/$SCRIPT_NAME'"


### PR DESCRIPTION
## Summary
- The `run-devcontainer` composite action creates temp scripts in `.git/` but executes them as `./$SCRIPT_NAME`, missing the `.git/` prefix
- Inside the devcontainer the working directory is the workspace root, so the script at `.git/devcontainer-run-XXXXXX.sh` was not found at `./devcontainer-run-XXXXXX.sh`
- This caused exit code 127 on every workflow using the action (e.g. [run #24006088945](https://github.com/NickBorgersProbably/hide-my-list/actions/runs/24006088945/job/70009947314))

## Test plan
- [ ] Verify the diagnose-workflow-failure pipeline passes on the next trigger
- [ ] Verify other workflows using `run-devcontainer` (codex, codex-code-review, review-coverage-evaluator) also pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)