### PR TITLE
Stop forcing mini model in Codex review jobs

### DIFF
--- a/.github/workflows/codex-code-review.yml
+++ b/.github/workflows/codex-code-review.yml
@@ -1355,7 +1355,6 @@ jobs:
           workspace_folder: ${{ env.PR_WORKSPACE_PATH }}
           pull: 'true'
           env: |
-            CODEX_MODEL=gpt-5-mini
             OPENAI_API_KEY=fake-key
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
@@ -1598,7 +1597,6 @@ jobs:
           workspace_folder: ${{ env.PR_WORKSPACE_PATH }}
           pull: 'true'
           env: |
-            CODEX_MODEL=gpt-5-mini
             OPENAI_API_KEY=fake-key
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
@@ -1801,7 +1799,6 @@ jobs:
           workspace_folder: ${{ env.PR_WORKSPACE_PATH }}
           pull: 'true'
           env: |
-            CODEX_MODEL=gpt-5-mini
             OPENAI_API_KEY=fake-key
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}


### PR DESCRIPTION
Resolves #294

## Summary
Removed the `CODEX_MODEL=gpt-5-mini` overrides from the psych, docs, and prompt review jobs in `.github/workflows/codex-code-review.yml` so they inherit the known-good default from `.devcontainer/configure-codex.sh` (`gpt-5.4`).

## Test Plan
- `shellcheck scripts/*.sh`
- `yamllint .github/workflows/*.yml`
- Verified local markdown documentation links resolve from `README.md` and `docs/*.md`
- Confirmed `.github/workflows/codex-code-review.yml` no longer sets `CODEX_MODEL=gpt-5-mini` for those three review jobs

Generated with Codex