### PR TITLE
Harden Phase 0 judge: mixed epochs + id collisions

### DIFF
--- a/.github/scripts/review/aggregate.mjs
+++ b/.github/scripts/review/aggregate.mjs
@@ -1,19 +1,48 @@
-// Deterministic verdict aggregator for the v2 review pipeline.
+// Internal judge-stage helper for the v2 review pipeline (Phase 0).
 //
-// Pure function: array of reviewer artifacts (parsed JSON conforming to
-// schema/reviewer-v1.json) + a fix-result artifact -> { verdict, reasons[] }.
+// SCOPE: this module defines ONLY the internal judge-stage verdict
+// (binary GO | NO-GO) that the read-only judge job will emit once the
+// v2 orchestrator workflows land in Phase 1. It is NOT the same thing
+// as the existing pipeline's final merge-decision outcome
+// (GO-CLEAN / GO-WITH-RESERVATIONS / NO-GO documented in
+// docs/agentic-pipeline-learnings.md §1.4) and does not currently
+// affect any PR. The mapping from this internal verdict to the
+// pipeline-level outcome — and any reconciling updates to
+// agentic-pipeline-learnings.md §1.4/§1.5 and AGENTS.md "Review
+// Pipeline" — will land in Phase 1 alongside the workflows that
+// actually invoke this module.
 //
-// Verdicts are binary: "GO" | "NO-GO". NO-GO is the human-escalation path
-// (see plan: pipeline does not auto-close PRs and does not auto-create
-// replacement issues on NO-GO).
+// Pure function: array of reviewer artifacts (parsed JSON conforming
+// to schema/reviewer-v1.json) + a fix-result artifact -> verdict.
+// No I/O, no Codex, no git. Designed to run in a job with
+// permissions: contents: read so the judge structurally cannot push.
 //
-// This module is used by the judge job, which runs with permissions:
-// contents: read and no git credentials. The judge therefore CANNOT push.
+// FAIL-CLOSED CONTRACT
 //
-// The judge MUST NOT read PR comments or PR Reviews. Reviewers are
-// responsible for ingesting inline comments and folding any blocking
-// change requests into their artifact's blocking_issues[] (per
-// docs/agentic-pipeline-learnings.md rule 1.5).
+// The aggregator rejects mixed review epochs and ambiguous inputs by
+// returning NO-GO with a `reasons[]` line explaining why. Phase 1
+// orchestration must hand the judge a coherent set, but this module
+// does not assume that — it validates:
+//
+//   1. All reviewer artifacts share the same `reviewed_sha`.
+//   2. All reviewer artifacts share the same `cycle`.
+//   3. The fix-result's `input_sha` (the SHA the fixer started from)
+//      matches the reviewers' `reviewed_sha`.
+//   4. Blocker resolution is keyed by namespaced `role/id`, not by
+//      bare `id`, so two reviewers emitting the same id cannot
+//      cross-clear each other's blockers. The fixer must therefore
+//      emit `addressed[]` entries as `"<role>/<id>"` strings.
+//   5. The empty-reviewer set is NO-GO ("no reviewers ran").
+//   6. The all-abstain case is NO-GO ("no applicable reviewers"),
+//      not a vacuous GO. Phase 1 should ensure at least one role
+//      always applies, but Phase 0 fails closed if it doesn't.
+//
+// Reviewers are responsible for ingesting inline PR comments via
+// `gh api` and folding any blocking change requests into their own
+// `blocking_issues[]` (with `source: "inline_comment"`), so the
+// judge never has to read PR comments or PR Reviews. This honors
+// agentic-pipeline-learnings.md §1.5 from the judge's side; the
+// reviewer-side authority chain will be documented in Phase 1.
 
 /**
  * @typedef {Object} BlockingIssue
@@ -36,9 +65,10 @@
 
 /**
  * @typedef {Object} FixResult
- * @property {string[]} addressed   ids of blocking_issues the fixer applied
+ * @property {string} input_sha    SHA the fixer started from; MUST equal reviewers' reviewed_sha
+ * @property {string} new_sha      resulting SHA after fix (== input_sha if no-op)
+ * @property {string[]} addressed  namespaced ids of blockers the fixer applied, e.g. "security/sec-1"
  * @property {Array<{id:string,reason:string}>} skipped
- * @property {string} new_sha       resulting SHA after fix (== input sha if no-op)
  */
 
 /**
@@ -48,8 +78,14 @@
  * @property {string[]} unaddressed_blocker_ids
  */
 
