### PR TITLE
Fix: create dummy SSH socket when agent is missing in CI

### DIFF
--- a/.github/actions/run-devcontainer/action.yml
+++ b/.github/actions/run-devcontainer/action.yml
@@ -76,14 +76,23 @@ runs:
           docker pull "${{ inputs.image }}"
         fi
 
+        # Ensure SSH_AUTH_SOCK points to a valid socket so that
+        # devcontainer mounts using ${localEnv:SSH_AUTH_SOCK} don't
+        # produce an empty bind-mount source (which Docker rejects).
+        # CI runners typically have no SSH agent; create a dummy socket.
+        # Upstream fix: https://github.com/devcontainers/cli/issues/479
+        if [ -z "${SSH_AUTH_SOCK:-}" ] || [ ! -S "${SSH_AUTH_SOCK:-}" ]; then
+          export SSH_AUTH_SOCK=/tmp/ssh-agent-dummy.sock
+          python3 -c "import socket; s=socket.socket(socket.AF_UNIX); s.bind('$SSH_AUTH_SOCK')"
+          echo "Created dummy SSH agent socket at $SSH_AUTH_SOCK"
+        fi
+
         python3 \
           - \
           "$WORKSPACE/.devcontainer/devcontainer.json" \
           "$OVERRIDE_CONFIG" \
           "${{ inputs.image }}" <<'PY'
         import json
-        import os
-        import stat
         import sys
 
         source_path, target_path, image = sys.argv[1:4]
@@ -92,33 +101,6 @@ runs:
 
         config.pop("build", None)
         config.pop("initializeCommand", None)
-
-        # Auto-detect whether the host has a usable SSH agent socket.
-        # When missing, strip the SSH bind mount to prevent Docker from
-        # rejecting an empty source path.
-        ssh_sock = os.environ.get("SSH_AUTH_SOCK", "")
-        has_ssh_agent = False
-        if ssh_sock:
-            try:
-                has_ssh_agent = stat.S_ISSOCK(os.stat(ssh_sock).st_mode)
-            except OSError:
-                has_ssh_agent = False
-
-        if not has_ssh_agent:
-            print(
-                "SSH_AUTH_SOCK is empty or not a live socket; "
-                "stripping SSH agent mount and remoteEnv from override config."
-            )
-            # Set an empty list rather than removing the key — the
-            # devcontainer CLI merges the override with the base
-            # .devcontainer/devcontainer.json, so omitting the key lets the
-            # base config's mounts pass through.
-            config["mounts"] = []
-            remote_env = config.get("remoteEnv", {})
-            remote_env.pop("SSH_AUTH_SOCK", None)
-            if not remote_env:
-                config.pop("remoteEnv", None)
-
         config["image"] = image
 
         with open(target_path, "w", encoding="utf-8") as handle:


### PR DESCRIPTION
## Summary

Creates a dummy Unix socket file when `SSH_AUTH_SOCK` is unset or stale, so the devcontainer SSH bind mount has a valid source path. This replaces the SSH detection Python code from PRs #248/#249 which couldn't work.

## Why the previous approach failed

The `devcontainers/ci` build step bakes `devcontainer.json` config into Docker image metadata labels. The devcontainer spec merges mount arrays by **concatenation**, so there is no way to override image metadata mounts to empty at runtime — the SSH mount always survives regardless of what the override config says.

## This approach

Instead of trying to remove the mount, make it succeed:

```bash
if [ -z "${SSH_AUTH_SOCK:-}" ] || [ ! -S "${SSH_AUTH_SOCK:-}" ]; then
  export SSH_AUTH_SOCK=/tmp/ssh-agent-dummy.sock
  python3 -c "import socket; s=socket.socket(socket.AF_UNIX); s.bind('$SSH_AUTH_SOCK')"
fi
```

Docker gets a real file to bind-mount, the container starts, CI doesn't need SSH anyway.

## Upstream

Filed devcontainers/cli#1190 — the CLI should skip mounts with empty `${localEnv:}` sources rather than passing them to Docker.

## Test plan

- [x] Locally verified: dummy socket created, `devcontainer up` succeeds, container starts
- [ ] After merge: verify `resolve-issue` job completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)