### PR TITLE
Set EDITOR=nano in devcontainer for plan viewing

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,8 @@
     "SSH_AUTH_SOCK": "/run/ssh-agent.sock",
     "OPENAI_API_KEY": "fake-key",
     "TERM": "xterm-256color",
-    "LANG": "en_US.UTF-8"
+    "LANG": "en_US.UTF-8",
+    "EDITOR": "nano"
   },
   "customizations": {
     "vscode": {


### PR DESCRIPTION
## Summary
- Adds `EDITOR=nano` to `remoteEnv` in `devcontainer.json`
- Fixes ctrl+g plan viewing in Claude Code, which defaults to VSCode but fails in tmux/devcontainer environments without it

## Test plan
- [ ] Rebuild devcontainer and verify `echo $EDITOR` outputs `nano`
- [ ] Run Claude Code, create a plan, press ctrl+g — should open in nano

🤖 Generated with [Claude Code](https://claude.com/claude-code)