### PR TITLE
Use stable default Codex model for review jobs

### DIFF
--- a/.github/workflows/codex-code-review.yml
+++ b/.github/workflows/codex-code-review.yml
@@ -1354,8 +1354,9 @@ jobs:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           workspace_folder: ${{ env.PR_WORKSPACE_PATH }}
           pull: 'true'
+          # Use the shared stable default configured in .devcontainer/configure-codex.sh.
+          # The gpt-5-mini LiteLLM path has produced invalid tool-call transcripts in CI.
           env: |
-            CODEX_MODEL=gpt-5-mini
             OPENAI_API_KEY=fake-key
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
@@ -1597,8 +1598,9 @@ jobs:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           workspace_folder: ${{ env.PR_WORKSPACE_PATH }}
           pull: 'true'
+          # Use the shared stable default configured in .devcontainer/configure-codex.sh.
+          # The gpt-5-mini LiteLLM path has produced invalid tool-call transcripts in CI.
           env: |
-            CODEX_MODEL=gpt-5-mini
             OPENAI_API_KEY=fake-key
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
@@ -1800,8 +1802,9 @@ jobs:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           workspace_folder: ${{ env.PR_WORKSPACE_PATH }}
           pull: 'true'
+          # Use the shared stable default configured in .devcontainer/configure-codex.sh.
+          # The gpt-5-mini LiteLLM path has produced invalid tool-call transcripts in CI.
           env: |
-            CODEX_MODEL=gpt-5-mini
             OPENAI_API_KEY=fake-key
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}


### PR DESCRIPTION
Resolves #296

## Summary
- stop overriding the psych, docs, and prompt review jobs to `gpt-5-mini`
- let those jobs use the stable default Codex model configured in `.devcontainer/configure-codex.sh`
- document in the workflow why the override was removed so the CI regression does not get reintroduced

## Test Plan
- run `shellcheck scripts/*.sh`
- run `yamllint .github/workflows/*.yml`
- confirm `.github/workflows/codex-code-review.yml` no longer sets `CODEX_MODEL=gpt-5-mini` for the affected review jobs

Generated with Codex