+/** Build a namespaced blocker id: "<role>/<id>". */
+function nsId(role, id) {
+  return `${role}/${id}`;
+}
+
 /**
  * Aggregate reviewer artifacts and a fix-result into a single verdict.
+ * Fails closed on any input inconsistency.
  *
  * @param {ReviewerArtifact[]} reviewers
  * @param {FixResult} fixResult
@@ -57,7 +93,6 @@
  */
 export function aggregate(reviewers, fixResult) {
   const reasons = [];
-  const addressed = new Set(fixResult?.addressed ?? []);
 
   if (!Array.isArray(reviewers) || reviewers.length === 0) {
     return {
@@ -67,27 +102,73 @@ export function aggregate(reviewers, fixResult) {
     };
   }
 
-  // Collect all unaddressed blockers across reviewers.
+  // (1) All reviewers must share reviewed_sha.
+  const shas = new Set(reviewers.map((r) => r.reviewed_sha));
+  if (shas.size > 1) {
+    return {
+      verdict: "NO-GO",
+      reasons: [
+        `Reviewer artifacts span multiple reviewed_sha values (${[...shas].join(", ")}); refusing to aggregate mixed epochs.`,
+      ],
+      unaddressed_blocker_ids: [],
+    };
+  }
+  const reviewedSha = [...shas][0];
+
+  // (2) All reviewers must share cycle.
+  const cycles = new Set(reviewers.map((r) => r.cycle));
+  if (cycles.size > 1) {
+    return {
+      verdict: "NO-GO",
+      reasons: [
+        `Reviewer artifacts span multiple cycle values (${[...cycles].join(", ")}); refusing to aggregate mixed epochs.`,
+      ],
+      unaddressed_blocker_ids: [],
+    };
+  }
+
+  // (3) Fix-result must reference the same input SHA as the reviewers.
+  if (!fixResult || typeof fixResult !== "object") {
+    return {
+      verdict: "NO-GO",
+      reasons: ["Missing fix-result artifact."],
+      unaddressed_blocker_ids: [],
+    };
+  }
+  if (fixResult.input_sha !== reviewedSha) {
+    return {
+      verdict: "NO-GO",
+      reasons: [
+        `Fix-result input_sha (${fixResult.input_sha}) does not match reviewers' reviewed_sha (${reviewedSha}); refusing to aggregate mixed epochs.`,
+      ],
+      unaddressed_blocker_ids: [],
+    };
+  }
+
+  // (4) Resolve blockers by NAMESPACED id ("<role>/<id>").
+  const addressed = new Set(Array.isArray(fixResult.addressed) ? fixResult.addressed : []);
+
   const unaddressed = [];
   for (const r of reviewers) {
     for (const b of r.blocking_issues ?? []) {
-      if (!addressed.has(b.id)) {
-        unaddressed.push({ role: r.role, id: b.id, severity: b.severity, message: b.message });
+      const key = nsId(r.role, b.id);
+      if (!addressed.has(key)) {
+        unaddressed.push({ role: r.role, id: b.id, key, severity: b.severity, message: b.message });
       }
     }
   }
 
-  // Reviewers requesting changes whose blockers were NOT all addressed.
+  // Reviewers whose decision is request_changes AND who still have unaddressed blockers.
   const requestingChanges = reviewers.filter(
     (r) =>
       r.decision === "request_changes" &&
-      (r.blocking_issues ?? []).some((b) => !addressed.has(b.id))
+      (r.blocking_issues ?? []).some((b) => !addressed.has(nsId(r.role, b.id)))
   );
 
   if (unaddressed.length > 0) {
     reasons.push(
       `${unaddressed.length} blocking issue(s) not addressed by fixer: ` +
-        unaddressed.map((u) => `${u.role}/${u.id}`).join(", ")
+        unaddressed.map((u) => u.key).join(", ")
     );
   }
   if (requestingChanges.length > 0) {
@@ -96,24 +177,27 @@ export function aggregate(reviewers, fixResult) {
         requestingChanges.map((r) => r.role).join(", ")
     );
   }
-
   if (unaddressed.length > 0 || requestingChanges.length > 0) {
     return {
       verdict: "NO-GO",
       reasons,
-      unaddressed_blocker_ids: unaddressed.map((u) => `${u.role}/${u.id}`),
+      unaddressed_blocker_ids: unaddressed.map((u) => u.key),
     };
   }
 
+  // (6) All-abstain is NO-GO, not a vacuous GO.
   const nonAbstaining = reviewers.filter((r) => r.decision !== "abstain");
   if (nonAbstaining.length === 0) {
-    reasons.push("All reviewers abstained; treating as vacuous GO.");
-  } else {
-    reasons.push(
-      `All ${nonAbstaining.length} non-abstaining reviewer(s) cleared; ` +
-        `${addressed.size} blocker(s) addressed by fixer.`
-    );
+    return {
+      verdict: "NO-GO",
+      reasons: ["All reviewers abstained; no applicable reviewer cleared this change."],
+      unaddressed_blocker_ids: [],
+    };
   }
 
+  reasons.push(
+    `All ${nonAbstaining.length} non-abstaining reviewer(s) cleared; ` +
+      `${addressed.size} blocker(s) addressed by fixer.`
+  );
   return { verdict: "GO", reasons, unaddressed_blocker_ids: [] };
 }

--- a/.github/scripts/review/aggregate.test.mjs
+++ b/.github/scripts/review/aggregate.test.mjs
@@ -6,15 +6,16 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { aggregate } from "./aggregate.mjs";
 
-const SHA = "a".repeat(40);
+const SHA_A = "a".repeat(40);
+const SHA_B = "b".repeat(40);
 
 /** Helper: build a minimal reviewer artifact. */
-function reviewer(role, decision, blockers = []) {
+function reviewer(role, decision, blockers = [], { sha = SHA_A, cycle = 1 } = {}) {
   return {
     schema_version: "1",
     role,
-    reviewed_sha: SHA,
-    cycle: 1,
+    reviewed_sha: sha,
+    cycle,
     decision,
     summary: "",
     blocking_issues: blockers,
@@ -28,12 +29,10 @@ function blocker(id, severity = "high") {
   return { id, severity, message: `issue ${id}` };
 }
 
-const noFix = { addressed: [], skipped: [], new_sha: SHA };
+/** Default no-op fix-result targeting SHA_A. */
+const noFix = { input_sha: SHA_A, new_sha: SHA_A, addressed: [], skipped: [] };
 
-test("empty reviewer set is NO-GO", () => {
-  const v = aggregate([], noFix);
-  assert.equal(v.verdict, "NO-GO");
-});
+// ───────────────────────── happy paths ─────────────────────────
 
 test("all approve, no blockers -> GO", () => {
   const v = aggregate(
@@ -44,25 +43,45 @@ test("all approve, no blockers -> GO", () => {
   assert.deepEqual(v.unaddressed_blocker_ids, []);
 });
 
-test("approve + comment + abstain, no blockers -> GO", () => {
+test("approve + comment, no blockers -> GO", () => {
   const v = aggregate(
-    [
-      reviewer("design", "approve"),
-      reviewer("security", "comment"),
-      reviewer("psych", "abstain"),
-    ],
+    [reviewer("design", "approve"), reviewer("security", "comment")],
     noFix
   );
   assert.equal(v.verdict, "GO");
 });
 
-test("all abstain -> GO (vacuous)", () => {
+test("blocker fully addressed by namespaced id -> GO", () => {
+  const v = aggregate(
+    [reviewer("security", "request_changes", [blocker("sec-1")])],
+    { input_sha: SHA_A, new_sha: SHA_B, addressed: ["security/sec-1"], skipped: [] }
+  );
+  assert.equal(v.verdict, "GO");
+});
+
+test("request_changes overridden when fixer addressed every blocker -> GO", () => {
+  const v = aggregate(
+    [reviewer("security", "request_changes", [blocker("sec-1")])],
+    { input_sha: SHA_A, new_sha: SHA_B, addressed: ["security/sec-1"], skipped: [] }
+  );
+  assert.equal(v.verdict, "GO");
+});
+
+// ───────────────────────── NO-GO paths ─────────────────────────
+
+test("empty reviewer set is NO-GO", () => {
+  const v = aggregate([], noFix);
+  assert.equal(v.verdict, "NO-GO");
+  assert.match(v.reasons.join("\n"), /No reviewer artifacts/);
+});
+
+test("all abstain -> NO-GO (fail closed, no vacuous GO)", () => {
   const v = aggregate(
     [reviewer("design", "abstain"), reviewer("security", "abstain")],
     noFix
   );
-  assert.equal(v.verdict, "GO");
-  assert.match(v.reasons.join("\n"), /vacuous/i);
+  assert.equal(v.verdict, "NO-GO");
+  assert.match(v.reasons.join("\n"), /abstained/i);
 });
 
 test("unaddressed critical blocker -> NO-GO", () => {
@@ -82,14 +101,6 @@ test("unaddressed medium blocker -> NO-GO", () => {
   assert.equal(v.verdict, "NO-GO");
 });
 
-test("blocker fully addressed by fixer -> GO", () => {
-  const v = aggregate(
-    [reviewer("security", "request_changes", [blocker("sec-1")])],
-    { addressed: ["sec-1"], skipped: [], new_sha: "b".repeat(40) }
-  );
-  assert.equal(v.verdict, "GO");
-});
-
 test("partially addressed blockers -> NO-GO with remaining ids", () => {
   const v = aggregate(
     [
@@ -99,7 +110,12 @@ test("partially addressed blockers -> NO-GO with remaining ids", () => {
       ]),
       reviewer("design", "request_changes", [blocker("d-1")]),
     ],
-    { addressed: ["sec-1"], skipped: [{ id: "sec-2", reason: "manual" }], new_sha: SHA }
+    {
+      input_sha: SHA_A,
+      new_sha: SHA_A,
+      addressed: ["security/sec-1"],
+      skipped: [{ id: "security/sec-2", reason: "manual" }],
+    }
   );
   assert.equal(v.verdict, "NO-GO");
   assert.deepEqual(
@@ -108,18 +124,93 @@ test("partially addressed blockers -> NO-GO with remaining ids", () => {
   );
 });
 
-test("request_changes with all blockers addressed -> GO", () => {
-  // Edge case: a reviewer can return decision=request_changes but the
-  // fixer addressed every blocker. We treat the fix as authoritative.
+// ───────────── fail-closed: mixed-epoch & invalid inputs ─────────────
+
+test("mixed reviewed_sha across reviewers -> NO-GO (refuses mixed epochs)", () => {
   const v = aggregate(
-    [reviewer("security", "request_changes", [blocker("sec-1")])],
-    { addressed: ["sec-1"], skipped: [], new_sha: "c".repeat(40) }
+    [
+      reviewer("design", "approve", [], { sha: SHA_A }),
+      reviewer("security", "approve", [], { sha: SHA_B }),
+    ],
+    noFix
+  );
+  assert.equal(v.verdict, "NO-GO");
+  assert.match(v.reasons.join("\n"), /multiple reviewed_sha/);
+});
+
+test("mixed cycle across reviewers -> NO-GO", () => {
+  const v = aggregate(
+    [
+      reviewer("design", "approve", [], { cycle: 1 }),
+      reviewer("security", "approve", [], { cycle: 2 }),
+    ],
+    noFix
+  );
+  assert.equal(v.verdict, "NO-GO");
+  assert.match(v.reasons.join("\n"), /multiple cycle/);
+});
+
+test("fixResult.input_sha mismatched against reviewers -> NO-GO", () => {
+  const v = aggregate(
+    [reviewer("design", "approve")],
+    { input_sha: SHA_B, new_sha: SHA_B, addressed: [], skipped: [] }
+  );
+  assert.equal(v.verdict, "NO-GO");
+  assert.match(v.reasons.join("\n"), /input_sha.*does not match/);
+});
+
+test("missing fixResult -> NO-GO", () => {
+  const v = aggregate([reviewer("design", "approve")], null);
+  assert.equal(v.verdict, "NO-GO");
+  assert.match(v.reasons.join("\n"), /Missing fix-result/);
+});
+
+// ────────────── regression: blocker id collisions across reviewers ──────────────
+
+test("two reviewers emit same bare id; addressing one MUST NOT clear the other", () => {
+  // Both reviewers use bare id "issue-1". Fixer addresses only security's
+  // namespaced "security/issue-1". Design's "design/issue-1" must remain
+  // unaddressed → NO-GO. (Pre-fix: this returned GO.)
+  const v = aggregate(
+    [
+      reviewer("design", "request_changes", [blocker("issue-1")]),
+      reviewer("security", "request_changes", [blocker("issue-1")]),
+    ],
+    {
+      input_sha: SHA_A,
+      new_sha: SHA_A,
+      addressed: ["security/issue-1"],
+      skipped: [],
+    }
+  );
+  assert.equal(v.verdict, "NO-GO");
+  assert.deepEqual(v.unaddressed_blocker_ids, ["design/issue-1"]);
+});
+
+test("addressing both colliding ids by namespace -> GO", () => {
+  const v = aggregate(
+    [
+      reviewer("design", "request_changes", [blocker("issue-1")]),
+      reviewer("security", "request_changes", [blocker("issue-1")]),
+    ],
+    {
+      input_sha: SHA_A,
+      new_sha: SHA_B,
+      addressed: ["design/issue-1", "security/issue-1"],
+      skipped: [],
+    }
   );
   assert.equal(v.verdict, "GO");
 });
 
-test("verdict object always carries reasons", () => {
-  const v = aggregate([reviewer("design", "approve")], noFix);
-  assert.ok(Array.isArray(v.reasons));
-  assert.ok(v.reasons.length > 0);
+test("bare id in addressed[] (not namespaced) does NOT clear blockers", () => {
+  // Defends the namespacing contract: if Phase 1 orchestration regresses
+  // and emits bare ids, the judge fails closed instead of silently
+  // clearing the wrong blockers.
+  const v = aggregate(
+    [reviewer("security", "request_changes", [blocker("sec-1")])],
+    { input_sha: SHA_A, new_sha: SHA_A, addressed: ["sec-1"], skipped: [] }
+  );
+  assert.equal(v.verdict, "NO-GO");
+  assert.deepEqual(v.unaddressed_blocker_ids, ["security/sec-1"]);
 });

--- a/.github/scripts/review/schema/reviewer-v1.json
+++ b/.github/scripts/review/schema/reviewer-v1.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/NickBorgersProbably/hide-my-list/.github/scripts/review/schema/reviewer-v1.json",
   "title": "Reviewer Artifact v1",
-  "description": "Structured output produced by a single reviewer role in the v2 review pipeline. The judge (aggregate.mjs) consumes ONLY these artifacts; it never reads PR comments or PR Reviews. Reviewers are responsible for ingesting inline PR comments via `gh api` and folding any blocking change requests into `blocking_issues[]` (per agentic-pipeline-learnings.md rule 1.5).",
+  "description": "Structured output produced by a single reviewer role in the v2 review pipeline (Phase 0). This is the *internal* contract between reviewers and the read-only judge stage that aggregate.mjs implements; it does not yet replace the existing pipeline's final merge-decision outcome (GO-CLEAN / GO-WITH-RESERVATIONS / NO-GO documented in docs/agentic-pipeline-learnings.md §1.4). The judge (aggregate.mjs) consumes ONLY these artifacts; it never reads PR comments or PR Reviews. Reviewers are responsible for ingesting inline PR comments via `gh api` and folding any blocking change requests into `blocking_issues[]` with `source: \"inline_comment\"`. Doc reconciliation (§1.4 / §1.5 / AGENTS.md Review Pipeline) lands in Phase 1 alongside the workflows that actually invoke this contract.",
   "type": "object",
   "additionalProperties": false,
   "required": [


### PR DESCRIPTION
Follow-up to #341 addressing the design review's blocking feedback. Plan: `.claude/plans/reflective-coalescing-peach.md`. Still **zero workflow changes** — pure logic + schema + tests.

## Summary
- **Mixed-epoch artifacts (blocker 1):** judge now fails closed if reviewer artifacts disagree on `reviewed_sha` or `cycle`, or if `fixResult.input_sha` doesn't match the reviewers' `reviewed_sha`. `FixResult` gains a required `input_sha` field. Pre-fix: stale artifacts could silently aggregate into a GO.
- **Blocker id collisions (blocker 2):** resolution is now keyed by namespaced `role/id`, not bare `id`. The fixer must emit `addressed[]` as namespaced strings; bare ids no longer clear anything. Pre-fix: two reviewers emitting the same id would cross-clear each other. Two regression tests pin this.
- **All-abstain is now NO-GO** (fail closed), not a vacuous GO — addresses the docs reviewer's "worth considering" note.
- **Doc-contradiction blocker:** narrowed the schema description and `aggregate.mjs` header to scope them to *internal judge-stage helper, Phase 0*, and explicitly defer reconciling `docs/agentic-pipeline-learnings.md` §1.4 / §1.5 and `AGENTS.md` "Review Pipeline" to Phase 1, when the workflows that actually invoke this contract land. Rewriting those docs now would describe behavior that doesn't yet exist.

## Test plan
- [x] `node --test .github/scripts/review/aggregate.test.mjs` — 16/16 pass locally (was 10)
- [ ] CI runs the same test

## Mapping back to #341 review
- design review blocker 1 (stale/mixed epochs) → fail-closed checks 1–3 + tests `mixed reviewed_sha`, `mixed cycle`, `fixResult.input_sha mismatched`, `missing fixResult`
- design review blocker 2 (colliding ids) → namespaced `role/id` keying + tests `two reviewers emit same bare id`, `addressing both colliding ids by namespace`, `bare id in addressed[] does NOT clear blockers`
- design review "worth considering" (all-abstain risky) → all-abstain → NO-GO + test `all abstain -> NO-GO`
- docs review blockers (§1.4 / §1.5 / AGENTS.md contradictions) → narrowed Phase 0 wording + explicit Phase 1 deferral note