### PR TITLE
Stabilize Codex review devcontainer startup

### DIFF
--- a/.github/actions/run-devcontainer/action.yml
+++ b/.github/actions/run-devcontainer/action.yml
@@ -1,10 +1,9 @@
 ---
 name: Run command in devcontainer
 description: >
-  Runs a command inside a pre-built devcontainer image using the
-  devcontainer CLI directly, avoiding the devcontainers/ci post-step
-  cleanup crash while preserving the repository's devcontainer
-  lifecycle hooks.
+  Runs a command inside a pre-built devcontainer image with docker run,
+  avoiding the devcontainer CLI startup path that rebuilds feature
+  layers on the runner.
 
 inputs:
   image:
@@ -63,62 +62,125 @@ runs:
           WORKSPACE="$WORKSPACE/${{ inputs.workspace_folder }}"
         fi
         SCRIPT_PATH="${{ steps.prepare-script.outputs.script }}"
-        OVERRIDE_DIR=$(mktemp -d /tmp/devcontainer-override-XXXXXX)
-        OVERRIDE_CONFIG="$OVERRIDE_DIR/devcontainer.json"
+        METADATA_FILE=$(mktemp /tmp/devcontainer-metadata-XXXXXX.json)
+        REMOTE_ENV_FILE=$(mktemp /tmp/devcontainer-remote-env-XXXXXX)
         cleanup() {
-          rm -rf "$OVERRIDE_DIR"
+          rm -rf "${HOST_CONTAINER_HOME:-}"
+          rm -f "$METADATA_FILE"
+          rm -f "$REMOTE_ENV_FILE"
           rm -f "$SCRIPT_PATH"
         }
         trap cleanup EXIT
 
-        # Optionally pull the image
         if [ "${{ inputs.pull }}" != "false" ]; then
-          docker pull "${{ inputs.image }}"
+          if ! docker pull "${{ inputs.image }}"; then
+            echo "docker pull failed; checking for a cached local image..."
+            if docker image inspect "${{ inputs.image }}" > /dev/null 2>&1; then
+              echo "Using cached local image: ${{ inputs.image }}"
+            else
+              echo "Image is unavailable locally and could not be pulled." >&2
+              exit 1
+            fi
+          fi
         fi
 
         python3 \
           - \
           "$WORKSPACE/.devcontainer/devcontainer.json" \
-          "$OVERRIDE_CONFIG" \
-          "${{ inputs.image }}" <<'PY'
+          "$METADATA_FILE" <<'PY'
         import json
         import sys
 
-        source_path, target_path, image = sys.argv[1:4]
+        source_path, target_path = sys.argv[1:3]
         with open(source_path, "r", encoding="utf-8") as handle:
             config = json.load(handle)
 
-        config.pop("build", None)
-        config.pop("initializeCommand", None)
-
-        config["image"] = image
-
+        metadata = {
+            "remoteEnv": config.get("remoteEnv", {}),
+            "remoteUser": config.get("remoteUser", "root"),
+        }
         with open(target_path, "w", encoding="utf-8") as handle:
-            json.dump(config, handle, indent=2)
+            json.dump(metadata, handle, indent=2)
             handle.write("\n")
         PY
 
