### PR TITLE
Use immutable SHA checkout for review jobs

### DIFF
--- a/.github/workflows/codex-code-review.yml
+++ b/.github/workflows/codex-code-review.yml
@@ -1004,6 +1004,8 @@ jobs:
           repository: ${{ needs.get-context.outputs.head_repo }}
           path: ${{ env.PR_WORKSPACE_PATH }}
           fetch-depth: 0
+          # PAT required to push workflow file changes
+          token: ${{ secrets.WORKFLOW_PAT }}
 
       - name: Reattach PR branch when available
         if: steps.setup.outputs.verified == 'true'


### PR DESCRIPTION
Resolves #351

## Summary
- switch the design, security, psych, docs, and prompt review jobs to check out `${{ needs.get-context.outputs.reviewed_sha }}` instead of the mutable PR branch name
- add the same guarded local-branch reattach step already used by `merge-decision`, so review jobs still get a local branch when `origin/${HEAD_REF}` exists but continue safely on a detached reviewed commit when it does not
- use the workflow PAT for those immutable checkouts to match the existing review execution pattern

## Test Plan
- `yamllint .github/workflows/*.yml`
- `shellcheck scripts/*.sh`
- `git diff --check`

Generated with Codex