### PR TITLE
Add /review comment command to re-trigger AI reviews

### DIFF
--- a/.github/workflows/codex-code-review.yml
+++ b/.github/workflows/codex-code-review.yml
@@ -4,6 +4,7 @@ name: Codex Code Review
 # Format: "Codex Code Review (PR #123)" or "Codex Code Review (branch-name)"
 run-name: >-
   ${{ github.event_name == 'workflow_dispatch' && format('Codex Code Review (PR #{0})', inputs.pr_number) ||
+      github.event_name == 'issue_comment' && format('Codex Code Review (PR #{0})', github.event.issue.number) ||
       github.event_name == 'pull_request' && format('Codex Code Review (PR #{0})', github.event.pull_request.number) ||
       format('Codex Code Review ({0})', github.event.workflow_run.head_branch) }}
 
@@ -17,9 +18,12 @@ on:
   workflow_run:
     workflows: ["PR Tests"]
     types: [completed]
-  # Clear review labels on close; reset reviews on reopen (allows re-triggering full review cycle)
+  # Allow re-triggering reviews via /review comment on a PR
+  issue_comment:
+    types: [created]
+  # Clear review labels when PR is closed
   pull_request:
-    types: [closed, reopened]
+    types: [closed]
   # Allow manual triggering after workflow_dispatch-triggered PR Tests completes
   # (workflow_run events don't fire for workflow_dispatch triggers)
   workflow_dispatch:
@@ -49,7 +53,7 @@ on:
 # Uses branch name for concurrency group
 # cancel-in-progress: false ensures we complete the first review rather than restarting
 concurrency:
-  group: codex-review-${{ github.event_name == 'workflow_dispatch' && inputs.head_ref || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.event.workflow_run.head_branch }}
+  group: codex-review-${{ github.event_name == 'workflow_dispatch' && inputs.head_ref || github.event_name == 'issue_comment' && format('pr-{0}', github.event.issue.number) || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.event.workflow_run.head_branch }}
   cancel-in-progress: false
 
 env:
@@ -76,17 +80,17 @@ jobs:
       head_repo: ${{ steps.get-pr.outputs.head_repo }}
       # Draft PR status - used to skip auto-fix pipeline for TDD workflows
       is_draft: ${{ steps.get-pr.outputs.is_draft }}
-      # Handle workflow_run, workflow_dispatch, and pull_request events
-      # For pull_request (reopen), tests haven't run yet so tests_passed is false
-      tests_passed: ${{ github.event_name == 'workflow_dispatch' && inputs.tests_passed == 'true' || github.event_name == 'pull_request' && 'false' || github.event.workflow_run.conclusion == 'success' }}
-      run_id: ${{ github.event_name == 'workflow_dispatch' && inputs.run_id || github.event_name == 'pull_request' && github.run_id || github.event.workflow_run.id }}
+      # Handle workflow_run, workflow_dispatch, issue_comment, and pull_request events
+      # For issue_comment (/review), look up latest PR Tests result
+      # For pull_request (close), tests_passed is irrelevant (downstream jobs skip)
+      tests_passed: ${{ github.event_name == 'workflow_dispatch' && inputs.tests_passed == 'true' || github.event_name == 'issue_comment' && steps.lookup-tests.outputs.tests_passed || github.event_name == 'pull_request' && 'false' || github.event.workflow_run.conclusion == 'success' }}
+      run_id: ${{ github.event_name == 'workflow_dispatch' && inputs.run_id || github.event_name == 'issue_comment' && steps.lookup-tests.outputs.run_id || github.event_name == 'pull_request' && github.run_id || github.event.workflow_run.id }}
       # Workflow run ID for the PR Tests execution that validated this PR head.
       # reviewer-setup uses that run to verify the current PR head SHA before
       # checking out the immutable commit for each review job.
-      # Reopen-triggered pull_request runs do not have a completed PR Tests run yet.
-      pr_tests_run_id: ${{ github.event_name == 'pull_request' && '' || github.event_name == 'workflow_dispatch' && inputs.run_id || github.event.workflow_run.id }}
+      pr_tests_run_id: ${{ github.event_name == 'issue_comment' && steps.lookup-tests.outputs.run_id || github.event_name == 'pull_request' && '' || github.event_name == 'workflow_dispatch' && inputs.run_id || github.event.workflow_run.id }}
       # SHA that triggered this workflow - used to detect if author pushed newer commits
