### PR TITLE
Fix Codex review workflow local action checkout bug

### DIFF
--- a/.github/actions/run-devcontainer/action.yml
+++ b/.github/actions/run-devcontainer/action.yml
@@ -9,6 +9,10 @@ inputs:
   image:
     description: Devcontainer image to run (e.g. ghcr.io/org/repo-devcontainer)
     required: true
+  workspace_folder:
+    description: Repo checkout path to mount into the devcontainer
+    required: false
+    default: '.'
   run_cmd:
     description: Shell commands to execute inside the container
     required: true
@@ -35,7 +39,12 @@ runs:
       id: prepare-script
       shell: bash
       run: |
-        SCRIPT=$(mktemp "${{ github.workspace }}/.git/devcontainer-run-XXXXXX.sh")
+        WORKSPACE="${{ github.workspace }}"
+        if [ "${{ inputs.workspace_folder }}" != "." ]; then
+          WORKSPACE="$WORKSPACE/${{ inputs.workspace_folder }}"
+        fi
+
+        SCRIPT=$(mktemp "$WORKSPACE/.git/devcontainer-run-XXXXXX.sh")
         cat > "$SCRIPT" <<'RUNCMD'
         set -euo pipefail
         cd '${{ inputs.workdir }}'
@@ -50,6 +59,9 @@ runs:
         set -euo pipefail
 
         WORKSPACE="${{ github.workspace }}"
+        if [ "${{ inputs.workspace_folder }}" != "." ]; then
+          WORKSPACE="$WORKSPACE/${{ inputs.workspace_folder }}"
+        fi
         SCRIPT_PATH="${{ steps.prepare-script.outputs.script }}"
         OVERRIDE_CONFIG=$(mktemp /tmp/devcontainer-override-XXXXXX.json)
         cleanup() {

--- a/.github/workflows/codex-code-review.yml
+++ b/.github/workflows/codex-code-review.yml
@@ -55,6 +55,7 @@ concurrency:
 env:
   # Note: must be lowercase for Docker compatibility
   DEVCONTAINER_IMAGE: ghcr.io/nickborgersprobably/hide-my-list-devcontainer
+  PR_WORKSPACE_PATH: pr-head
 
 jobs:
   # Extract PR and Issue context from workflow_run or workflow_dispatch event
@@ -411,11 +412,17 @@ jobs:
       statuses: write  # Required to create commit status after tests pass
 
     steps:
+      - name: Checkout main for local actions
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.get-context.outputs.head_ref }}
           repository: ${{ needs.get-context.outputs.head_repo }}
+          path: ${{ env.PR_WORKSPACE_PATH }}
           fetch-depth: 0
           token: ${{ secrets.WORKFLOW_PAT }}  # PAT required to push workflow file changes
 
@@ -453,6 +460,7 @@ jobs:
         uses: ./.github/actions/run-devcontainer
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
+          workspace_folder: ${{ env.PR_WORKSPACE_PATH }}
           pull: 'true'
           env: |
             OPENAI_API_KEY=fake-key
@@ -543,6 +551,7 @@ jobs:
 
       - name: Trigger PR Tests and reviews after fix
         if: success()
+        working-directory: ${{ env.PR_WORKSPACE_PATH }}
         env:
           GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
           FIX_ATTEMPTS: ${{ needs.get-context.outputs.fix_attempts }}
@@ -671,8 +680,10 @@ jobs:
       packages: read
 
     steps:
-      - name: Checkout for composite action
+      - name: Checkout main for composite actions
         uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Reviewer setup
         id: setup
@@ -694,6 +705,7 @@ jobs:
         with:
           ref: ${{ needs.get-context.outputs.head_ref }}
           repository: ${{ needs.get-context.outputs.head_repo }}
+          path: ${{ env.PR_WORKSPACE_PATH }}
           fetch-depth: 0
 
       - name: Create directories for devcontainer mounts
@@ -713,6 +725,7 @@ jobs:
         uses: ./.github/actions/run-devcontainer
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
+          workspace_folder: ${{ env.PR_WORKSPACE_PATH }}
           pull: 'true'
           env: |
             OPENAI_API_KEY=fake-key
@@ -848,8 +861,10 @@ jobs:
       packages: read
 
     steps:
-      - name: Checkout for composite action
+      - name: Checkout main for composite actions
         uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Reviewer setup
         id: setup
@@ -868,6 +883,7 @@ jobs:
         with:
           ref: ${{ needs.get-context.outputs.head_ref }}
           repository: ${{ needs.get-context.outputs.head_repo }}
+          path: ${{ env.PR_WORKSPACE_PATH }}
           fetch-depth: 0
 
       - name: Create directories for devcontainer mounts
