### PR TITLE
Remove SSH agent forwarding from devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,11 +13,7 @@
   "initializeCommand": "bash .devcontainer/init-host-credentials.sh",
   "postCreateCommand": "bash .devcontainer/post-create.sh && bash .githooks/install-hooks.sh",
   "postStartCommand": "bash .devcontainer/fix-dns-order.sh && sudo chown -R \"$(id -u):$(id -g)\" /workspaces 2>/dev/null || true",
-  "mounts": [
-    "source=${localEnv:SSH_AUTH_SOCK},target=/run/ssh-agent.sock,type=bind"
-  ],
   "remoteEnv": {
-    "SSH_AUTH_SOCK": "/run/ssh-agent.sock",
     "OPENAI_API_KEY": "fake-key",
     "TERM": "xterm-256color",
     "LANG": "en_US.UTF-8",

--- a/.github/actions/run-devcontainer/action.yml
+++ b/.github/actions/run-devcontainer/action.yml
@@ -76,12 +76,6 @@ runs:
           docker pull "${{ inputs.image }}"
         fi
 
-        # Unset SSH_AUTH_SOCK so the devcontainer CLI doesn't resolve
-        # ${localEnv:SSH_AUTH_SOCK} to an empty bind-mount source.
-        # The devcontainer.json mounts the host SSH agent for local dev;
-        # CI has no agent, so we strip the reference entirely.
-        unset SSH_AUTH_SOCK
-
         python3 \
           - \
           "$WORKSPACE/.devcontainer/devcontainer.json" \
@@ -96,29 +90,6 @@ runs:
 
         config.pop("build", None)
         config.pop("initializeCommand", None)
-
-        mounts = config.get("mounts", [])
-        filtered_mounts = []
-        for mount in mounts:
-            if isinstance(mount, str):
-                if "SSH_AUTH_SOCK" in mount or "/run/ssh-agent.sock" in mount:
-                    continue
-            elif isinstance(mount, dict):
-                source = str(mount.get("source", ""))
-                target = str(mount.get("target", ""))
-                if "SSH_AUTH_SOCK" in source or target == "/run/ssh-agent.sock":
-                    continue
-            filtered_mounts.append(mount)
-
-        if filtered_mounts:
-            config["mounts"] = filtered_mounts
-        else:
-            config.pop("mounts", None)
-
-        remote_env = config.get("remoteEnv", {})
-        remote_env.pop("SSH_AUTH_SOCK", None)
-        if not remote_env:
-            config.pop("remoteEnv", None)
 
         config["image"] = image
 


### PR DESCRIPTION
## Summary
- Removes `SSH_AUTH_SOCK` mount and `remoteEnv` entry from `devcontainer.json` entirely
- Removes the SSH mount filtering and env unsetting workarounds from the CI action (no longer needed)
- The SSH mount was causing all CI devcontainer jobs to fail with `invalid value for 'source': value is empty` because the devcontainer CLI resolves `${localEnv:SSH_AUTH_SOCK}` before any override config takes effect
- Multiple prior workaround attempts (dummy sockets in #260, config filtering in #270, env unsetting in #280) all failed for this reason

## Test plan
- [ ] CI devcontainer jobs pass (no more empty SSH mount source)
- [ ] Local devcontainer still starts without the SSH mount

🤖 Generated with [Claude Code](https://claude.com/claude-code)