### PR TITLE
Fix CI devcontainer launch when SSH_AUTH_SOCK is unset

### DIFF
--- a/.github/actions/run-devcontainer/action.yml
+++ b/.github/actions/run-devcontainer/action.yml
@@ -1,3 +1,4 @@
+---
 name: Run command in devcontainer
 description: >
   Runs a command inside a pre-built devcontainer image using the
@@ -63,9 +64,11 @@ runs:
           WORKSPACE="$WORKSPACE/${{ inputs.workspace_folder }}"
         fi
         SCRIPT_PATH="${{ steps.prepare-script.outputs.script }}"
-        OVERRIDE_CONFIG=$(mktemp /tmp/devcontainer-override-XXXXXX.json)
+        GENERATED_CONFIG=$(
+          mktemp "$WORKSPACE/.devcontainer/devcontainer-codex-ci-XXXXXX.json"
+        )
         cleanup() {
-          rm -f "$OVERRIDE_CONFIG" "$SCRIPT_PATH"
+          rm -f "$GENERATED_CONFIG" "$SCRIPT_PATH"
         }
         trap cleanup EXIT
 
@@ -74,24 +77,57 @@ runs:
           docker pull "${{ inputs.image }}"
         fi
 
-        python3 - "$WORKSPACE/.devcontainer/devcontainer.json" "$OVERRIDE_CONFIG" "${{ inputs.image }}" <<'PY'
+        python3 \
+          - \
+          "$WORKSPACE/.devcontainer/devcontainer.json" \
+          "$GENERATED_CONFIG" \
+          "${{ inputs.image }}" \
+          "${SSH_AUTH_SOCK:-}" <<'PY'
         import json
         import sys
 
-        source_path, target_path, image = sys.argv[1:4]
+        source_path, target_path, image, ssh_auth_sock = sys.argv[1:5]
         with open(source_path, "r", encoding="utf-8") as handle:
             config = json.load(handle)
+
+        def is_ssh_agent_mount(mount):
+            if isinstance(mount, str):
+                return (
+                    "${localEnv:SSH_AUTH_SOCK}" in mount
+                    or "target=/run/ssh-agent.sock" in mount.replace(" ", "")
+                )
+            if isinstance(mount, dict):
+                source = str(mount.get("source", ""))
+                target = str(mount.get("target", ""))
+                return (
+                    "${localEnv:SSH_AUTH_SOCK}" in source
+                    or target == "/run/ssh-agent.sock"
+                )
+            return False
 
         config.pop("build", None)
         config.pop("initializeCommand", None)
         config["image"] = image
+
+        if not ssh_auth_sock:
+            mounts = config.get("mounts")
+            if isinstance(mounts, list):
+                config["mounts"] = [
+                    mount for mount in mounts if not is_ssh_agent_mount(mount)
+                ]
+
+            remote_env = config.get("remoteEnv")
+            if isinstance(remote_env, dict):
+                remote_env.pop("SSH_AUTH_SOCK", None)
+                if not remote_env:
+                    config.pop("remoteEnv", None)
 
         with open(target_path, "w", encoding="utf-8") as handle:
             json.dump(config, handle, indent=2)
             handle.write("\n")
         PY
 
-        # Forward remote env vars to both lifecycle hooks and the target command.
+        # Forward remote env vars to lifecycle hooks and the target command.
         REMOTE_ENV_ARGS=()
         while IFS= read -r line; do
           [[ -z "$line" || "$line" == \#* ]] && continue
@@ -102,7 +138,7 @@ runs:
 
         npx -y @devcontainers/cli up \
           --workspace-folder "$WORKSPACE" \
-          --override-config "$OVERRIDE_CONFIG" \
+          --config "$GENERATED_CONFIG" \
           --remove-existing-container \
           --skip-post-attach \
           "${REMOTE_ENV_ARGS[@]}"
@@ -111,6 +147,6 @@ runs:
 
         npx -y @devcontainers/cli exec \
           --workspace-folder "$WORKSPACE" \
-          --override-config "$OVERRIDE_CONFIG" \
+          --config "$GENERATED_CONFIG" \
           "${REMOTE_ENV_ARGS[@]}" \
           bash -lc "bash '.git/$SCRIPT_NAME'"


### PR DESCRIPTION
Resolves #225

## Summary
- switch the shared `run-devcontainer` action from `--override-config` to a generated workspace-local `--config` file so CI uses the sanitized config directly
- strip SSH agent mount entries and `remoteEnv.SSH_AUTH_SOCK` when the runner does not provide `SSH_AUTH_SOCK`
- keep other devcontainer settings intact so review jobs still run against the PR workspace

## Test Plan
- `shellcheck scripts/*.sh`
- `yamllint .github/actions/run-devcontainer/action.yml`
- `yamllint .github/workflows/*.yml` (currently fails due to many pre-existing line-length/document-start issues in unrelated workflow files)
- run a targeted Python config-generation check with a synthetic SSH mount to verify the mount is removed when `SSH_AUTH_SOCK` is empty

Generated with Codex