### PR TITLE
Re-trigger Codex on codex-started label removal

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -231,7 +231,11 @@ jobs:
       needs.authorize.outputs.authorized == 'true' &&
       needs.preflight.outputs.should_run == 'true' &&
       (
-        (github.event_name == 'issues') ||
+        (github.event_name == 'issues' && (
+          github.event.action == 'opened' ||
+          github.event.action == 'reopened' ||
+          (github.event.action == 'unlabeled' && github.event.label.name == 'codex-started')
+        )) ||
         needs.detect_codex_invocation.outputs.codex_requested == 'true'
       )
     runs-on: [self-hosted, homelab]


### PR DESCRIPTION
## Summary
- Adds `unlabeled` to the `issues` event types in the Codex Agent workflow
- Extends the `resolve-issue` job condition to fire when the `codex-started` label is specifically removed
- Authorizes `unlabeled` events by checking the sender's collaborator permission via the GitHub API

## Why
When Codex fails to produce a PR (timeouts, pipeline errors, etc.), the `codex-started` label remains on the issue with no way to retry short of closing/reopening. This adds a simple retry: remove the label to re-trigger.

## Test plan
- [ ] Remove `codex-started` from an issue → verify the `resolve-issue` job triggers
- [ ] Confirm `opened` and `reopened` still trigger as before
- [ ] Verify that removing other labels does NOT trigger `resolve-issue`
- [ ] Verify unauthorized users cannot trigger via label removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)