### PR TITLE
Align local git hooks with required CI checks

### DIFF
--- a/.githooks/install-hooks.sh
+++ b/.githooks/install-hooks.sh
@@ -3,5 +3,12 @@
 set -euo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
-git config core.hooksPath "$REPO_ROOT/.githooks"
-echo "Git hooks installed (core.hooksPath set to .githooks/)"
+
+# core.hooksPath should resolve inside the current worktree.
+# Linked worktrees need their own setting after `git worktree add`.
+git config extensions.worktreeConfig true
+git config --worktree core.hooksPath "$REPO_ROOT/.githooks"
+
+echo "Git hooks installed for this worktree:"
+echo "  core.hooksPath = $REPO_ROOT/.githooks"
+echo "Re-run bash .githooks/install-hooks.sh after creating a new git worktree."

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,55 +4,10 @@
 
 set -euo pipefail
 
-# Get staged files (added, copied, modified — not deleted)
-STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
+mapfile -t staged_files < <(git diff --cached --name-only --diff-filter=ACM)
 
-if [ -z "$STAGED_FILES" ]; then
+if [ "${#staged_files[@]}" -eq 0 ]; then
   exit 0
 fi
 
-FAILED=0
-
-# --- Scripts: shellcheck ---
-SCRIPT_FILES=$(echo "$STAGED_FILES" | grep '^scripts/.*\.sh$' || true)
-if [ -n "$SCRIPT_FILES" ]; then
-  echo "Running shellcheck on staged scripts..."
-  if ! echo "$SCRIPT_FILES" | xargs shellcheck; then
-    FAILED=1
-  fi
-fi
-
-# --- Docs: mermaid rendering lint + mermaid syntax validation ---
-DOC_FILES=$(echo "$STAGED_FILES" | grep -E '^(docs/|design/|README\.md|AGENTS\.md)' | grep '\.md$' || true)
-if [ -n "$DOC_FILES" ]; then
-  echo "Running Mermaid rendering lint on staged docs..."
-  # shellcheck disable=SC2086
-  if ! bash scripts/lint-mermaid-rendering.sh $DOC_FILES; then
-    FAILED=1
-  fi
-
-  echo "Running Mermaid syntax validation on staged docs..."
-  # shellcheck disable=SC2086
-  if ! bash scripts/validate-mermaid.sh $DOC_FILES; then
-    FAILED=1
-  fi
-fi
-
-# --- Workflows: yamllint ---
-WORKFLOW_FILES=$(echo "$STAGED_FILES" | grep '^\.github/workflows/.*\.yml$' || true)
-if [ -n "$WORKFLOW_FILES" ]; then
-  if command -v yamllint &> /dev/null; then
-    echo "Running yamllint on staged workflows..."
-    if ! echo "$WORKFLOW_FILES" | xargs yamllint -d "{extends: default, rules: {line-length: disable, truthy: disable, comments-indentation: disable}}"; then
-      FAILED=1
-    fi
-  else
-    echo "WARNING: yamllint not installed, skipping workflow validation"
-  fi
-fi
-
-if [ "$FAILED" -ne 0 ]; then
-  echo ""
-  echo "Pre-commit checks failed. Fix the issues above before committing."
-  exit 1
-fi
+./scripts/run-required-checks.sh --mode pre-commit -- "${staged_files[@]}"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Pre-push hook: run the local-required CI checks before allowing a push.
+# Install with: bash .githooks/install-hooks.sh
+
+set -euo pipefail
+
+remote_name=${1:-origin}
+zero_oid=0000000000000000000000000000000000000000
+fallback_to_full_checks=0
+
+declare -a changed_files=()
+declare -A seen_files=()
+
+add_changed_file() {
+  local file=$1
+  if [ -n "$file" ] && [ -z "${seen_files[$file]+x}" ]; then
+    seen_files["$file"]=1
+    changed_files+=("$file")
+  fi
+}
+
+default_base_ref() {
+  local candidate
+
+  candidate=$(git symbolic-ref --quiet --short "refs/remotes/${remote_name}/HEAD" 2>/dev/null || true)
+  if [ -n "$candidate" ]; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  for candidate in "${remote_name}/main" "${remote_name}/master"; do
+    if git rev-parse --verify --quiet "$candidate" >/dev/null; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+while read -r local_ref local_sha _remote_ref remote_sha; do
+  [ -n "${local_ref:-}" ] || continue
+
+  if [ "$local_sha" = "$zero_oid" ]; then
+    continue
+  fi
+
+  if [ "$remote_sha" = "$zero_oid" ]; then
+    base_ref=$(default_base_ref || true)
+    if [ -z "${base_ref:-}" ]; then
+      fallback_to_full_checks=1
+      continue
+    fi
+
+    base_sha=$(git merge-base "$local_sha" "$base_ref" 2>/dev/null || true)
+    if [ -z "${base_sha:-}" ]; then
+      fallback_to_full_checks=1
+      continue
+    fi
+
+    range="${base_sha}..${local_sha}"
+  else
+    range="${remote_sha}..${local_sha}"
+  fi
+
+  while IFS= read -r file; do
+    add_changed_file "$file"
+  done < <(git diff --name-only --diff-filter=ACM "$range")
+done
+
+if [ "$fallback_to_full_checks" -eq 1 ]; then
+  echo "Unable to determine the exact push diff. Running the full local-required check suite."
+  ./scripts/run-required-checks.sh --mode pre-push --check scripts --check docs --check workflows
+  exit 0
+fi
+
+if [ "${#changed_files[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+./scripts/run-required-checks.sh --mode pre-push -- "${changed_files[@]}"

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -66,12 +66,14 @@ jobs:
             docs:
               - 'docs/**'
               - 'design/**'
+              - 'setup/**'
               - 'README.md'
               - 'AGENTS.md'
             workflows:
               - '.github/workflows/**'
               - '.github/actions/**'
               - '.github/actionlint.yaml'
+              - '.yamllint'
               - 'scripts/validate-gh-cli-usage.sh'
               - 'scripts/validate-workflow-refs.sh'
             devcontainer:
@@ -88,18 +90,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run script validation
-        run: |
-          echo "=== Linting shell scripts ==="
-          find scripts/ -name '*.sh' -exec shellcheck {} +
-
-          echo "=== Checking script permissions ==="
-          find scripts/ -name '*.sh' | while read f; do
-            if [ ! -x "$f" ]; then
-              echo "ERROR: $f is not executable"
-              exit 1
-            fi
-          done
-          echo "All scripts have execute permission"
+        run: ./scripts/run-required-checks.sh --mode ci --check scripts
 
   doc-validation:
     name: Documentation Validation
@@ -123,43 +114,11 @@ jobs:
         env:
           CHANGED_FILES: ${{ needs.changes.outputs.docs_files }}
         run: |
-          echo "=== Checking for broken internal links ==="
-          ERRORS=0
-          # Check markdown files for internal links and verify targets exist
-          find docs/ design/ -name '*.md' | while read f; do
-            # Extract relative links like [text](./file.md) or [text](../docs/file.md)
-            grep -oP '\[.*?\]\(\K[^)]+' "$f" 2>/dev/null | grep -v '^http' | while read link; do
-              # Resolve relative to the file's directory
-              dir=$(dirname "$f")
-              target="$dir/$link"
-              # Strip anchors
-              target=$(echo "$target" | cut -d'#' -f1)
-              if [ -n "$target" ] && [ ! -e "$target" ]; then
-                echo "BROKEN LINK in $f: $link (resolved to $target)"
-                ERRORS=$((ERRORS + 1))
-              fi
-            done
-          done
-          if [ "$ERRORS" -gt 0 ]; then
-            echo "$ERRORS broken links found"
-            exit 1
-          fi
-          echo "No broken internal links found"
-
-          echo "=== Linting Mermaid diagrams ==="
           if [ -n "$CHANGED_FILES" ]; then
-            # shellcheck disable=SC2086
-            ./scripts/lint-mermaid-rendering.sh $CHANGED_FILES
+            readarray -t changed_files <<<"$CHANGED_FILES"
+            ./scripts/run-required-checks.sh --mode ci --check docs -- "${changed_files[@]}"
           else
-            echo "No changed doc files to lint"
-          fi
-
-          echo "=== Validating Mermaid diagrams ==="
-          if [ -n "$CHANGED_FILES" ]; then
-            # shellcheck disable=SC2086
-            ./scripts/validate-mermaid.sh $CHANGED_FILES
-          else
-            echo "No changed doc files to validate"
+            ./scripts/run-required-checks.sh --mode ci --check docs
           fi
 
   workflow-validation:
@@ -174,10 +133,6 @@ jobs:
 
       - name: Install yamllint
         run: pip3 install yamllint
-
-      - name: Run workflow validation
-        run: |
-          yamllint -c .yamllint .github/workflows/*.yml
 
       - name: Install actionlint
         run: |
@@ -196,14 +151,8 @@ jobs:
           )
           sudo tar -xzf "${TMP_DIR}/${ARCHIVE}" -C /usr/local/bin actionlint
 
-      - name: Run actionlint
-        run: actionlint .github/workflows/*.yml
-
-      - name: Validate cross-file workflow references
-        run: ./scripts/validate-workflow-refs.sh
-
-      - name: Validate GitHub CLI usage in workflows
-        run: ./scripts/validate-gh-cli-usage.sh
+      - name: Run workflow validation
+        run: ./scripts/run-required-checks.sh --mode ci --check workflows
 
   devcontainer-validation:
     name: Devcontainer Build Check

--- a/scripts/run-required-checks.sh
+++ b/scripts/run-required-checks.sh
@@ -1,0 +1,331 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/run-required-checks.sh --mode <pre-commit|pre-push|ci> [--check <scripts|docs|workflows>]... [-- FILE...]
+
+Modes:
+  pre-commit  Run staged-file checks for the supplied files.
+  pre-push    Run push-blocking checks for the supplied files.
+  ci          Run the CI-required checks for the requested categories.
+
+If --check is omitted in pre-commit/pre-push mode, categories are inferred from FILE paths.
+EOF
+}
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require_command() {
+  local cmd=$1
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    fail "required command '$cmd' is not installed. Re-run setup/bootstrap.sh or use the devcontainer before pushing."
+  fi
+}
+
+declare -a requested_checks=()
+declare -a files=()
+mode=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --mode)
+      [ "$#" -ge 2 ] || fail "--mode requires a value"
+      mode=$2
+      shift 2
+      ;;
+    --check)
+      [ "$#" -ge 2 ] || fail "--check requires a value"
+      requested_checks+=("$2")
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      files+=("$@")
+      break
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+[ -n "$mode" ] || fail "--mode is required"
+
+case "$mode" in
+  pre-commit|pre-push|ci)
+    ;;
+  *)
+    fail "unsupported mode: $mode"
+    ;;
+esac
+
+has_check() {
+  local target=$1
+  local item
+  for item in "${requested_checks[@]}"; do
+    if [ "$item" = "$target" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+add_check() {
+  local target=$1
+  has_check "$target" || requested_checks+=("$target")
+}
+
+is_doc_file() {
+  case "$1" in
+    docs/*.md|design/*.md|setup/*.md|README.md|AGENTS.md)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+is_workflow_trigger_file() {
+  case "$1" in
+    .github/workflows/*.yml|.github/workflows/*.yaml|.github/actions/*|.github/actionlint.yaml|.yamllint|scripts/validate-workflow-refs.sh|scripts/validate-gh-cli-usage.sh)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+if [ "${#requested_checks[@]}" -eq 0 ] && [ "$mode" != "ci" ]; then
+  for file in "${files[@]}"; do
+    case "$file" in
+      scripts/*.sh)
+        add_check "scripts"
+        ;;
+    esac
+
+    if is_doc_file "$file"; then
+      add_check "docs"
+    fi
+
+    if is_workflow_trigger_file "$file"; then
+      add_check "workflows"
+    fi
+  done
+fi
+
+if [ "${#requested_checks[@]}" -eq 0 ]; then
+  echo "No required checks to run for this invocation."
+  exit 0
+fi
+
+declare -a changed_script_files=()
+declare -a changed_doc_files=()
+declare -a changed_workflow_files=()
+
+for file in "${files[@]}"; do
+  case "$file" in
+    scripts/*.sh)
+      changed_script_files+=("$file")
+      ;;
+  esac
+
+  if is_doc_file "$file"; then
+    changed_doc_files+=("$file")
+  fi
+
+  case "$file" in
+    .github/workflows/*.yml|.github/workflows/*.yaml)
+      changed_workflow_files+=("$file")
+      ;;
+  esac
+done
+
+declare -a all_script_files=()
+declare -a all_workflow_files=()
+shopt -s nullglob
+all_script_files=(scripts/*.sh)
+all_workflow_files=(.github/workflows/*.yml .github/workflows/*.yaml)
+shopt -u nullglob
+
+run_shellcheck() {
+  local scope=$1
+  shift
+  local -a script_files=("$@")
+
+  [ "${#script_files[@]}" -gt 0 ] || return 0
+  require_command shellcheck
+  echo "=== shellcheck (${scope}) ==="
+  shellcheck "${script_files[@]}"
+}
+
+check_script_permissions() {
+  local script_file
+  [ "${#all_script_files[@]}" -gt 0 ] || return 0
+
+  echo "=== executable bit check (scripts/*.sh) ==="
+  for script_file in "${all_script_files[@]}"; do
+    if [ ! -x "$script_file" ]; then
+      echo "ERROR: $script_file is not executable"
+      return 1
+    fi
+  done
+}
+
+check_broken_links() {
+  echo "=== broken internal link check ==="
+
+  python3 - <<'PY'
+import re
+import sys
+from pathlib import Path
+
+repo_root = Path.cwd()
+targets = []
+for pattern in ("docs/**/*.md", "design/**/*.md", "setup/**/*.md"):
+    targets.extend(sorted(repo_root.glob(pattern)))
+for rel in ("README.md", "AGENTS.md"):
+    path = repo_root / rel
+    if path.exists():
+        targets.append(path)
+
+link_re = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
+skip_prefixes = ("http://", "https://", "mailto:", "tel:", "data:")
+errors = []
+
+for md_path in targets:
+    text = md_path.read_text(encoding="utf-8")
+    for raw_target in link_re.findall(text):
+        target = raw_target.strip()
+        if not target or target.startswith(skip_prefixes) or target.startswith("#"):
+            continue
+        resolved = (md_path.parent / target.split("#", 1)[0]).resolve()
+        if not resolved.exists():
+            if resolved.is_relative_to(repo_root):
+                display = resolved.relative_to(repo_root)
+            else:
+                display = resolved
+            errors.append(f"BROKEN LINK in {md_path.relative_to(repo_root)}: {target} (resolved to {display})")
+
+if errors:
+    for error in errors:
+        print(error)
+    print(f"FAILED: {len(errors)} broken internal link(s) found")
+    sys.exit(1)
+
+print("No broken internal links found")
+PY
+}
+
+run_mermaid_checks() {
+  local scope=$1
+  shift
+  local -a doc_files=("$@")
+
+  if [ "${#doc_files[@]}" -eq 0 ]; then
+    echo "No markdown files matched for Mermaid validation in ${scope}."
+    return 0
+  fi
+
+  echo "=== Mermaid rendering lint (${scope}) ==="
+  ./scripts/lint-mermaid-rendering.sh "${doc_files[@]}"
+
+  echo "=== Mermaid syntax validation (${scope}) ==="
+  ./scripts/validate-mermaid.sh "${doc_files[@]}"
+}
+
+run_yamllint() {
+  local scope=$1
+  shift
+  local -a workflow_files=("$@")
+
+  [ "${#workflow_files[@]}" -gt 0 ] || return 0
+  require_command yamllint
+  echo "=== yamllint (${scope}) ==="
+  yamllint -c .yamllint "${workflow_files[@]}"
+}
+
+run_actionlint() {
+  require_command actionlint
+  [ "${#all_workflow_files[@]}" -gt 0 ] || return 0
+  echo "=== actionlint ==="
+  actionlint "${all_workflow_files[@]}"
+}
+
+run_workflow_reference_checks() {
+  echo "=== workflow reference validation ==="
+  ./scripts/validate-workflow-refs.sh
+}
+
+run_gh_cli_usage_checks() {
+  echo "=== workflow gh cli usage validation ==="
+  ./scripts/validate-gh-cli-usage.sh
+}
+
+run_scripts_checks() {
+  case "$mode" in
+    pre-commit)
+      run_shellcheck "staged scripts" "${changed_script_files[@]}"
+      ;;
+    pre-push|ci)
+      run_shellcheck "scripts/*.sh" "${all_script_files[@]}"
+      check_script_permissions
+      ;;
+  esac
+}
+
+run_docs_checks() {
+  case "$mode" in
+    pre-commit)
+      run_mermaid_checks "staged docs" "${changed_doc_files[@]}"
+      ;;
+    pre-push|ci)
+      check_broken_links
+      run_mermaid_checks "changed docs" "${changed_doc_files[@]}"
+      ;;
+  esac
+}
+
+run_workflow_checks() {
+  case "$mode" in
+    pre-commit)
+      run_yamllint "staged workflows" "${changed_workflow_files[@]}"
+      ;;
+    pre-push|ci)
+      run_yamllint "all workflows" "${all_workflow_files[@]}"
+      run_actionlint
+      run_workflow_reference_checks
+      run_gh_cli_usage_checks
+      ;;
+  esac
+}
+
+for check in "${requested_checks[@]}"; do
+  case "$check" in
+    scripts)
+      run_scripts_checks
+      ;;
+    docs)
+      run_docs_checks
+      ;;
+    workflows)
+      run_workflow_checks
+      ;;
+    *)
+      fail "unsupported check: $check"
+      ;;
+  esac
+done

