### PR TITLE
Avoid NO-GO on stale PR Tests verification

### DIFF
--- a/.github/actions/reviewer-setup/action.yml
+++ b/.github/actions/reviewer-setup/action.yml
@@ -26,6 +26,9 @@ outputs:
   verified:
     description: 'Whether PR Tests passed for the current PR head (true/false)'
     value: ${{ steps.verify-tests.outputs.verified }}
+  verification_state:
+    description: 'Why verification succeeded or failed'
+    value: ${{ steps.verify-tests.outputs.verification_state }}
   head_sha:
     description: 'Current PR head SHA that was verified against PR Tests'
     value: ${{ steps.verify-tests.outputs.head_sha }}
@@ -44,6 +47,13 @@ runs:
         export HEAD_SHA
         echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
         echo "Checking PR Tests status for commit $HEAD_SHA"
+
+        set_verification_result() {
+          local verified=$1
+          local state=$2
+          echo "verified=$verified" >> "$GITHUB_OUTPUT"
+          echo "verification_state=$state" >> "$GITHUB_OUTPUT"
+        }
 
         get_run_json() {
           if [ -n "${{ inputs.pr_tests_run_id }}" ]; then
@@ -82,8 +92,13 @@ runs:
               RETRYABLE=false
             elif [ "$RETRYABLE" = "true" ] && [ "$RUN_STATUS" = "completed" ] && [ "$RUN_CONCLUSION" = "success" ]; then
               echo "PR Tests passed for current commit"
-              echo "verified=true" >> $GITHUB_OUTPUT
+              set_verification_result "true" "verified"
               exit 0
+            elif [ "$RETRYABLE" = "true" ] && [ "$RUN_STATUS" = "completed" ]; then
+              STATUS="completed/${RUN_CONCLUSION:-unknown}"
+              RETRYABLE=false
+            elif [ "$RETRYABLE" = "true" ] && [ "$RUN_STATUS" = "in_progress" ] && [ "$RUN_HEAD_SHA" = "$HEAD_SHA" ]; then
+              STATUS="in_progress"
             fi
           else
             STATUS="not found"
@@ -92,7 +107,20 @@ runs:
           if [ "$RETRYABLE" != "true" ]; then
             echo "PR Tests cannot verify the current commit: $STATUS"
             echo "Skipping review - a new PR Tests/code review cycle is required"
-            echo "verified=false" >> $GITHUB_OUTPUT
+            case "$STATUS" in
+              head\ SHA\ mismatch*)
+                set_verification_result "false" "head_sha_mismatch"
+                ;;
+              unexpected\ workflow\ path*)
+                set_verification_result "false" "unexpected_workflow"
+                ;;
+              completed/*)
+                set_verification_result "false" "tests_failed"
+                ;;
+              *)
+                set_verification_result "false" "unverified"
+                ;;
+            esac
             exit 0
           fi
 
@@ -105,4 +133,4 @@ runs:
 
         echo "PR Tests did not verify the current commit after $MAX_ATTEMPTS attempts (status: $STATUS)"
         echo "Skipping review - tests must pass on the current PR head first"
-        echo "verified=false" >> $GITHUB_OUTPUT
+        set_verification_result "false" "not_ready"

--- a/.github/workflows/codex-code-review.yml
+++ b/.github/workflows/codex-code-review.yml
@@ -1980,6 +1980,7 @@ jobs:
     runs-on: [self-hosted, homelab]
     outputs:
       decision: ${{ steps.parse-decision.outputs.decision }}
+      decision_reason: ${{ steps.parse-decision.outputs.decision_reason }}
       head_changed: ${{ steps.trigger-follow-up.outputs.head_changed }}
       follow_up_triggered: ${{ steps.trigger-follow-up.outputs.follow_up_triggered }}
     permissions:
@@ -2172,8 +2173,10 @@ jobs:
           PR_NUMBER: ${{ needs.get-context.outputs.pr_number }}
         run: |
           if [ "${{ steps.setup.outputs.verified }}" != "true" ]; then
-            echo "Reviewer setup could not verify PR Tests for the current head - defaulting to NO-GO"
-            echo "decision=NO-GO" >> $GITHUB_OUTPUT
+            VERIFICATION_STATE="${{ steps.setup.outputs.verification_state }}"
+            echo "Reviewer setup could not verify PR Tests for the current head (state: ${VERIFICATION_STATE:-unknown})"
+            echo "decision=PENDING" >> "$GITHUB_OUTPUT"
+            echo "decision_reason=${VERIFICATION_STATE:-unverified}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -2505,8 +2508,14 @@ jobs:
 
             # Check the actual merge decision (GO vs NO-GO) from the agent's comment
             MERGE_DECISION="${{ needs.merge-decision.outputs.decision }}"
+            MERGE_DECISION_REASON="${{ needs.merge-decision.outputs.decision_reason }}"
             echo "Merge Decision Agent Verdict: $MERGE_DECISION"
-            if [ "$MERGE_DECISION" = "NO-GO" ]; then
+            if [ "$MERGE_DECISION" = "PENDING" ]; then
+              echo "Merge decision is pending until PR Tests verification matches the current head"
+              echo "Reason: ${MERGE_DECISION_REASON:-unverified}"
+              set_status_output "pending" "Waiting for a fresh PR Tests/code review cycle"
+              exit 0
+            elif [ "$MERGE_DECISION" = "NO-GO" ]; then
               echo "Merge decision agent returned NO-GO - blocking issues found"
               echo "See the 'Merge Decision' comment on the PR for details"
               MERGE_DECISION_NOGO=true


### PR DESCRIPTION
Resolves #311

## Summary
- expose reviewer verification state from the shared reviewer setup action
- treat stale or otherwise unverified PR Tests context as a pending review cycle instead of a synthetic NO-GO
- keep the final agent review status pending until a fresh PR Tests run matches the current PR head

## Test Plan
- shellcheck scripts/*.sh
- yamllint .github/workflows/*.yml
- local internal docs link check across docs/ and design/

Generated with Codex