### PR TITLE
Fix: override SSH mount with empty list instead of removing key

### DIFF
--- a/.github/actions/run-devcontainer/action.yml
+++ b/.github/actions/run-devcontainer/action.yml
@@ -109,7 +109,11 @@ runs:
                 "SSH_AUTH_SOCK is empty or not a live socket; "
                 "stripping SSH agent mount and remoteEnv from override config."
             )
-            config.pop("mounts", None)
+            # Set an empty list rather than removing the key — the
+            # devcontainer CLI merges the override with the base
+            # .devcontainer/devcontainer.json, so omitting the key lets the
+            # base config's mounts pass through.
+            config["mounts"] = []
             remote_env = config.get("remoteEnv", {})
             remote_env.pop("SSH_AUTH_SOCK", None)
             if not remote_env:


### PR DESCRIPTION
## Summary

Follow-up to #248 — the SSH auto-detection was working (log showed the diagnostic message) but the mount still failed because `config.pop("mounts", None)` only removed the key from the override config. The devcontainer CLI merges the override with the base `.devcontainer/devcontainer.json`, so the base config's SSH mount passed through unchanged.

Fix: set `config["mounts"] = []` to explicitly override the base mounts to empty.

## Test plan

- [ ] Re-run the failing resolve-issue workflow — container should start successfully
- [ ] Verify the CI log still shows the "stripping SSH agent mount" diagnostic message

🤖 Generated with [Claude Code](https://claude.com/claude-code)