--- a/setup/README.md
+++ b/setup/README.md
@@ -101,6 +101,24 @@ git pull origin main
 
 The agent reads docs on every interaction, so changes take effect immediately. No restart needed unless `openclaw.json` changed.
 
+## Git Hooks
+
+The repo uses versioned hooks in `.githooks/` to block pushes that would fail deterministic local CI checks. Install them in each worktree with:
+
+```bash
+bash .githooks/install-hooks.sh
+```
+
+The devcontainer runs that installer automatically on first create, but linked worktrees need their own hook path. After every `git worktree add`, re-run `bash .githooks/install-hooks.sh` inside the new worktree so `core.hooksPath` points at that worktree's `.githooks/` directory.
+
+Manual regression playbook for the push gate:
+
+1. Create a feature branch and run `bash .githooks/install-hooks.sh`.
+2. Introduce a known workflow lint failure, such as a malformed GitHub Actions expression in `.github/workflows/pr-tests.yml`.
+3. Commit the change and run `git push`.
+4. Confirm `.githooks/pre-push` rejects the push locally with the same `actionlint` diagnostic CI would have produced.
+5. Fix the workflow file and push again.
+
 ## Troubleshooting
 
 **Reminders not firing:**


### PR DESCRIPTION
Resolves #344

## Summary
- add a shared `scripts/run-required-checks.sh` entrypoint that defines the required local check set for scripts, docs, and workflows
- wire `.githooks/pre-commit`, new `.githooks/pre-push`, and `.github/workflows/pr-tests.yml` to that shared runner so hooks and CI cannot drift
- install hooks per worktree and document the worktree reinstall/manual push-gate regression playbook in `setup/README.md`

## Test Plan
- shellcheck scripts/*.sh
- yamllint .github/workflows/*.yml
- shellcheck .githooks/pre-commit .githooks/pre-push .githooks/install-hooks.sh scripts/run-required-checks.sh
- ./scripts/run-required-checks.sh --mode ci --check scripts
- ./scripts/run-required-checks.sh --mode ci --check docs -- setup/README.md
- ./scripts/run-required-checks.sh --mode ci --check workflows
- bash .githooks/install-hooks.sh
- git push -u origin codex/issue-344

Generated with Codex