### PR TITLE
Guard devcontainer review runs from empty SSH agent mounts

### DIFF
--- a/.github/actions/run-devcontainer/action.yml
+++ b/.github/actions/run-devcontainer/action.yml
@@ -58,6 +58,23 @@ runs:
       run: |
         set -euo pipefail
 
+        sanitize_ssh_agent_forwarding() {
+          if [ -z "${SSH_AUTH_SOCK:-}" ]; then
+            echo \
+              "SSH_AUTH_SOCK is empty or unset; disabling SSH agent" \
+              "forwarding for devcontainer CLI."
+            unset SSH_AUTH_SOCK SSH_AGENT_PID
+            return
+          fi
+
+          if [ ! -S "$SSH_AUTH_SOCK" ]; then
+            echo \
+              "SSH_AUTH_SOCK='$SSH_AUTH_SOCK' is not a live socket;" \
+              "disabling SSH agent forwarding for devcontainer CLI."
+            unset SSH_AUTH_SOCK SSH_AGENT_PID
+          fi
+        }
+
         WORKSPACE="${{ github.workspace }}"
         if [ "${{ inputs.workspace_folder }}" != "." ]; then
           WORKSPACE="$WORKSPACE/${{ inputs.workspace_folder }}"
@@ -99,6 +116,10 @@ runs:
         done <<'ENVEOF'
         ${{ inputs.env }}
         ENVEOF
+
+        # Prevent the devcontainer CLI from synthesizing an empty bind mount
+        # when a runner exports SSH_AUTH_SOCK without a usable agent socket.
+        sanitize_ssh_agent_forwarding
 
         npx -y @devcontainers/cli up \
           --workspace-folder "$WORKSPACE" \


### PR DESCRIPTION
Resolves #223

## Summary
- sanitize runner-side SSH agent forwarding in `.github/actions/run-devcontainer/action.yml`
- unset `SSH_AUTH_SOCK` and `SSH_AGENT_PID` before invoking `@devcontainers/cli` when the runner socket is empty, unset, or not a live socket
- keep valid SSH agent forwarding intact on runners that do have a usable socket

## Test Plan
- `shellcheck scripts/*.sh`
- `yamllint .github/workflows/*.yml` (fails due to pre-existing repo-wide workflow style violations unrelated to this change)
- `yamllint .github/actions/run-devcontainer/action.yml` (fails on pre-existing line-length/document-start rules in that file)
- internal markdown link validation across `docs/` and `design/`

Generated with Codex