### PR TITLE
Stop forcing mini model in Codex review jobs

### DIFF
--- a/.github/workflows/codex-code-review.yml
+++ b/.github/workflows/codex-code-review.yml
@@ -1355,7 +1355,6 @@ jobs:
           workspace_folder: ${{ env.PR_WORKSPACE_PATH }}
           pull: 'true'
           env: |
-            CODEX_MODEL=gpt-5-mini
             OPENAI_API_KEY=fake-key
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
@@ -1598,7 +1597,6 @@ jobs:
           workspace_folder: ${{ env.PR_WORKSPACE_PATH }}
           pull: 'true'
           env: |
-            CODEX_MODEL=gpt-5-mini
             OPENAI_API_KEY=fake-key
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
@@ -1801,7 +1799,6 @@ jobs:
           workspace_folder: ${{ env.PR_WORKSPACE_PATH }}
           pull: 'true'
           env: |
-            CODEX_MODEL=gpt-5-mini
             OPENAI_API_KEY=fake-key
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}


### PR DESCRIPTION
Resolves #294

## Summary
Removed the `CODEX_MODEL=gpt-5-mini` overrides from the psych, docs, and prompt review jobs in `.github/workflows/codex-code-review.yml` so those heavier review jobs inherit the known-good default from `.devcontainer/configure-codex.sh` (`gpt-5.4`).

## Test Plan
- `shellcheck scripts/*.sh`
- `yamllint .github/workflows/*.yml`
- Ran a repo-local markdown link sanity check across `README.md` and `docs/*.md`; it surfaced unrelated pre-existing broken anchors in `docs/notion-schema.md` and `docs/task-lifecycle.md`
- Confirmed `.github/workflows/codex-code-review.yml` no longer sets `CODEX_MODEL=gpt-5-mini` for the psych, docs, and prompt review jobs

Generated with Codex