### PR TITLE
Fix v2 review pipeline startup failure

### DIFF
--- a/.github/workflows/review-pipeline.yml
+++ b/.github/workflows/review-pipeline.yml
@@ -41,17 +41,16 @@ permissions:
 env:
   DEVCONTAINER_IMAGE: ghcr.io/nickborgersprobably/hide-my-list-devcontainer
 
-concurrency:
-  # SHA-keyed concurrency: two events for the same SHA collapse;
-  # different SHAs are independent runs of the pipeline (which is
-  # exactly the cycle granularity we want).
-  group: review-pipeline-v2-${{ inputs.reviewed_sha }}
-  cancel-in-progress: false
-
 jobs:
   gather:
     name: Gather + classify + cycle check
     runs-on: ubuntu-latest
+    concurrency:
+      # SHA-keyed concurrency: two events for the same SHA collapse;
+      # different SHAs are independent runs of the pipeline (which is
+      # exactly the cycle granularity we want).
+      group: review-pipeline-v2-${{ inputs.reviewed_sha }}
+      cancel-in-progress: false
     outputs:
       roles_json: ${{ steps.classify.outputs.roles_json }}
       cycle: ${{ steps.cycle.outputs.cycle }}


### PR DESCRIPTION
Resolves #356

## Summary
Moved the SHA-keyed concurrency group in `.github/workflows/review-pipeline.yml` from workflow scope to the `gather` job so the reusable workflow no longer references `inputs.reviewed_sha` at load time.

This preserves the per-reviewed-SHA serialization behavior for v2 runs while allowing the workflow to schedule normally.

## Test Plan
- Run `shellcheck scripts/*.sh`
- Run `yamllint .github/workflows/*.yml`
- Validate docs-relative markdown links under `docs/`
- Confirm the only workflow change removes top-level `concurrency` from `review-pipeline.yml` and adds the same group to `jobs.gather.concurrency`

Generated with Codex