### PR TITLE
Fix: place dummy SSH socket in workspace, not /tmp

### DIFF
--- a/.github/actions/run-devcontainer/action.yml
+++ b/.github/actions/run-devcontainer/action.yml
@@ -82,7 +82,9 @@ runs:
         # CI runners typically have no SSH agent; create a dummy socket.
         # Upstream fix: https://github.com/devcontainers/cli/issues/479
         if [ -z "${SSH_AUTH_SOCK:-}" ] || [ ! -S "${SSH_AUTH_SOCK:-}" ]; then
-          export SSH_AUTH_SOCK=/tmp/ssh-agent-dummy.sock
+          # Place in workspace so it's visible to the Docker daemon
+          # (runner may be containerized with a separate /tmp).
+          export SSH_AUTH_SOCK="$WORKSPACE/.git/ssh-agent-dummy.sock"
           python3 -c "import socket; s=socket.socket(socket.AF_UNIX); s.bind('$SSH_AUTH_SOCK')"
           echo "Created dummy SSH agent socket at $SSH_AUTH_SOCK"
         fi


### PR DESCRIPTION
## Summary

Follow-up to #251 — the dummy socket was created in `/tmp` which isn't visible to the Docker daemon on the containerized self-hosted runner. Moves it to `$WORKSPACE/.git/` which is on the shared filesystem.

## Test plan

- [ ] Verify `resolve-issue` job starts successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)