### PR TITLE
Review pipeline v2: judge logic + schema (Phase 0)

### DIFF
--- a/.github/scripts/review/aggregate.mjs
+++ b/.github/scripts/review/aggregate.mjs
@@ -1,0 +1,119 @@
+// Deterministic verdict aggregator for the v2 review pipeline.
+//
+// Pure function: array of reviewer artifacts (parsed JSON conforming to
+// schema/reviewer-v1.json) + a fix-result artifact -> { verdict, reasons[] }.
+//
+// Verdicts are binary: "GO" | "NO-GO". NO-GO is the human-escalation path
+// (see plan: pipeline does not auto-close PRs and does not auto-create
+// replacement issues on NO-GO).
+//
+// This module is used by the judge job, which runs with permissions:
+// contents: read and no git credentials. The judge therefore CANNOT push.
+//
+// The judge MUST NOT read PR comments or PR Reviews. Reviewers are
+// responsible for ingesting inline comments and folding any blocking
+// change requests into their artifact's blocking_issues[] (per
+// docs/agentic-pipeline-learnings.md rule 1.5).
+
+/**
+ * @typedef {Object} BlockingIssue
+ * @property {string} id
+ * @property {"critical"|"high"|"medium"} severity
+ * @property {string} message
+ */
+
+/**
+ * @typedef {Object} ReviewerArtifact
+ * @property {"1"} schema_version
+ * @property {string} role
+ * @property {string} reviewed_sha
+ * @property {number} cycle
+ * @property {"approve"|"request_changes"|"comment"|"abstain"} decision
+ * @property {string} summary
+ * @property {BlockingIssue[]} blocking_issues
+ * @property {Array<{id:string}>} fix_suggestions
+ */
+
+/**
+ * @typedef {Object} FixResult
+ * @property {string[]} addressed   ids of blocking_issues the fixer applied
+ * @property {Array<{id:string,reason:string}>} skipped
+ * @property {string} new_sha       resulting SHA after fix (== input sha if no-op)
+ */
+
+/**
+ * @typedef {Object} Verdict
+ * @property {"GO"|"NO-GO"} verdict
+ * @property {string[]} reasons     human-readable explanation lines
+ * @property {string[]} unaddressed_blocker_ids
+ */
+
+/**
+ * Aggregate reviewer artifacts and a fix-result into a single verdict.
+ *
+ * @param {ReviewerArtifact[]} reviewers
+ * @param {FixResult} fixResult
+ * @returns {Verdict}
+ */
+export function aggregate(reviewers, fixResult) {
+  const reasons = [];
+  const addressed = new Set(fixResult?.addressed ?? []);
+
+  if (!Array.isArray(reviewers) || reviewers.length === 0) {
+    return {
+      verdict: "NO-GO",
+      reasons: ["No reviewer artifacts present."],
+      unaddressed_blocker_ids: [],
+    };
+  }
+
+  // Collect all unaddressed blockers across reviewers.
+  const unaddressed = [];
+  for (const r of reviewers) {
+    for (const b of r.blocking_issues ?? []) {
+      if (!addressed.has(b.id)) {
+        unaddressed.push({ role: r.role, id: b.id, severity: b.severity, message: b.message });
+      }
+    }
+  }
+
+  // Reviewers requesting changes whose blockers were NOT all addressed.
+  const requestingChanges = reviewers.filter(
+    (r) =>
+      r.decision === "request_changes" &&
+      (r.blocking_issues ?? []).some((b) => !addressed.has(b.id))
+  );
+
+  if (unaddressed.length > 0) {
+    reasons.push(
+      `${unaddressed.length} blocking issue(s) not addressed by fixer: ` +
+        unaddressed.map((u) => `${u.role}/${u.id}`).join(", ")
+    );
+  }
+  if (requestingChanges.length > 0) {
+    reasons.push(
+      `Reviewers requesting changes with unaddressed blockers: ` +
+        requestingChanges.map((r) => r.role).join(", ")
+    );
+  }
+
+  if (unaddressed.length > 0 || requestingChanges.length > 0) {
+    return {
+      verdict: "NO-GO",
+      reasons,
+      unaddressed_blocker_ids: unaddressed.map((u) => `${u.role}/${u.id}`),
+    };
+  }
+
+  const nonAbstaining = reviewers.filter((r) => r.decision !== "abstain");
+  if (nonAbstaining.length === 0) {
+    reasons.push("All reviewers abstained; treating as vacuous GO.");
+  } else {
+    reasons.push(
+      `All ${nonAbstaining.length} non-abstaining reviewer(s) cleared; ` +
+        `${addressed.size} blocker(s) addressed by fixer.`
+    );
+  }
+
+  return { verdict: "GO", reasons, unaddressed_blocker_ids: [] };
+}

