### PR TITLE
Use the default Codex CI model in review jobs

### DIFF
--- a/.github/workflows/codex-code-review.yml
+++ b/.github/workflows/codex-code-review.yml
@@ -1355,7 +1355,6 @@ jobs:
           workspace_folder: ${{ env.PR_WORKSPACE_PATH }}
           pull: 'true'
           env: |
-            CODEX_MODEL=gpt-5-mini
             OPENAI_API_KEY=fake-key
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
@@ -1598,7 +1597,6 @@ jobs:
           workspace_folder: ${{ env.PR_WORKSPACE_PATH }}
           pull: 'true'
           env: |
-            CODEX_MODEL=gpt-5-mini
             OPENAI_API_KEY=fake-key
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
@@ -1801,7 +1799,6 @@ jobs:
           workspace_folder: ${{ env.PR_WORKSPACE_PATH }}
           pull: 'true'
           env: |
-            CODEX_MODEL=gpt-5-mini
             OPENAI_API_KEY=fake-key
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}


### PR DESCRIPTION
Resolves #298

## Summary
Removed the hardcoded `CODEX_MODEL=gpt-5-mini` override from the psych-review, docs-review, and prompt-review jobs in `.github/workflows/codex-code-review.yml`.
This lets those review jobs inherit the CI default from `.devcontainer/configure-codex.sh` (`gpt-5.4`), which matches the repo’s current Codex tool-calling configuration.

## Test Plan
- `shellcheck scripts/*.sh`
- `yamllint .github/workflows/*.yml`
- Internal markdown link check via `python3` against repo `.md` files

Generated with Codex