-      triggering_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.workflow_run.head_sha }}
+      triggering_sha: ${{ github.event_name == 'issue_comment' && steps.lookup-tests.outputs.head_sha || github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.workflow_run.head_sha }}
       issue_number: ${{ steps.get-issue.outputs.issue_number }}
       issue_title: ${{ steps.get-issue.outputs.issue_title }}
       issue_body_b64: ${{ steps.get-issue.outputs.issue_body_b64 }}
@@ -100,9 +104,88 @@ jobs:
       docs_only: ${{ steps.classify-files.outputs.docs_only }}
 
     steps:
+      # Gate for /review comment triggers — skip non-matching comments early
+      - name: Check /review comment trigger
+        id: comment-gate
+        if: github.event_name == 'issue_comment'
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          # Must be a PR comment (issues don't have pull_request field)
+          if [ -z "${{ github.event.issue.pull_request.url }}" ]; then
+            echo "Not a PR comment, skipping"
+            echo "valid=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Must contain /review command
+          if ! echo "$COMMENT_BODY" | grep -qE '^\s*/review\s*$'; then
+            echo "Comment does not contain /review command"
+            echo "valid=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Authorization check
+          AUTHOR_ASSOC="${{ github.event.comment.author_association }}"
+          case "$AUTHOR_ASSOC" in
+            OWNER|MEMBER|COLLABORATOR)
+              echo "Authorized: ${{ github.event.comment.user.login }} ($AUTHOR_ASSOC)"
+              echo "valid=true" >> $GITHUB_OUTPUT
+              ;;
+            *)
+              echo "Not authorized: ${{ github.event.comment.user.login }} ($AUTHOR_ASSOC)"
+              echo "valid=false" >> $GITHUB_OUTPUT
+              ;;
+          esac
+
+      - name: Acknowledge /review comment
+        if: github.event_name == 'issue_comment' && steps.comment-gate.outputs.valid == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            -f content='eyes' || true
+
+      # Look up the latest PR Tests result for /review triggers
+      - name: Look up PR Tests status
+        id: lookup-tests
+        if: github.event_name == 'issue_comment' && steps.comment-gate.outputs.valid == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER="${{ github.event.issue.number }}"
+
+          # Get PR head SHA and branch
+          PR_DATA=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER)
+          HEAD_SHA=$(echo "$PR_DATA" | jq -r '.head.sha')
+          HEAD_REF=$(echo "$PR_DATA" | jq -r '.head.ref')
+          echo "head_sha=$HEAD_SHA" >> $GITHUB_OUTPUT
+
+          # Find most recent completed PR Tests run for this branch
+          RUN_JSON=$(gh api "repos/${{ github.repository }}/actions/workflows/pr-tests.yml/runs?branch=$HEAD_REF&per_page=1&status=completed" --jq '.workflow_runs[0] // empty')
+
+          if [ -n "$RUN_JSON" ]; then
+            RUN_ID=$(echo "$RUN_JSON" | jq -r '.id')
+            CONCLUSION=$(echo "$RUN_JSON" | jq -r '.conclusion')
+            RUN_SHA=$(echo "$RUN_JSON" | jq -r '.head_sha')
+            echo "Found PR Tests run #$RUN_ID (conclusion: $CONCLUSION, sha: $RUN_SHA)"
+
+            if [ "$RUN_SHA" = "$HEAD_SHA" ] && [ "$CONCLUSION" = "success" ]; then
+              echo "tests_passed=true" >> $GITHUB_OUTPUT
+            else
+              echo "tests_passed=false" >> $GITHUB_OUTPUT
+            fi
+            echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
+          else
+            echo "No completed PR Tests run found"
+            echo "tests_passed=false" >> $GITHUB_OUTPUT
+            echo "run_id=${{ github.run_id }}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Get PR from workflow run or dispatch inputs
         uses: actions/github-script@v7
         id: get-pr
+        if: github.event_name != 'issue_comment' || steps.comment-gate.outputs.valid == 'true'
         with:
           script: |
             // Check if this is a workflow_dispatch event with inputs
@@ -115,8 +198,12 @@ jobs:
               headRepo = '${{ inputs.head_repo }}';
               prNumber = parseInt('${{ inputs.pr_number }}', 10);
               console.log(`Triggered via workflow_dispatch for PR #${prNumber}`);