--- a/.github/scripts/review/aggregate.test.mjs
+++ b/.github/scripts/review/aggregate.test.mjs
@@ -1,0 +1,125 @@
+// Unit tests for the v2 review pipeline judge logic.
+//
+// Run with: node --test .github/scripts/review/aggregate.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { aggregate } from "./aggregate.mjs";
+
+const SHA = "a".repeat(40);
+
+/** Helper: build a minimal reviewer artifact. */
+function reviewer(role, decision, blockers = []) {
+  return {
+    schema_version: "1",
+    role,
+    reviewed_sha: SHA,
+    cycle: 1,
+    decision,
+    summary: "",
+    blocking_issues: blockers,
+    non_blocking_notes: [],
+    fix_suggestions: [],
+    followup_issues: [],
+  };
+}
+
+function blocker(id, severity = "high") {
+  return { id, severity, message: `issue ${id}` };
+}
+
+const noFix = { addressed: [], skipped: [], new_sha: SHA };
+
+test("empty reviewer set is NO-GO", () => {
+  const v = aggregate([], noFix);
+  assert.equal(v.verdict, "NO-GO");
+});
+
+test("all approve, no blockers -> GO", () => {
+  const v = aggregate(
+    [reviewer("design", "approve"), reviewer("security", "approve")],
+    noFix
+  );
+  assert.equal(v.verdict, "GO");
+  assert.deepEqual(v.unaddressed_blocker_ids, []);
+});
+
+test("approve + comment + abstain, no blockers -> GO", () => {
+  const v = aggregate(
+    [
+      reviewer("design", "approve"),
+      reviewer("security", "comment"),
+      reviewer("psych", "abstain"),
+    ],
+    noFix
+  );
+  assert.equal(v.verdict, "GO");
+});
+
+test("all abstain -> GO (vacuous)", () => {
+  const v = aggregate(
+    [reviewer("design", "abstain"), reviewer("security", "abstain")],
+    noFix
+  );
+  assert.equal(v.verdict, "GO");
+  assert.match(v.reasons.join("\n"), /vacuous/i);
+});
+
+test("unaddressed critical blocker -> NO-GO", () => {
+  const v = aggregate(
+    [reviewer("security", "request_changes", [blocker("sec-1", "critical")])],
+    noFix
+  );
+  assert.equal(v.verdict, "NO-GO");
+  assert.deepEqual(v.unaddressed_blocker_ids, ["security/sec-1"]);
+});
+
+test("unaddressed medium blocker -> NO-GO", () => {
+  const v = aggregate(
+    [reviewer("design", "request_changes", [blocker("d-1", "medium")])],
+    noFix
+  );
+  assert.equal(v.verdict, "NO-GO");
+});
+
+test("blocker fully addressed by fixer -> GO", () => {
+  const v = aggregate(
+    [reviewer("security", "request_changes", [blocker("sec-1")])],
+    { addressed: ["sec-1"], skipped: [], new_sha: "b".repeat(40) }
+  );
+  assert.equal(v.verdict, "GO");
+});
+
+test("partially addressed blockers -> NO-GO with remaining ids", () => {
+  const v = aggregate(
+    [
+      reviewer("security", "request_changes", [
+        blocker("sec-1"),
+        blocker("sec-2"),
+      ]),
+      reviewer("design", "request_changes", [blocker("d-1")]),
+    ],
+    { addressed: ["sec-1"], skipped: [{ id: "sec-2", reason: "manual" }], new_sha: SHA }
+  );
+  assert.equal(v.verdict, "NO-GO");
+  assert.deepEqual(
+    v.unaddressed_blocker_ids.sort(),
+    ["design/d-1", "security/sec-2"]
+  );
+});
+
+test("request_changes with all blockers addressed -> GO", () => {
+  // Edge case: a reviewer can return decision=request_changes but the
+  // fixer addressed every blocker. We treat the fix as authoritative.
+  const v = aggregate(
+    [reviewer("security", "request_changes", [blocker("sec-1")])],
+    { addressed: ["sec-1"], skipped: [], new_sha: "c".repeat(40) }
+  );
+  assert.equal(v.verdict, "GO");
+});
+
+test("verdict object always carries reasons", () => {
+  const v = aggregate([reviewer("design", "approve")], noFix);
+  assert.ok(Array.isArray(v.reasons));
+  assert.ok(v.reasons.length > 0);
+});

