### PR TITLE
Capture residual gaps after GO-WITH-RESERVATIONS merges

### DIFF
--- a/.github/workflows/codex-code-review.yml
+++ b/.github/workflows/codex-code-review.yml
@@ -2151,6 +2151,7 @@ jobs:
 
             **REQUIRED COMMENT FORMAT** — post via \`gh pr comment ${PR_NUMBER} --body '...'\`:
 
+            <!-- codex-merge-decision -->
             ## Merge Decision
 
             **Decision: [NO-GO | GO-WITH-RESERVATIONS | GO-CLEAN]**
@@ -2211,9 +2212,22 @@ jobs:
             exit 0
           fi
 
-          # Fetch the most recent "Merge Decision" comment from the PR
+          MERGE_DECISION_MARKER='<!-- codex-merge-decision -->'
+
+          # Fetch the most recent trusted "Merge Decision" comment from the PR
           COMMENTS=$(gh api repos/${{ github.repository }}/issues/${PR_NUMBER}/comments \
-            --jq '[.[] | select(.body | contains("## Merge Decision"))] | last')
+            --paginate \
+            --slurp \
+            --jq 'add
+              | map(
+                  select(
+                    .user.login == "github-actions[bot]"
+                    and ((.body // "") | contains("'"${MERGE_DECISION_MARKER}"'"))
+                    and ((.body // "") | contains("## Merge Decision"))
+                  )
+                )
+              | sort_by(.id)
+              | last')
 
           if [ -z "$COMMENTS" ] || [ "$COMMENTS" = "null" ]; then
             echo "No merge decision comment found - emitting PENDING (agent likely crashed or timed out)"
@@ -2278,9 +2292,23 @@ jobs:
           if [ "$DECISION" = "NO-GO" ]; then
             echo "NO-GO: closing PR and creating follow-up issue"
 
-            # Fetch the merge-decision comment again to parse the Follow-Up Issue block
+            MERGE_DECISION_MARKER='<!-- codex-merge-decision -->'
+
+            # Fetch the trusted merge-decision comment again to parse the Follow-Up Issue block
             COMMENT_BODY=$(gh api repos/${{ github.repository }}/issues/$PR_NUMBER/comments \
-              --jq '[.[] | select(.body | contains("## Merge Decision"))] | last | .body // ""')
+              --paginate \
+              --slurp \
+              --jq 'add
+                | map(
+                    select(
+                      .user.login == "github-actions[bot]"
+                      and ((.body // "") | contains("'"${MERGE_DECISION_MARKER}"'"))
+                      and ((.body // "") | contains("## Merge Decision"))
+                    )
+                  )
+                | sort_by(.id)
+                | last
+                | .body // ""')
 
             FU_TITLE=""
             FU_BODY=""

--- a/scripts/create-residual-gap-issue.sh
+++ b/scripts/create-residual-gap-issue.sh
@@ -6,13 +6,24 @@ set -euo pipefail
 : "${PR_NUMBER:?PR_NUMBER is required}"
 
 LINKED_ISSUE="${LINKED_ISSUE:-}"
+MERGE_DECISION_MARKER="<!-- codex-merge-decision -->"
 RESIDUAL_BLOCK_START="<codex-residual-gap>"
 RESIDUAL_BLOCK_END="</codex-residual-gap>"
 DEDUP_MARKER="<!-- codex-residual-gap:pr-${PR_NUMBER} -->"
 
 comment_json="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
   --paginate \
-  --jq '[.[] | select(.body | contains("## Merge Decision"))] | last')"
+  --slurp \
+  --jq 'add
+    | map(
+        select(
+          .user.login == "github-actions[bot]"
+          and ((.body // "") | contains("'"${MERGE_DECISION_MARKER}"'"))
+          and ((.body // "") | contains("## Merge Decision"))
+        )
+      )
+    | sort_by(.id)
+    | last')"
 
 if [[ -z "${comment_json}" || "${comment_json}" == "null" ]]; then
   echo "No merge decision comment found for PR #${PR_NUMBER}"


### PR DESCRIPTION
Resolves #316

## Summary
- add a machine-readable residual-gap block to the merge-decision prompt for GO-WITH-RESERVATIONS comments
- create a dedicated post-merge workflow path that parses the residual-gap sentinel and runs non-blocking
- add a helper script that paginates dedupe checks and opens a backlinking follow-up issue only once per merged PR

## Test Plan
- run `bash -n scripts/create-residual-gap-issue.sh`
- run `shellcheck scripts/*.sh`
- run `yamllint .github/workflows/*.yml`
- run the repo internal docs-link validation snippet from `pr-tests.yml`

Generated with Codex