-        # Forward remote env vars to both lifecycle hooks and the target
-        # command.
-        REMOTE_ENV_ARGS=()
+        IMAGE_USER=$(python3 - "$METADATA_FILE" <<'PY'
+        import json
+        import sys
+
+        with open(sys.argv[1], "r", encoding="utf-8") as handle:
+            print(json.load(handle).get("remoteUser", "root"))
+        PY
+        )
+        if [ "$IMAGE_USER" = "root" ] || [ "$IMAGE_USER" = "0" ]; then
+          IMAGE_USER_HOME="/root"
+        else
+          IMAGE_USER_HOME="/home/$IMAGE_USER"
+        fi
+
+        WORKSPACE_UID=$(stat -c '%u' "$WORKSPACE")
+        WORKSPACE_GID=$(stat -c '%g' "$WORKSPACE")
+        CONTAINER_HOME="/tmp/codex-home"
+        HOST_CONTAINER_HOME=$(mktemp -d /tmp/devcontainer-home-XXXXXX)
+        mkdir -p "$HOST_CONTAINER_HOME/.config" "$HOST_CONTAINER_HOME/.claude" "$HOST_CONTAINER_HOME/.codex"
+        chmod 700 "$HOST_CONTAINER_HOME"
+
+        CONTAINER_WORKSPACE="/workspaces/$(basename "$WORKSPACE")"
+        CONTAINER_WORKDIR="$CONTAINER_WORKSPACE"
+        if [ "${{ inputs.workdir }}" != "." ]; then
+          CONTAINER_WORKDIR="$CONTAINER_WORKSPACE/${{ inputs.workdir }}"
+        fi
+
+        python3 - "$METADATA_FILE" > "$REMOTE_ENV_FILE" <<'PY'
+        import json
+        import sys
+
+        with open(sys.argv[1], "r", encoding="utf-8") as handle:
+            remote_env = json.load(handle).get("remoteEnv", {})
+
+        for key, value in remote_env.items():
+            print(f"{key}={value}")
+        PY
+
+        ENV_ARGS=()
         while IFS= read -r line; do
           [[ -z "$line" || "$line" == \#* ]] && continue
-          REMOTE_ENV_ARGS+=( --remote-env "$line" )
+          ENV_ARGS+=( -e "$line" )
+        done < "$REMOTE_ENV_FILE"
+
+        while IFS= read -r line; do
+          [[ -z "$line" || "$line" == \#* ]] && continue
+          ENV_ARGS+=( -e "$line" )
         done <<'ENVEOF'
         ${{ inputs.env }}
         ENVEOF
 
-        npx -y @devcontainers/cli up \
-          --workspace-folder "$WORKSPACE" \
-          --config "$OVERRIDE_CONFIG" \
-          --remove-existing-container \
-          --skip-post-attach \
-          "${REMOTE_ENV_ARGS[@]}"
+        for passthrough in CI GITHUB_ACTIONS; do
+          if [ -n "${!passthrough:-}" ]; then
+            ENV_ARGS+=( -e "$passthrough=${!passthrough}" )
+          fi
+        done
+        ENV_ARGS+=(
+          -e "HOME=$CONTAINER_HOME"
+          -e "PATH=$IMAGE_USER_HOME/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+          -e "XDG_CONFIG_HOME=$CONTAINER_HOME/.config"
+        )
+
+        VOLUME_ARGS=(
+          -v "$WORKSPACE:$CONTAINER_WORKSPACE"
+          -v "$HOST_CONTAINER_HOME:$CONTAINER_HOME"
+        )
+
+        if [ -S /var/run/docker.sock ]; then
+          VOLUME_ARGS+=( -v /var/run/docker.sock:/var/run/docker.sock )
+        fi
 
         SCRIPT_NAME=$(basename "$SCRIPT_PATH")
 
-        npx -y @devcontainers/cli exec \
-          --workspace-folder "$WORKSPACE" \
-          --config "$OVERRIDE_CONFIG" \
-          "${REMOTE_ENV_ARGS[@]}" \
-          bash -lc "bash '.git/$SCRIPT_NAME'"
+        docker run --rm --init \
+          --user "$WORKSPACE_UID:$WORKSPACE_GID" \
+          --workdir "$CONTAINER_WORKDIR" \
+          "${ENV_ARGS[@]}" \
+          "${VOLUME_ARGS[@]}" \
+          "${{ inputs.image }}" \
+          bash -lc "if [ -x .devcontainer/fix-dns-order.sh ]; then bash .devcontainer/fix-dns-order.sh || true; fi; bash '.git/$SCRIPT_NAME'"

--- a/.github/workflows/codex-code-review.yml
+++ b/.github/workflows/codex-code-review.yml
@@ -517,7 +517,9 @@ jobs:
         run: mkdir -p ~/.config/gh ~/.claude ~/.codex
 
       - name: Log in to GHCR
+        id: ghcr_login
         uses: docker/login-action@v3
+        continue-on-error: true
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -525,6 +527,7 @@ jobs:
 
       - name: Build and push devcontainer
         id: build_devcontainer
+        if: steps.ghcr_login.outcome == 'success'
         uses: devcontainers/ci@v0.3
         # continue-on-error: Post-action cleanup may fail on GHCR push
         # even when the image builds successfully. Downstream review jobs
@@ -536,16 +539,29 @@ jobs:
           push: always
 
       - name: Validate devcontainer image availability
-        if: steps.build_devcontainer.outcome != 'success'
+        if: steps.ghcr_login.outcome != 'success' || steps.build_devcontainer.outcome != 'success'
         run: |
-          echo "Build step did not succeed (outcome: ${{ steps.build_devcontainer.outcome }})"
+          if [ "${{ steps.ghcr_login.outcome }}" != "success" ]; then
+            echo "GHCR login did not succeed (outcome: ${{ steps.ghcr_login.outcome }})."
+          fi
+
+          if [ "${{ steps.build_devcontainer.outcome }}" != "success" ]; then
+            echo "Build step did not succeed (outcome: ${{ steps.build_devcontainer.outcome }})."
+          fi
+
+          if docker image inspect "${{ env.DEVCONTAINER_IMAGE }}" > /dev/null 2>&1; then
+            echo "Image is already cached locally on the runner."
+            exit 0
+          fi
+
           echo "Checking if the image is available in the registry..."
           if docker manifest inspect "${{ env.DEVCONTAINER_IMAGE }}" > /dev/null 2>&1; then
-            echo "Image is available — the build likely succeeded but post-step cleanup crashed."
-          else
-            echo "Image is NOT available — the build genuinely failed."
-            exit 1
+            echo "Image is available in GHCR - the build/login failure was non-blocking."
+            exit 0
           fi
+
+          echo "Devcontainer image is unavailable locally and in GHCR."
+          exit 1
 
   # Fix test failures - runs in a retry loop until tests pass (max 3 attempts)
   fix-test-failures:
@@ -606,6 +622,7 @@ jobs:
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
+        continue-on-error: true
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -925,6 +942,7 @@ jobs:
       - name: Log in to GHCR
         if: steps.setup.outputs.verified == 'true'
         uses: docker/login-action@v3
+        continue-on-error: true
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -1152,6 +1170,7 @@ jobs:
       - name: Log in to GHCR
         if: steps.setup.outputs.verified == 'true'
         uses: docker/login-action@v3
+        continue-on-error: true
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -1342,6 +1361,7 @@ jobs:
       - name: Log in to GHCR
         if: steps.setup.outputs.verified == 'true'
         uses: docker/login-action@v3
+        continue-on-error: true
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -1584,6 +1604,7 @@ jobs:
       - name: Log in to GHCR
         if: steps.setup.outputs.verified == 'true'
         uses: docker/login-action@v3
+        continue-on-error: true
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -1786,6 +1807,7 @@ jobs:
       - name: Log in to GHCR
         if: steps.setup.outputs.verified == 'true'
         uses: docker/login-action@v3
+        continue-on-error: true
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -2004,6 +2026,7 @@ jobs:
       - name: Log in to GHCR
         if: steps.setup.outputs.verified == 'true'
         uses: docker/login-action@v3
+        continue-on-error: true
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
Resolves #286

## Summary
- replace the shared `run-devcontainer` action's `@devcontainers/cli up` bootstrap with a direct `docker run` path against the prebuilt image
- run review containers as the mounted workspace owner with an isolated writable home so review jobs can still edit, commit, and push from the mounted checkout
- make GHCR login non-fatal in `codex-code-review.yml` and fall back to cached or already-published devcontainer images before failing the workflow

## Test Plan
- `shellcheck scripts/*.sh`
- `yamllint .github/workflows/*.yml`
- run the repository's internal docs link existence check across `docs/` and `design/`
- `actionlint .github/workflows/*.yml`

Generated with Codex
