### PR TITLE
Remove SSH agent mount from devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,11 +13,7 @@
   "initializeCommand": "bash .devcontainer/init-host-credentials.sh",
   "postCreateCommand": "bash .devcontainer/post-create.sh && bash .githooks/install-hooks.sh",
   "postStartCommand": "bash .devcontainer/fix-dns-order.sh && sudo chown -R \"$(id -u):$(id -g)\" /workspaces 2>/dev/null || true",
-  "mounts": [
-    "source=${localEnv:SSH_AUTH_SOCK},target=/run/ssh-agent.sock,type=bind"
-  ],
   "remoteEnv": {
-    "SSH_AUTH_SOCK": "/run/ssh-agent.sock",
     "OPENAI_API_KEY": "fake-key",
     "TERM": "xterm-256color",
     "LANG": "en_US.UTF-8"

--- a/.github/actions/run-devcontainer/action.yml
+++ b/.github/actions/run-devcontainer/action.yml
@@ -82,8 +82,6 @@ runs:
           "$OVERRIDE_CONFIG" \
           "${{ inputs.image }}" <<'PY'
         import json
-        import os
-        import stat
         import sys
 
         source_path, target_path, image = sys.argv[1:4]
@@ -92,33 +90,6 @@ runs:
 
         config.pop("build", None)
         config.pop("initializeCommand", None)
-
-        # Auto-detect whether the host has a usable SSH agent socket.
-        # When missing, strip the SSH bind mount to prevent Docker from
-        # rejecting an empty source path.
-        ssh_sock = os.environ.get("SSH_AUTH_SOCK", "")
-        has_ssh_agent = False
-        if ssh_sock:
-            try:
-                has_ssh_agent = stat.S_ISSOCK(os.stat(ssh_sock).st_mode)
-            except OSError:
-                has_ssh_agent = False
-
-        if not has_ssh_agent:
-            print(
-                "SSH_AUTH_SOCK is empty or not a live socket; "
-                "stripping SSH agent mount and remoteEnv from override config."
-            )
-            # Set an empty list rather than removing the key — the
-            # devcontainer CLI merges the override with the base
-            # .devcontainer/devcontainer.json, so omitting the key lets the
-            # base config's mounts pass through.
-            config["mounts"] = []
-            remote_env = config.get("remoteEnv", {})
-            remote_env.pop("SSH_AUTH_SOCK", None)
-            if not remote_env:
-                config.pop("remoteEnv", None)
-
         config["image"] = image
 
         with open(target_path, "w", encoding="utf-8") as handle:


### PR DESCRIPTION
## Summary

- Removes the SSH agent bind mount and `SSH_AUTH_SOCK` remoteEnv from `devcontainer.json`
- Simplifies `run-devcontainer` action by removing the SSH detection logic (which never worked due to image metadata)

## Root cause

The `devcontainers/ci` build step bakes `devcontainer.json` config into Docker image labels as `devcontainer.metadata`. The devcontainer spec merges mount arrays by **concatenation** (union), so there is no way to override them to empty at runtime. PRs #248 and #249 tried to strip the mount in the override config, but the mount from image metadata always survived.

This is a [known limitation](https://github.com/devcontainers/ci/issues/166) with no upstream fix.

## What this changes

| File | Change |
|------|--------|
| `.devcontainer/devcontainer.json` | Remove `mounts` array and `SSH_AUTH_SOCK` from `remoteEnv` |
| `.github/actions/run-devcontainer/action.yml` | Remove SSH socket detection Python code — no longer needed |

## After merge

The GHCR image needs one rebuild to clear stale metadata. The `build-devcontainer` job in the first triggered workflow will handle this automatically.

## Test plan

- [x] Locally verified: generated override config has no SSH references
- [x] Locally verified: `devcontainer up` produces `docker run` with no SSH mount
- [ ] After merge: verify `resolve-issue` job starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)