### PR TITLE
Make pull-main.sh self-contained (zero agent tokens)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,7 +162,7 @@ The following restrictions apply to the **OpenClaw runtime agent** — the conve
 - Infrastructure & CI files are outside this restriction — but the OpenClaw agent should still file issues rather than editing them directly, since CI changes warrant review.
 - This restriction is about repo-managed content, not OpenClaw runtime features. Keep using OpenClaw heartbeat, durable cron, bootstrap loading, hooks, and messaging as documented.
 - OpenClaw-owned runtime state (for example cron registrations and task records stored outside the repo) is not "managed content" for this rule.
-- Outside explicit operational recovery procedures in `HEARTBEAT.md` and `setup/cron/pull-main.md`, the only files the OpenClaw agent may write to directly are `state.json`, `memory/`, `MEMORY.md`, `USER.md`, `.env`, and `.reminder-signal`.
+- Outside the self-contained dirty-pull recovery path in `scripts/pull-main.sh` (with `HEARTBEAT.md` only retrying stale `.pull-dirty` signals when recovery did not complete), the only files the OpenClaw agent may write to directly are `state.json`, `memory/`, `MEMORY.md`, `USER.md`, `.env`, and `.reminder-signal`.
 
 ## Memory
 

--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -14,7 +14,7 @@ Verify that durable cron jobs are registered. If any are missing, re-register th
 |-----|----------|--------|
 | reminder-check | `*/5 * * * *` | Run `scripts/check-reminders.sh`; if it writes `.reminder-signal`, read it, deliver reminders, update Notion, delete the file |
 | pipeline-monitor | `*/2 * * * *` | Run `scripts/check-github-status.sh`, report actionable changes |
-| pull-main | `*/10 * * * *` | Run `scripts/pull-main.sh`, handle dirty pulls |
+| pull-main | `*/10 * * * *` | Run `scripts/pull-main.sh`; the script handles dirty-pull recovery |
 
 To check: use CronList. If a job is missing (7-day auto-expiry), re-create it with CronCreate (durable: true) using the schedule, prompt, and options from `setup/cron/`. `reminder-check` and `pull-main` must inject into the main agent session with `sessionTarget: main`, `payload.kind: systemEvent`, `delivery.mode: none`, and `timeout-seconds: 120`. `pipeline-monitor` must stay isolated from `main`; re-create it without `sessionTarget` (or with a dedicated non-main target) so GitHub-derived content never persists in the shared user session. Cron jobs should never deliver directly to Signal or any other channel on their own.
 
@@ -39,8 +39,8 @@ If all jobs already match their specs, do not report anything. If any jobs were 
 
 ### 5. Dirty Pull Recovery (safety net)
 - If `.pull-dirty` exists and is older than 20 minutes, the pull-main cron may have failed to recover
-- Run `scripts/pull-main.sh --recover-only` to retry (the script creates the GitHub issue and resets the repo)
-- If that also fails, note the failure for operator attention
-- Normally the pull-main cron handles recovery automatically — this check is a backstop for cases where `gh` wasn't authenticated or the script errored
+- Run `scripts/pull-main.sh --recover-only` to retry after the underlying problem is fixed (for example restoring `gh` authentication). The script creates the GitHub issue and resets the repo when recovery can proceed.
+- If recovery still does not complete, note the failure for operator attention
+- Normally the pull-main cron handles recovery automatically. This check is a backstop for cases where `gh` was not authenticated or the script errored; until `gh` auth is restored, heartbeat will preserve `.pull-dirty` and surface the problem rather than clearing it
 
 That's it. If nothing needs attention, reply HEARTBEAT_OK.

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -53,7 +53,7 @@ OpenClaw runtime features still operate normally:
 - Cron registrations and task records live in OpenClaw-owned runtime state outside this repo checkout.
 - Messaging, session lifecycle, and hooks remain platform responsibilities.
 
-The one repo-mutating runtime exception is dirty-pull recovery in `scripts/pull-main.sh`: preserve the local diff in a GitHub issue, then reset the workspace to match remote so the GitHub-reviewed branch stays the source of truth. The script handles this entirely — the agent never reasons about it. That exception exists to reduce merge conflicts and recover safely, not to bypass the GitHub process.
+The one repo-mutating runtime exception is dirty-pull recovery in `scripts/pull-main.sh`: preserve the local diff in a GitHub issue, then reset the workspace to match remote so the GitHub-reviewed branch stays the source of truth. The normal `pull-main` cron path is script-managed; `HEARTBEAT.md` remains the retry backstop if `.pull-dirty` persists after an auth or recovery failure. That exception exists to reduce merge conflicts and recover safely, not to bypass the GitHub process.
 
 ## Cron (Durable Scheduled Jobs)
 
