### PR TITLE
Use reviewed_sha for v2 reviewer and fixer checkouts

### DIFF
--- a/.github/workflows/review-fixer.yml
+++ b/.github/workflows/review-fixer.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.head_ref }}
+          ref: ${{ inputs.reviewed_sha }}
           repository: ${{ inputs.head_repo }}
           path: ${{ env.PR_WORKSPACE_PATH }}
           fetch-depth: 0
@@ -139,6 +139,46 @@ jobs:
             exit 0
           fi
 
+          # Push from the PR workspace, which has the PAT-authenticated remote.
+          cd "${{ env.PR_WORKSPACE_PATH }}"
+          REMOTE_HEAD=$(git ls-remote --heads origin "refs/heads/${HEAD_REF}" | awk 'NR==1 {print $1}')
+          if [ -z "$REMOTE_HEAD" ] || [ "$REMOTE_HEAD" != "$REVIEWED_SHA" ]; then
+            TMP_ARTIFACT=$(mktemp)
+            jq \
+              --arg reviewed_sha "$REVIEWED_SHA" \
+              --arg remote_head "$REMOTE_HEAD" \
+              --arg head_ref "$HEAD_REF" \
+              '
+              def push_skip_reason:
+                if $remote_head == "" then
+                  "Not pushed because origin/" + $head_ref + " no longer exists after gather froze " + $reviewed_sha + "."
+                else
+                  "Not pushed because origin/" + $head_ref + " advanced to " + $remote_head + " after gather froze " + $reviewed_sha + "."
+                end;
+              .new_sha = $reviewed_sha
+              | .skipped = (
+                  (.skipped // [])
+                  + ((.addressed // []) | map({id: ., reason: push_skip_reason}))
+                  | if length == 0 then
+                      [{id: "docs/review-pipeline-head-moved", reason: push_skip_reason}]
+                    else
+                      .
+                    end
+                )
+              | .addressed = []
+              ' "$ARTIFACT" > "$TMP_ARTIFACT"
+            mv "$TMP_ARTIFACT" "$ARTIFACT"
+
+            if [ -z "$REMOTE_HEAD" ]; then
+              echo "origin/${HEAD_REF} no longer exists; refusing to push fixer commit built from ${REVIEWED_SHA}"
+            else
+              echo "origin/${HEAD_REF} moved to ${REMOTE_HEAD}; refusing to push fixer commit built from ${REVIEWED_SHA}"
+            fi
+
+            echo "new_sha=$REVIEWED_SHA" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           # Claim review/pipeline on the new SHA BEFORE pushing.
           # This is the structural protection: the synchronize event
           # GitHub fires for the push will land on an already-claimed
@@ -148,8 +188,6 @@ jobs:
             -f context=review/pipeline \
             -f description="cycle=${{ inputs.cycle }} (fixer claim)" >/dev/null
 
-          # Push from the PR workspace, which has the PAT-authenticated remote.
-          cd "${{ env.PR_WORKSPACE_PATH }}"
           git push origin "HEAD:${HEAD_REF}"
 
           echo "new_sha=$NEW_SHA" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/review-reviewer.yml
+++ b/.github/workflows/review-reviewer.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.head_ref }}
+          ref: ${{ inputs.reviewed_sha }}
           repository: ${{ inputs.head_repo }}
           path: ${{ env.PR_WORKSPACE_PATH }}
           fetch-depth: 0

--- a/docs/agentic-pipeline-learnings.md
+++ b/docs/agentic-pipeline-learnings.md
@@ -46,9 +46,11 @@ Two meta-lessons span everything below:
 **Evidence:** #244, #234
 
 ### 1.7 Track immutable `reviewed_sha`, separate from the branch ref
-**Why:** Once a PR merges, the branch may be deleted. Follow-up validation must check out the SHA we reviewed, not the (now missing) branch.
+**Why:** Reviewers and fixers must check out the immutable `reviewed_sha`, not the mutable branch ref, because the branch may be deleted or advanced while the pipeline is still working. Any branch-writing stage must also re-read `origin/<head_ref>` immediately before push and refuse to publish if that tip no longer equals the frozen `reviewed_sha`; otherwise it can silently overwrite newer author commits with changes prepared against stale code.
 **Before:** Post-merge follow-ups failed with "could not fetch ref".
-**Evidence:** #308
+**Evidence:** #308, #351, #353, #354
+
+**Manual regression playbook:** Open a PR, let `review-entry.yml` freeze `reviewed_sha`, then push another commit before `review-fixer.yml` reaches its push step. The fixer should log that `origin/<head_ref>` moved, rewrite `fix-result.json` so `new_sha == input_sha == reviewed_sha`, add a `skipped[]` reason explaining the head changed, and exit without pushing. The subsequent judge/finalize path should evaluate the unchanged reviewed tree instead of overwriting the newer commit.
 
 ### 1.8 Dedupe workflow-failure issues by fingerprint
 **Why:** A helper script fingerprints failures by (workflow, branch, commit) and reuses any existing open issue.


### PR DESCRIPTION
Resolves #354

## Summary
- switch `review-reviewer.yml` and `review-fixer.yml` to check out the immutable `reviewed_sha` instead of the mutable `head_ref`
- make the v2 fixer re-read `origin/$HEAD_REF` before claiming/pushing and abort cleanly when the remote head moved or disappeared
- document the SHA-vs-branch invariant and a manual regression playbook in `docs/agentic-pipeline-learnings.md`

## Test Plan
- `shellcheck scripts/*.sh`
- `yamllint .github/workflows/*.yml`
- `node --test .github/scripts/review/aggregate.test.mjs`
- manual sanity check of the fixer artifact rewrite path with `jq`

Generated with Codex