### PR TITLE
Downgrade 3 review stages to gpt-5-mini for ~45% cost savings

### DIFF
--- a/.github/workflows/codex-code-review.yml
+++ b/.github/workflows/codex-code-review.yml
@@ -1355,6 +1355,7 @@ jobs:
           workspace_folder: ${{ env.PR_WORKSPACE_PATH }}
           pull: 'true'
           env: |
+            CODEX_MODEL=gpt-5-mini
             OPENAI_API_KEY=fake-key
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
@@ -1597,6 +1598,7 @@ jobs:
           workspace_folder: ${{ env.PR_WORKSPACE_PATH }}
           pull: 'true'
           env: |
+            CODEX_MODEL=gpt-5-mini
             OPENAI_API_KEY=fake-key
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
@@ -1799,6 +1801,7 @@ jobs:
           workspace_folder: ${{ env.PR_WORKSPACE_PATH }}
           pull: 'true'
           env: |
+            CODEX_MODEL=gpt-5-mini
             OPENAI_API_KEY=fake-key
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}


### PR DESCRIPTION
## Summary
- Downgrades psych research, docs consistency, and prompt engineering reviews from `gpt-5.4` to `gpt-5-mini`
- Design review, security review, and merge decision stay on `gpt-5.4`
- Uses the existing `CODEX_MODEL` env var override in `configure-codex.sh` — no infra changes needed

## Cost impact
| Tier | Input | Output | Stages |
|------|-------|--------|--------|
| gpt-5.4 (Standard) | $2.50/M | $15/M | design, security, merge decision |
| gpt-5-mini (Mini) | $0.25/M | $2.00/M | psych, docs, prompt |

~45% reduction in total review pipeline model costs.

## Test plan
- [ ] Verify workflow runs successfully on this PR
- [ ] Check Codex CLI logs confirm `gpt-5-mini` for the 3 downgraded stages
- [ ] Compare review comment quality across a few PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)