### PR TITLE
Unset SSH_AUTH_SOCK before devcontainer up in CI

### DIFF
--- a/.github/actions/run-devcontainer/action.yml
+++ b/.github/actions/run-devcontainer/action.yml
@@ -76,6 +76,12 @@ runs:
           docker pull "${{ inputs.image }}"
         fi
 
+        # Unset SSH_AUTH_SOCK so the devcontainer CLI doesn't resolve
+        # ${localEnv:SSH_AUTH_SOCK} to an empty bind-mount source.
+        # The devcontainer.json mounts the host SSH agent for local dev;
+        # CI has no agent, so we strip the reference entirely.
+        unset SSH_AUTH_SOCK
+
         python3 \
           - \
           "$WORKSPACE/.devcontainer/devcontainer.json" \


### PR DESCRIPTION
## Summary
- The devcontainer CLI resolves `${localEnv:SSH_AUTH_SOCK}` from the host environment **before** applying config overrides, so PR #270's approach of stripping the mount from the override config is not sufficient
- When `SSH_AUTH_SOCK` is empty/unset on CI runners, Docker rejects the mount: `invalid value for 'source': value is empty`
- This unsets the variable before `devcontainer up` so the CLI skips the mount entirely
- The SSH agent mount in `devcontainer.json` continues to work for local dev where `SSH_AUTH_SOCK` is set

## Test plan
- [ ] Verify CI devcontainer jobs (agent reviews, Codex) no longer fail with empty SSH mount source
- [ ] Verify local devcontainer still forwards SSH agent when `SSH_AUTH_SOCK` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)