### PR TITLE
Preserve local actions in Codex review workflow

### DIFF
--- a/.github/actions/run-devcontainer/action.yml
+++ b/.github/actions/run-devcontainer/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: Repo-relative working directory for the command
     required: false
     default: '.'
+  workspace_folder:
+    description: Repository path relative to github.workspace to mount into the devcontainer
+    required: false
+    default: '.'
   pull:
     description: Pull the image before running (set to 'false' to skip)
     required: false
@@ -35,7 +39,9 @@ runs:
       id: prepare-script
       shell: bash
       run: |
-        SCRIPT=$(mktemp "${{ github.workspace }}/.git/devcontainer-run-XXXXXX.sh")
+        set -euo pipefail
+        WORKSPACE="${{ github.workspace }}/${{ inputs.workspace_folder }}"
+        SCRIPT=$(mktemp "$WORKSPACE/.git/devcontainer-run-XXXXXX.sh")
         cat > "$SCRIPT" <<'RUNCMD'
         set -euo pipefail
         cd '${{ inputs.workdir }}'
@@ -49,7 +55,7 @@ runs:
       run: |
         set -euo pipefail
 
-        WORKSPACE="${{ github.workspace }}"
+        WORKSPACE="${{ github.workspace }}/${{ inputs.workspace_folder }}"
         SCRIPT_PATH="${{ steps.prepare-script.outputs.script }}"
         OVERRIDE_CONFIG=$(mktemp /tmp/devcontainer-override-XXXXXX.json)
         cleanup() {

--- a/.github/workflows/codex-code-review.yml
+++ b/.github/workflows/codex-code-review.yml
@@ -55,6 +55,7 @@ concurrency:
 env:
   # Note: must be lowercase for Docker compatibility
   DEVCONTAINER_IMAGE: ghcr.io/nickborgersprobably/hide-my-list-devcontainer
+  REVIEW_REPO_PATH: pr
 
 jobs:
   # Extract PR and Issue context from workflow_run or workflow_dispatch event
@@ -411,6 +412,9 @@ jobs:
       statuses: write  # Required to create commit status after tests pass
 
     steps:
+      - name: Checkout for composite action
+        uses: actions/checkout@v4
+
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
@@ -418,6 +422,7 @@ jobs:
           repository: ${{ needs.get-context.outputs.head_repo }}
           fetch-depth: 0
           token: ${{ secrets.WORKFLOW_PAT }}  # PAT required to push workflow file changes
+          path: ${{ env.REVIEW_REPO_PATH }}
 
       - name: Increment fix attempt counter
         env:
@@ -453,6 +458,7 @@ jobs:
         uses: ./.github/actions/run-devcontainer
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
+          workspace_folder: ${{ env.REVIEW_REPO_PATH }}
           pull: 'true'
           env: |
             OPENAI_API_KEY=fake-key
@@ -685,9 +691,9 @@ jobs:
           repository: ${{ github.repository }}
           pr_tests_run_id: ${{ needs.get-context.outputs.pr_tests_run_id }}
 
-      # Keep post-actions out of the local composite action. Re-checking out the
-      # PR branch over the workspace that contains ./.github/actions/reviewer-setup
-      # can trigger runner cleanup failures on self-hosted runners.
+      # Keep the workflow checkout at the workspace root so local composite
+      # actions remain available. Check out the PR branch into a sibling
+      # directory so the review still runs against the PR code.
       - name: Checkout PR branch
         if: steps.setup.outputs.verified == 'true'
         uses: actions/checkout@v4
@@ -695,6 +701,7 @@ jobs:
           ref: ${{ needs.get-context.outputs.head_ref }}
           repository: ${{ needs.get-context.outputs.head_repo }}
           fetch-depth: 0
+          path: ${{ env.REVIEW_REPO_PATH }}
 
       - name: Create directories for devcontainer mounts
         if: steps.setup.outputs.verified == 'true'
@@ -713,6 +720,7 @@ jobs:
         uses: ./.github/actions/run-devcontainer
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
+          workspace_folder: ${{ env.REVIEW_REPO_PATH }}
           pull: 'true'
           env: |
             OPENAI_API_KEY=fake-key
@@ -869,6 +877,7 @@ jobs:
           ref: ${{ needs.get-context.outputs.head_ref }}
           repository: ${{ needs.get-context.outputs.head_repo }}
           fetch-depth: 0
+          path: ${{ env.REVIEW_REPO_PATH }}
 
       - name: Create directories for devcontainer mounts
         if: steps.setup.outputs.verified == 'true'
@@ -887,6 +896,7 @@ jobs:
         uses: ./.github/actions/run-devcontainer
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
+          workspace_folder: ${{ env.REVIEW_REPO_PATH }}
           pull: 'true'
           env: |
             OPENAI_API_KEY=fake-key
@@ -994,6 +1004,7 @@ jobs:
           ref: ${{ needs.get-context.outputs.head_ref }}
           repository: ${{ needs.get-context.outputs.head_repo }}
           fetch-depth: 0
+          path: ${{ env.REVIEW_REPO_PATH }}
 
       - name: Create directories for devcontainer mounts
         if: steps.setup.outputs.verified == 'true'
@@ -1012,6 +1023,7 @@ jobs:
         uses: ./.github/actions/run-devcontainer
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
+          workspace_folder: ${{ env.REVIEW_REPO_PATH }}
           pull: 'true'
           env: |
             OPENAI_API_KEY=fake-key
@@ -1183,6 +1195,7 @@ jobs:
           ref: ${{ needs.get-context.outputs.head_ref }}
           repository: ${{ needs.get-context.outputs.head_repo }}
           fetch-depth: 0
+          path: ${{ env.REVIEW_REPO_PATH }}
 
       - name: Create directories for devcontainer mounts
         if: steps.setup.outputs.verified == 'true'
@@ -1201,6 +1214,7 @@ jobs:
         uses: ./.github/actions/run-devcontainer
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
+          workspace_folder: ${{ env.REVIEW_REPO_PATH }}
           pull: 'true'
           env: |
             OPENAI_API_KEY=fake-key
@@ -1332,6 +1346,7 @@ jobs:
           ref: ${{ needs.get-context.outputs.head_ref }}
           repository: ${{ needs.get-context.outputs.head_repo }}
           fetch-depth: 0
+          path: ${{ env.REVIEW_REPO_PATH }}
 
       - name: Create directories for devcontainer mounts
         if: steps.setup.outputs.verified == 'true'
@@ -1350,6 +1365,7 @@ jobs:
         uses: ./.github/actions/run-devcontainer
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
+          workspace_folder: ${{ env.REVIEW_REPO_PATH }}
           pull: 'true'
           env: |
             OPENAI_API_KEY=fake-key
@@ -1493,6 +1509,7 @@ jobs:
           repository: ${{ needs.get-context.outputs.head_repo }}
           fetch-depth: 0
           token: ${{ secrets.WORKFLOW_PAT }}
+          path: ${{ env.REVIEW_REPO_PATH }}
 
       - name: Create directories for devcontainer mounts
         if: steps.setup.outputs.verified == 'true'
@@ -1511,6 +1528,7 @@ jobs:
         uses: ./.github/actions/run-devcontainer
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
+          workspace_folder: ${{ env.REVIEW_REPO_PATH }}
           pull: 'true'
           env: |
             OPENAI_API_KEY=fake-key


### PR DESCRIPTION
Resolves #217

## Summary
- keep the workflow checkout at the workspace root so local composite actions remain available
- check out the PR branch into `pr/` for the code-review and fix-test-failures jobs
- extend the `run-devcontainer` composite action with a `workspace_folder` input so it can execute against the PR checkout explicitly

## Test Plan
- `shellcheck scripts/*.sh`
- `yamllint .github/workflows/*.yml` (repo has pre-existing style violations; modified workflow still parses cleanly)
- `python3` YAML parse check for `.github/workflows/codex-code-review.yml` and `.github/actions/run-devcontainer/action.yml`
- `python3` local markdown link check across repo docs

Generated with Codex