@@ -65,7 +65,7 @@ OpenClaw provides `CronCreate` for scheduling recurring agent prompts. With `dur
 |-----|----------|----------|
 | `reminder-check` | `*/5 * * * *` | `reminder-daemon.sh` (bash while-loop) |
 | `pipeline-monitor` | `*/2 * * * *` | `monitor-pipeline.sh` (bash while-loop) |
-| `pull-main` | `*/10 * * * *` | Manual `git pull origin main` hygiene (script is self-contained — agent just runs it, no reasoning) |
+| `pull-main` | `*/10 * * * *` | Manual `git pull origin main` hygiene (normal path is script-managed; heartbeat retries stale recovery signals) |
 
 **Why this is better than daemons:**
 - No PID files, no silent death, no orphaned processes

--- a/scripts/pull-main.sh
+++ b/scripts/pull-main.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
-# pull-main.sh — Pull origin/main, self-contained (no agent reasoning needed)
+# pull-main.sh — Pull origin/main with script-managed dirty-pull recovery
 #
 # Runs on a 10-minute cron. Clean pulls happen silently. If the working tree
 # has uncommitted tracked-file changes or the pull hits a merge conflict, the
 # script creates a GitHub issue preserving the changes, then resets the repo.
-# The agent never needs to reason about pull state — it just runs this script.
+# The normal cron path never needs pull-state reasoning. HEARTBEAT only retries
+# stale recovery after operator fixes (for example restoring `gh` auth).
 #
 # SECURITY PROPERTIES:
 #   - Signal file contains diffs of tracked files only — no secrets
@@ -113,30 +114,12 @@ recover_dirty_pull() {
     local reason
     reason=$(echo "$signal_json" | python3 -c "import json,sys; print(json.load(sys.stdin).get('reason','unknown'))" 2>/dev/null || echo "unknown")
 
-    # Gather recent memory context (last 2 days, truncated)
-    local memory_context=""
-    local today yesterday
-    today=$(date -u +%Y-%m-%d)
-    yesterday=$(date -u -d "yesterday" +%Y-%m-%d 2>/dev/null || date -u -v-1d +%Y-%m-%d 2>/dev/null || echo "")
-
-    for datefile in "$ROOT_DIR/memory/$today.md" "$ROOT_DIR/memory/$yesterday.md"; do
-        if [ -f "$datefile" ]; then
-            local content
-            content=$(head -100 "$datefile")
-            memory_context="${memory_context}### $(basename "$datefile")
-${content}
-
-"
-        fi
-    done
-
     # Build the issue body
     local issue_body
-    issue_body=$(SIGNAL_JSON="$signal_json" MEMORY_CONTEXT="$memory_context" python3 -c "
+    issue_body=$(SIGNAL_JSON="$signal_json" python3 -c "
 import json, os
 
 signal = json.loads(os.environ['SIGNAL_JSON'])
-memory = os.environ.get('MEMORY_CONTEXT', '').strip()
 reason = signal.get('reason', 'unknown')
 head = signal.get('head_commit', 'unknown')
 remote = signal.get('remote_head', 'unknown')
@@ -168,9 +151,14 @@ elif reason == 'merge_conflict':
         for c in conflicts:
             body += f'- {c}\n'
         body += '\n'
-
-if memory:
-    body += f'## Memory context\n\n{memory}\n\n'
+    commits = signal.get('local_commits', [])
+    if commits:
+        body += '**Local commits pending merge:**\n'
+        for commit in commits:
+            body += f'- {commit}\n'
+        body += '\n'
+    body += '**Local diff preserved before reset:**\n'
+    body += f\"\`\`\`diff\n{signal.get('local_diff', '(no diff captured)')}\n\`\`\`\n\n\"
 
 body += '---\n*Auto-created by pull-main.sh — local changes preserved here before reset.*'
 
@@ -239,16 +227,26 @@ fi
 # 3. Pull failed — likely a merge conflict
 # Capture conflicting files before aborting
 conflicting=$(git diff --name-only --diff-filter=U 2>/dev/null || true)
+merge_base=$(git merge-base HEAD origin/main 2>/dev/null || true)
+local_commits=""
+local_diff=""
+
+if [ -n "$merge_base" ]; then
+    local_commits=$(git log --oneline "$merge_base..HEAD" 2>/dev/null || true)
+    local_diff=$(git diff "$merge_base..HEAD" 2>/dev/null || true)
+fi
 
 # Abort the failed merge to restore a usable state
 git merge --abort 2>/dev/null || true
 
 # Build extra fields for the signal — single python3 call for both values
-extra_json=$(PULL_OUTPUT="$pull_output" CONFLICTING="$conflicting" python3 -c "
+extra_json=$(PULL_OUTPUT="$pull_output" CONFLICTING="$conflicting" LOCAL_COMMITS="$local_commits" LOCAL_DIFF="$local_diff" python3 -c "
 import json, os
 print(json.dumps({
     'error_output': os.environ['PULL_OUTPUT'],
     'conflicting_files': [f for f in os.environ['CONFLICTING'].strip().split('\n') if f],
+    'local_commits': [c for c in os.environ['LOCAL_COMMITS'].strip().split('\n') if c],
+    'local_diff': os.environ['LOCAL_DIFF'],
 }))
 " 2>/dev/null || echo '{"error_output":"(could not capture)","conflicting_files":[]}')
 

--- a/setup/cron/pull-main.md
+++ b/setup/cron/pull-main.md
@@ -1,6 +1,6 @@
 # Cron Job: pull-main
 
-Keeps the local workspace in sync with origin/main. The script is fully self-contained — it handles clean pulls, dirty-state recovery (GitHub issue creation + repo reset), and conflict resolution without any agent reasoning.
+Keeps the local workspace in sync with origin/main. The normal cron run is script-driven: `scripts/pull-main.sh` handles clean pulls plus dirty-state recovery (GitHub issue creation + repo reset) without task-specific agent reasoning. HEARTBEAT remains the retry backstop if `.pull-dirty` persists.
 
 ## Registration
 
@@ -17,7 +17,7 @@ CronCreate:
   timeout-seconds: 120
 ```
 
