### PR TITLE
Fix commit-status auth in Codex review workflow

### DIFF
--- a/.github/workflows/codex-code-review.yml
+++ b/.github/workflows/codex-code-review.yml
@@ -567,6 +567,7 @@ jobs:
         working-directory: ${{ env.PR_WORKSPACE_PATH }}
         env:
           GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
+          STATUS_API_TOKEN: ${{ github.token }}
           FIX_ATTEMPTS: ${{ needs.get-context.outputs.fix_attempts }}
         run: |
           # Check if new commits were pushed by comparing current HEAD to triggering SHA
@@ -617,7 +618,9 @@ jobs:
               # Create a commit status for the PR's head SHA so the PR check shows as passed
               # This is needed because workflow_dispatch runs don't automatically create PR status checks
               echo "Creating commit status for $CURRENT_HEAD..."
-              gh api repos/${{ github.repository }}/statuses/$CURRENT_HEAD \
+              GH_TOKEN="$STATUS_API_TOKEN" \
+                gh api \
+                repos/${{ github.repository }}/statuses/$CURRENT_HEAD \
                 -f state="success" \
                 -f target_url="https://github.com/${{ github.repository }}/actions/runs/$RUN_ID" \
                 -f description="All required tests passed (via automated fix)" \


### PR DESCRIPTION
Resolves #240

## Summary
Use the job-scoped GitHub token for the `gh api repos/.../statuses/$CURRENT_HEAD` call in `codex-code-review.yml`.
Keep `WORKFLOW_PAT` for the later `gh workflow run` call so the workflow can still dispatch PR Tests and downstream review automation.

## Test Plan
- Run `shellcheck scripts/*.sh`
- Run `yamllint .github/workflows/*.yml` and confirm there are only pre-existing workflow lint findings outside this targeted auth fix
- Inspect `.github/workflows/codex-code-review.yml` to verify the status API call is overridden to use `${{ github.token }}` while the step still defaults to `WORKFLOW_PAT`

Generated with Codex