### PR TITLE
Restore reviewer prompt routing coverage

### DIFF
--- a/.github/actions/review-classify/action.yml
+++ b/.github/actions/review-classify/action.yml
@@ -20,7 +20,8 @@ description: >
   See agentic-pipeline-learnings.md §1.9: spec-critical .md files
   must NOT be classified as docs_only just because they end in .md.
   The classifier carves out AGENTS.md, SOUL.md, TOOLS.md, HEARTBEAT.md,
-  setup/cron/*, and design/adhd-priorities.md as runtime spec.
+  setup/cron/*, design/adhd-priorities.md, and
+  .github/scripts/review/prompts/*.md as prompt-bearing spec/config.
 
 inputs:
   base_ref:
@@ -74,6 +75,7 @@ runs:
             setup/cron/*) return 0 ;;
             design/adhd-priorities.md) return 0 ;;
             docs/ai-prompts.md|docs/task-lifecycle.md|docs/notion-schema.md|docs/architecture.md|docs/user-interactions.md|docs/user-preferences.md|docs/reward-system.md|docs/openclaw-integration.md) return 0 ;;
+            .github/scripts/review/prompts/*.md) return 0 ;;
             *) return 1 ;;
           esac
         }
@@ -86,6 +88,11 @@ runs:
             .github/*|.devcontainer/*|scripts/*) ;;
             *) CONFIG_ONLY=false ;;
           esac
+
+          # Reviewer prompts are prompt-bearing markdown, not inert CI config.
+          if is_spec_md "$f"; then
+            CONFIG_ONLY=false
+          fi
 
           # Spec MDs and any non-doc/design file invalidate docs_only.
           if is_spec_md "$f"; then

--- a/.github/scripts/review/prompts/security.md
+++ b/.github/scripts/review/prompts/security.md
@@ -19,6 +19,14 @@ Cover three areas:
    on the host (rule 2.1), env vars that get dropped between job
    boundaries, control flow that fails before the actual logic runs,
    bind-mount sources that depend on local state.
+4. **Reviewer-routing invariants.** When a PR changes review-pipeline
+   dispatch, classifier, or gating logic, compare the resulting
+   reviewer coverage against the current pipeline behavior and
+   `agentic-pipeline-learnings.md` rules 1.9 and 1.12. Any
+   unintended loss of specialist coverage is blocking unless the PR
+   explicitly documents and justifies it. Treat prompt/spec files,
+   including `.github/scripts/review/prompts/*.md`, as coverage that
+   must stay owned by the appropriate specialist reviewers.
 
 Run `shellcheck scripts/*.sh .github/actions/**/*.sh` if there are
 shell changes. For HIGH severity bugs, describe the fix precisely
@@ -31,8 +39,13 @@ apply it via your `fix_suggestions[]`.
 2. `gh api repos/${REPO}/pulls/${PR_NUMBER}/comments` — read inline
    comments. Any blocking change requests there must appear in your
    `blocking_issues[]` with `source: "inline_comment"`.
-3. Apply the three-area lens above.
-4. Write the JSON artifact to `$OUTPUT_PATH`.
+3. If the diff touches review orchestration files (for example
+   `.github/workflows/review-*.yml`,
+   `.github/actions/review-classify/action.yml`, or reviewer prompt
+   routing/gating code), explicitly compare the before/after reviewer
+   routing behavior instead of trusting the PR description.
+4. Apply the four-area lens above.
+5. Write the JSON artifact to `$OUTPUT_PATH`.
 
 ## Output contract
 

--- a/docs/agentic-pipeline-learnings.md
+++ b/docs/agentic-pipeline-learnings.md
@@ -68,6 +68,11 @@ Two meta-lessons span everything below:
 **Before:** New head commits inherited a green aggregate review check without any stage evaluating the updated diff.
 **Evidence:** #339, #338, #337
 
+### 1.12 Security/infra review explicitly owns reviewer-routing regressions
+**Why:** Review-pipeline dispatch and classifier changes can silently drop specialist coverage while the workflow still "works." When a PR changes reviewer routing, the Security & Infrastructure reviewer must compare the new behavior against the current pipeline contract and flag any unintended loss of coverage, especially for prompt/spec files such as `.github/scripts/review/prompts/*.md`, unless the PR explicitly documents and justifies the change.
+**Before:** The v2 classifier treated reviewer prompt markdown as config-only CI, which would have skipped specialist prompt/psych review and no reviewer called it out.
+**Evidence:** #343, #349
+
 ---
 
 ## 2. CI Runtime Infrastructure


### PR DESCRIPTION
Resolves #349

## Summary
- classify `.github/scripts/review/prompts/*.md` as prompt-bearing spec/config so review-pipeline prompt edits no longer stay `config_only`
- extend the Security & Infrastructure reviewer prompt to explicitly own reviewer-routing regressions when review dispatch/classifier/gating logic changes
- document that ownership rule in `docs/agentic-pipeline-learnings.md`

## Test Plan
- `shellcheck scripts/*.sh`
- `yamllint .github/workflows/*.yml`
- verified the updated classifier logic yields `config_only=false` and `docs_only=false` for `.github/scripts/review/prompts/security.md`

Generated with Codex