### PR TITLE
Fix Codex workflow local action resolution on PR refs

### DIFF
--- a/.github/actions/run-devcontainer/action.yml
+++ b/.github/actions/run-devcontainer/action.yml
@@ -9,6 +9,10 @@ inputs:
   image:
     description: Devcontainer image to run (e.g. ghcr.io/org/repo-devcontainer)
     required: true
+  workspace_folder:
+    description: Repo-relative path to the workspace to open in the devcontainer
+    required: false
+    default: '.'
   run_cmd:
     description: Shell commands to execute inside the container
     required: true
@@ -35,7 +39,9 @@ runs:
       id: prepare-script
       shell: bash
       run: |
-        SCRIPT=$(mktemp "${{ github.workspace }}/.git/devcontainer-run-XXXXXX.sh")
+        set -euo pipefail
+        WORKSPACE="${{ github.workspace }}/${{ inputs.workspace_folder }}"
+        SCRIPT=$(mktemp "$WORKSPACE/.git/devcontainer-run-XXXXXX.sh")
         cat > "$SCRIPT" <<'RUNCMD'
         set -euo pipefail
         cd '${{ inputs.workdir }}'
@@ -49,7 +55,7 @@ runs:
       run: |
         set -euo pipefail
 
-        WORKSPACE="${{ github.workspace }}"
+        WORKSPACE="${{ github.workspace }}/${{ inputs.workspace_folder }}"
         SCRIPT_PATH="${{ steps.prepare-script.outputs.script }}"
         OVERRIDE_CONFIG=$(mktemp /tmp/devcontainer-override-XXXXXX.json)
         cleanup() {

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -281,7 +281,15 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.WORKFLOW_PAT }}  # PAT required to push workflow file changes
+          ref: main
+
+      - name: Checkout target workspace
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.WORKFLOW_PAT }}
           ref: ${{ needs.preflight.outputs.checkout_ref }}
+          path: workspace
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -295,6 +303,7 @@ jobs:
         uses: ./.github/actions/run-devcontainer
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
+          workspace_folder: workspace
           pull: 'true'
           env: |
             OPENAI_API_KEY=fake-key
@@ -425,6 +434,15 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.WORKFLOW_PAT }}  # PAT required to push workflow file changes
+          ref: main
+
+      - name: Checkout working workspace
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.WORKFLOW_PAT }}
+          ref: main
+          path: workspace
 
       - name: Check for existing PR
         id: check-existing
@@ -466,6 +484,7 @@ jobs:
         uses: ./.github/actions/run-devcontainer
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
+          workspace_folder: workspace
           pull: 'true'
           env: |
             OPENAI_API_KEY=fake-key


### PR DESCRIPTION
Resolves #211

## Summary
- keep the trusted `main` checkout at the job workspace root so local actions remain available
- check out the mutable target ref into `workspace/` and run Codex against that separate checkout
- extend `.github/actions/run-devcontainer` with a `workspace_folder` input so the action can target the secondary checkout

## Test Plan
- `shellcheck scripts/*.sh`
- `yamllint .github/workflows/*.yml` (shows existing repository-wide line-length/document-start findings; no new syntax errors from this change)
- parse changed YAML files with `python3` + `yaml.safe_load`
- `git diff --check`

Generated with Codex