@@ -887,6 +903,7 @@ jobs:
         uses: ./.github/actions/run-devcontainer
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
+          workspace_folder: ${{ env.PR_WORKSPACE_PATH }}
           pull: 'true'
           env: |
             OPENAI_API_KEY=fake-key
@@ -973,8 +990,10 @@ jobs:
       packages: read
 
     steps:
-      - name: Checkout for composite action
+      - name: Checkout main for composite actions
         uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Reviewer setup
         id: setup
@@ -993,6 +1012,7 @@ jobs:
         with:
           ref: ${{ needs.get-context.outputs.head_ref }}
           repository: ${{ needs.get-context.outputs.head_repo }}
+          path: ${{ env.PR_WORKSPACE_PATH }}
           fetch-depth: 0
 
       - name: Create directories for devcontainer mounts
@@ -1012,6 +1032,7 @@ jobs:
         uses: ./.github/actions/run-devcontainer
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
+          workspace_folder: ${{ env.PR_WORKSPACE_PATH }}
           pull: 'true'
           env: |
             OPENAI_API_KEY=fake-key
@@ -1162,8 +1183,10 @@ jobs:
       packages: read
 
     steps:
-      - name: Checkout for composite action
+      - name: Checkout main for composite actions
         uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Reviewer setup
         id: setup
@@ -1182,6 +1205,7 @@ jobs:
         with:
           ref: ${{ needs.get-context.outputs.head_ref }}
           repository: ${{ needs.get-context.outputs.head_repo }}
+          path: ${{ env.PR_WORKSPACE_PATH }}
           fetch-depth: 0
 
       - name: Create directories for devcontainer mounts
@@ -1201,6 +1225,7 @@ jobs:
         uses: ./.github/actions/run-devcontainer
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
+          workspace_folder: ${{ env.PR_WORKSPACE_PATH }}
           pull: 'true'
           env: |
             OPENAI_API_KEY=fake-key
@@ -1311,8 +1336,10 @@ jobs:
       packages: read
 
     steps:
-      - name: Checkout for composite action
+      - name: Checkout main for composite actions
         uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Reviewer setup
         id: setup
@@ -1331,6 +1358,7 @@ jobs:
         with:
           ref: ${{ needs.get-context.outputs.head_ref }}
           repository: ${{ needs.get-context.outputs.head_repo }}
+          path: ${{ env.PR_WORKSPACE_PATH }}
           fetch-depth: 0
 
       - name: Create directories for devcontainer mounts
@@ -1350,6 +1378,7 @@ jobs:
         uses: ./.github/actions/run-devcontainer
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
+          workspace_folder: ${{ env.PR_WORKSPACE_PATH }}
           pull: 'true'
           env: |
             OPENAI_API_KEY=fake-key
@@ -1471,8 +1500,10 @@ jobs:
       packages: read
 
     steps:
-      - name: Checkout for composite action
+      - name: Checkout main for composite actions
         uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Reviewer setup
         id: setup
@@ -1491,6 +1522,7 @@ jobs:
         with:
           ref: ${{ needs.get-context.outputs.head_ref }}
           repository: ${{ needs.get-context.outputs.head_repo }}
+          path: ${{ env.PR_WORKSPACE_PATH }}
           fetch-depth: 0
           token: ${{ secrets.WORKFLOW_PAT }}
 
@@ -1511,6 +1543,7 @@ jobs:
         uses: ./.github/actions/run-devcontainer
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
+          workspace_folder: ${{ env.PR_WORKSPACE_PATH }}
           pull: 'true'
           env: |
             OPENAI_API_KEY=fake-key


### PR DESCRIPTION
Resolves #216

## Summary
- keep `main` checked out at the workspace root so local composite actions remain available throughout review jobs
- check out the PR branch into a separate `pr-head` path for fix and review jobs
- update `run-devcontainer` to accept an alternate workspace folder so the devcontainer runs against the PR checkout instead of the workflow checkout root
- run the post-fix git operations from the PR checkout path so fetch/push logic still targets the branch under review

## Test Plan
- `shellcheck scripts/*.sh`
- `yamllint .github/workflows/*.yml` (fails on pre-existing repo-wide style violations unrelated to this change)
- `yamllint -d {extends: default, rules: {line-length: disable, truthy: disable, document-start: disable}} .github/workflows/codex-code-review.yml .github/actions/run-devcontainer/action.yml`
- `python3 - <<PY`
  `import pathlib, yaml`
  `for path in [pathlib.Path(.github/workflows/codex-code-review.yml), pathlib.Path(.github/actions/run-devcontainer/action.yml)]:`
  `    yaml.safe_load(path.read_text())`
  `print(ok)`
  `PY`
- internal docs link check across `docs/` and `design/`

Generated with Codex