-This job injects a `systemEvent` into the main agent session. The prompt is trivial because the script handles all logic — the agent never needs to reason about pull state.
+This job injects a `systemEvent` into the main agent session. The prompt is trivial because the script handles the normal pull and recovery flow; heartbeat only retries stale recovery signals when needed.
 
 ## Prompt
 
@@ -29,6 +29,6 @@ Reply with ONLY: NO_REPLY
 ## Notes
 
 - The script handles everything: clean pulls silently, dirty pulls by creating a GitHub issue (preserving local changes) and resetting the repo. The agent's only job is to run the script.
-- If `gh` is not authenticated, the script leaves `.pull-dirty` in place for the HEARTBEAT backstop (section 5) to retry via `scripts/pull-main.sh --recover-only`.
+- If `gh` is not authenticated, the script leaves `.pull-dirty` in place for the HEARTBEAT backstop (section 5) to retry via `scripts/pull-main.sh --recover-only` after auth is restored. Until then, heartbeat only preserves the signal and surfaces the problem for operator attention.
 - Cron jobs auto-expire after 7 days. HEARTBEAT.md re-registers the job if missing and patches it back to this spec if the live registration drifts.
 - The GitHub issue preserves local changes for PR-based review before they're incorporated back into the system. This enforces the design principle that structural/prompt changes go through external review.


### PR DESCRIPTION
## Summary

- Moved dirty-pull recovery logic (GitHub issue creation + repo reset) from the OpenClaw cron prompt into `scripts/pull-main.sh` itself
- Cron prompt reduced from a 15-line recovery playbook to 2 lines: "Run the script. Reply NO_REPLY."
- Added `--recover-only` flag for HEARTBEAT backstop retries
- Script falls back gracefully if `gh` isn't authenticated (leaves `.pull-dirty` for HEARTBEAT)

The agent never reasons about pull state anymore. Clean pulls cost minimal tokens (just the trivial prompt + NO_REPLY). Dirty pulls are handled entirely in bash via `gh issue create`.

## Test plan

- [ ] Run `scripts/pull-main.sh` on a clean repo — pulls silently, no `.pull-dirty`
- [ ] Create a local tracked-file change, run the script — creates GH issue, resets, cleans up
- [ ] Run with `--recover-only` when `.pull-dirty` exists — recovers
- [ ] Run with `--recover-only` when no `.pull-dirty` — exits silently
- [ ] Verify `gh auth status` failure path: leaves `.pull-dirty` intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)