### PR TITLE
Fix devcontainer CLI override config filename rejection

### DIFF
--- a/.github/actions/run-devcontainer/action.yml
+++ b/.github/actions/run-devcontainer/action.yml
@@ -87,9 +87,11 @@ runs:
           WORKSPACE="$WORKSPACE/${{ inputs.workspace_folder }}"
         fi
         SCRIPT_PATH="${{ steps.prepare-script.outputs.script }}"
-        OVERRIDE_CONFIG=$(mktemp /tmp/devcontainer-override-XXXXXX.json)
+        OVERRIDE_DIR=$(mktemp -d /tmp/devcontainer-override-XXXXXX)
+        OVERRIDE_CONFIG="$OVERRIDE_DIR/devcontainer.json"
         cleanup() {
-          rm -f "$OVERRIDE_CONFIG" "$SCRIPT_PATH"
+          rm -rf "$OVERRIDE_DIR"
+          rm -f "$SCRIPT_PATH"
         }
         trap cleanup EXIT
 


### PR DESCRIPTION
## Summary
- `@devcontainers/cli` v0.85.0+ enforces that config files must be named `devcontainer.json` or `.devcontainer.json`
- The `run-devcontainer` action wrote the override config to `/tmp/devcontainer-override-XXXXXX.json`, which the CLI rejects
- Fix: write the override into a temp **directory** so the file can be named `devcontainer.json`

Fixes #243

## Test plan
- [ ] Codex Agent workflow passes on this branch (container starts successfully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)