+            } else if (eventName === 'issue_comment') {
+              // Triggered via /review comment on a PR
+              prNumber = context.payload.issue.number;
+              console.log(`Triggered via /review comment on PR #${prNumber}`);
             } else if (eventName === 'pull_request') {
-              // Use data from pull_request event (triggered on reopen)
+              // Use data from pull_request event (triggered on close)
               const pr = context.payload.pull_request;
               headBranch = pr.head.ref;
               headRepo = pr.head.repo.full_name;
@@ -222,7 +309,7 @@ jobs:
           echo "Current fix attempt count: $COUNT"
           echo "count=$COUNT" >> $GITHUB_OUTPUT
 
-      - name: Check if reviews already passed (or reset on reopen)
+      - name: Check if reviews already passed (or reset on /review)
         if: steps.get-pr.outputs.pr_number != ''
         id: check-existing-reviews
         env:
@@ -250,9 +337,9 @@ jobs:
             exit 0
           fi
 
-          # If PR was reopened, remove any remaining review labels to allow re-review
-          if [ "$EVENT_NAME" = "pull_request" ] && [ "${{ github.event.action }}" = "reopened" ]; then
-            echo "PR was reopened - removing review progress labels to allow re-review"
+          # If /review comment, remove all review progress labels to allow re-review
+          if [ "$EVENT_NAME" = "issue_comment" ]; then
+            echo "/review comment - removing review progress labels to allow re-review"
             for label in \
               "agent-reviews-passed" \
               "all-reviews-started" \
@@ -2037,18 +2124,9 @@ jobs:
           REVIEWS_ALREADY_PASSED="${{ needs.get-context.outputs.reviews_already_passed }}"
           if [ "$REVIEWS_ALREADY_PASSED" = "true" ]; then
             echo "Reviews already passed for this PR - skipping re-review"
-            echo "To re-run reviews: close and reopen the PR"
+            echo "To re-run reviews: comment /review on the PR"
             echo "skipped_with_success=true" >> $GITHUB_OUTPUT
             exit 0
-          fi
-
-          # PR reopen only resets the labels - the real reviews come from
-          # the workflow_run trigger once PR Tests complete. Exit with
-          # failure so this run does NOT satisfy the branch-protection
-          # check before actual reviews have run.
-          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.event.action }}" = "reopened" ]; then
-            echo "PR reopened — waiting for PR Tests to trigger the real review run"
-            exit 1
           fi
 
           # Check if we have a valid PR
@@ -2221,7 +2299,7 @@ jobs:
 
           echo "Added 'agent-reviews-passed' label to PR #$PR_NUMBER"
           echo "Subsequent pushes will skip agent reviews."
-          echo "To re-run reviews: close and reopen the PR."
+          echo "To re-run reviews: comment /review on the PR."
 
       - name: Notify agent webhook
         if: always() && needs.get-context.outputs.pr_number != ''


### PR DESCRIPTION
## Summary
- Replaces the broken `pull_request:reopened` trigger with an `issue_comment` trigger that listens for `/review` comments
- The close/reopen approach had a race condition: reopening fired both a direct trigger and a `workflow_run` trigger (via re-triggered PR Tests), causing one to be cancelled by the concurrency group
- `/review` fires a single clean workflow run with no race condition

## What changed
- Added `issue_comment: [created]` trigger with a gate step that validates: PR comment (not issue), `/review` command match, and OWNER/MEMBER/COLLABORATOR authorization
- Comment body is read via `env:` variable (not `${{ }}` interpolation) to prevent command injection
- Adds 👀 reaction to acknowledge the command
- Looks up the latest PR Tests run for the head SHA to correctly set `tests_passed`
- Strips all review progress labels on `/review` to allow full re-review
- Kept `pull_request: [closed]` trigger for label cleanup
- Removed dead `reopened` guard in merge decision job
- Updated help text from "close and reopen" to "comment `/review`"

## Test plan
- [ ] Comment `/review` on an existing PR → should trigger Codex Code Review with 👀 reaction
- [ ] Comment something else on a PR → should NOT trigger
- [ ] Comment `/review` on a plain issue → should NOT trigger
- [ ] Verify review run logs show correct `tests_passed` status
- [ ] Close a PR → review labels should still be cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)