--- a/.github/scripts/review/schema/reviewer-v1.json
+++ b/.github/scripts/review/schema/reviewer-v1.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/NickBorgersProbably/hide-my-list/.github/scripts/review/schema/reviewer-v1.json",
+  "title": "Reviewer Artifact v1",
+  "description": "Structured output produced by a single reviewer role in the v2 review pipeline. The judge (aggregate.mjs) consumes ONLY these artifacts; it never reads PR comments or PR Reviews. Reviewers are responsible for ingesting inline PR comments via `gh api` and folding any blocking change requests into `blocking_issues[]` (per agentic-pipeline-learnings.md rule 1.5).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "role",
+    "reviewed_sha",
+    "cycle",
+    "decision",
+    "summary",
+    "blocking_issues",
+    "non_blocking_notes",
+    "fix_suggestions",
+    "followup_issues"
+  ],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "role": {
+      "type": "string",
+      "enum": ["design", "security", "psych", "docs", "prompt"]
+    },
+    "reviewed_sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "cycle": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "decision": {
+      "type": "string",
+      "enum": ["approve", "request_changes", "comment", "abstain"]
+    },
+    "summary": {
+      "type": "string",
+      "maxLength": 500
+    },
+    "blocking_issues": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "severity", "message"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "severity": { "type": "string", "enum": ["critical", "high", "medium"] },
+          "file": { "type": ["string", "null"] },
+          "line": { "type": ["integer", "null"], "minimum": 1 },
+          "message": { "type": "string", "minLength": 1 },
+          "category": { "type": ["string", "null"] },
+          "source": {
+            "type": "string",
+            "enum": ["reviewer", "inline_comment"],
+            "description": "How this blocker was discovered. `inline_comment` means the reviewer ingested a human inline comment per pipeline rule 1.5."
+          }
+        }
+      }
+    },
+    "non_blocking_notes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["message"],
+        "properties": {
+          "file": { "type": ["string", "null"] },
+          "line": { "type": ["integer", "null"], "minimum": 1 },
+          "message": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "fix_suggestions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "applicable", "patch_hint", "confidence"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Should match the id of a blocking_issues[] or non_blocking_notes[] entry when this suggestion addresses one."
+          },
+          "applicable": { "type": "string", "enum": ["mechanical", "manual"] },
+          "patch_hint": { "type": "string", "minLength": 1 },
+          "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+        }
+      }
+    },
+    "followup_issues": {
+      "type": "array",
+      "description": "Tightly-scoped follow-up issues to auto-create on PR merge. Reviewers must keep these well-scoped; loose scoping risks an issue/PR loop.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["title", "body"],
+        "properties": {
+          "title": { "type": "string", "minLength": 1, "maxLength": 80 },
+          "body": { "type": "string", "minLength": 1 },
+          "labels": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
+    },
+    "tokens_used": { "type": "integer", "minimum": 0 },
+    "duration_seconds": { "type": "integer", "minimum": 0 }
+  }
+}


### PR DESCRIPTION
First step of the greenfield review-pipeline rearchitecture. Plan: `.claude/plans/reflective-coalescing-peach.md`.

## Summary
Lands pure logic + schema + unit tests with **zero workflow changes**, so they can be reviewed in isolation before any orchestrator work in Phase 1.

- `schema/reviewer-v1.json` — structured contract for reviewer artifacts. Reviewers fold inline-comment blockers into `blocking_issues[]` per `docs/agentic-pipeline-learnings.md` rule 1.5, so the judge never reads PR comments or reviews.
- `aggregate.mjs` — deterministic GO/NO-GO judge. Pure function, no I/O, no Codex, no git. Designed to run in a job with `permissions: contents: read` so the judge structurally cannot push. This is the mechanism that closes the autofix→synchronize→re-review loop class from #336.
- `aggregate.test.mjs` — 10 tests covering the truth table (empty set, all-approve, mixed approve/comment/abstain, unaddressed blockers at every severity, partially-addressed blockers, fixer-overrides-request_changes).

## Context: divergence from existing rules
- Rule **1.4** prefers 3-state verdicts (GO-CLEAN / GO-WITH-RESERVATIONS / NO-GO) for cost. v2 collapses to GO + NO-GO; NO-GO is the human-escalation path (apply label, do not close PR, do not auto-create replacement issue). Will be documented in `agentic-pipeline-learnings.md` in Phase 1 when the workflows actually flip.
- Rule **1.5** requires inline PR comments to be treated as blockers. v2 honors this by having each reviewer ingest inline comments and fold them into its own artifact's `blocking_issues[]` (with `source: "inline_comment"`). The judge stays artifact-only.

## Test plan
- [x] `node --test .github/scripts/review/aggregate.test.mjs` — 10/10 pass locally
- [ ] CI runs the same test