### PR TITLE
Re-trigger Codex on codex-started label removal

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -6,7 +6,7 @@ on:
   pull_request_review_comment:
     types: [created]
   issues:
-    types: [opened, reopened]
+    types: [opened, reopened, unlabeled]
   pull_request_review:
     types: [submitted]
 
@@ -410,7 +410,11 @@ jobs:
     needs: [authorize, detect_codex_invocation, build-devcontainer]
     if: |
       needs.authorize.outputs.authorized == 'true' &&
-      github.event_name == 'issues' && (github.event.action == 'opened' || github.event.action == 'reopened')
+      github.event_name == 'issues' && (
+        github.event.action == 'opened' ||
+        github.event.action == 'reopened' ||
+        (github.event.action == 'unlabeled' && github.event.label.name == 'codex-started')
+      )
     runs-on: [self-hosted, homelab]
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Adds `unlabeled` to the `issues` event types in the Codex Agent workflow
- Extends the `resolve-issue` job condition to fire when the `codex-started` label is specifically removed
- Enables a simple retry mechanism: remove the label to re-trigger Codex

## Why

During a 36-hour PR storm, several issues got `codex-started` labels but no PR was produced (pipeline failures, timeouts, etc.). The only way to retry was to close/reopen the issue or post an `@codex` comment. This change makes the label itself the retry control: remove it, Codex tries again.

## How it works

1. `issues: [opened, reopened, unlabeled]` — workflow now fires on label removal
2. `resolve-issue` job condition checks `github.event.action == 'unlabeled' && github.event.label.name == 'codex-started'`
3. The existing "Label issue as codex-started" step re-adds the label, so the cycle is: remove label → Codex re-triggers → label re-added → if it fails again, remove label again

## Security

The `authorize` job still gates on the issue author's association (OWNER/MEMBER/COLLABORATOR). Only issues created by trusted users will be processed regardless of who removes the label.

## Test plan

- [ ] Merge this PR
- [ ] Remove `codex-started` from an open issue
- [ ] Verify the Codex Agent workflow triggers and the resolve-issue job runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)