### PR TITLE
Fix v2 outage: replace dynamic matrix with per-role caller jobs

### DIFF
--- a/.github/workflows/review-pipeline.yml
+++ b/.github/workflows/review-pipeline.yml
@@ -126,17 +126,112 @@ jobs:
     secrets:
       WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}
 
-  reviewers:
-    name: Reviewer (${{ matrix.role }})
+  # Per-role caller jobs.
+  #
+  # Why five separate jobs instead of one matrix job:
+  #
+  # GitHub Actions does NOT support a dynamic `strategy.matrix` (one
+  # built from `fromJSON(needs.*.outputs.*)`) on a reusable-workflow
+  # caller (`uses:`). The validator must resolve matrix dimensions at
+  # workflow load time, before any job has run. Trying it produces a
+  # `startup_failure` with no logs (this is the bug from #356/#358).
+  #
+  # AND: `matrix.*` context is NOT available in `jobs.<id>.if` on a
+  # reusable-workflow caller — only `github`, `inputs`, `needs`, and
+  # `vars` are. So we can't even declare a static matrix and gate
+  # per-row from `matrix.role`.
+  #
+  # The remaining options are: (a) always run all five reviewers and
+  # have abstain be a no-op at the prompt layer (wastes Codex calls
+  # and devcontainer spin-up), or (b) declare five separate caller
+  # jobs, each with a static role and an `if:` checking the
+  # classifier output. (b) is verbose but minimal-cost; we use it.
+  #
+  # Each job's `if:` is statically resolvable at workflow load time
+  # (the role string is a literal constant; the runtime check is
+  # `contains(needs.gather.outputs.roles_json, '<role>')`).
+
+  review-design:
+    name: Reviewer (design)
     needs: gather
-    if: needs.gather.outputs.capped != 'true'
-    strategy:
-      fail-fast: false
-      matrix:
-        role: ${{ fromJSON(needs.gather.outputs.roles_json) }}
+    if: |
+      needs.gather.outputs.capped != 'true' &&
+      contains(fromJSON(needs.gather.outputs.roles_json), 'design')
     uses: ./.github/workflows/review-reviewer.yml
     with:
-      role: ${{ matrix.role }}
+      role: design
+      pr_number: ${{ inputs.pr_number }}
+      reviewed_sha: ${{ inputs.reviewed_sha }}
+      head_ref: ${{ inputs.head_ref }}
+      head_repo: ${{ inputs.head_repo }}
+      cycle: ${{ needs.gather.outputs.cycle }}
+      devcontainer_image: ghcr.io/nickborgersprobably/hide-my-list-devcontainer
+    secrets:
+      WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}
+
+  review-security:
+    name: Reviewer (security)
+    needs: gather
+    if: |
+      needs.gather.outputs.capped != 'true' &&
+      contains(fromJSON(needs.gather.outputs.roles_json), 'security')
+    uses: ./.github/workflows/review-reviewer.yml
+    with:
+      role: security
+      pr_number: ${{ inputs.pr_number }}
+      reviewed_sha: ${{ inputs.reviewed_sha }}
+      head_ref: ${{ inputs.head_ref }}
+      head_repo: ${{ inputs.head_repo }}
+      cycle: ${{ needs.gather.outputs.cycle }}
+      devcontainer_image: ghcr.io/nickborgersprobably/hide-my-list-devcontainer
+    secrets:
+      WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}
+
+  review-psych:
+    name: Reviewer (psych)
+    needs: gather
+    if: |
+      needs.gather.outputs.capped != 'true' &&
+      contains(fromJSON(needs.gather.outputs.roles_json), 'psych')
+    uses: ./.github/workflows/review-reviewer.yml
+    with:
+      role: psych
+      pr_number: ${{ inputs.pr_number }}
+      reviewed_sha: ${{ inputs.reviewed_sha }}
+      head_ref: ${{ inputs.head_ref }}
+      head_repo: ${{ inputs.head_repo }}
+      cycle: ${{ needs.gather.outputs.cycle }}
+      devcontainer_image: ghcr.io/nickborgersprobably/hide-my-list-devcontainer
+    secrets:
+      WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}
+
+  review-docs:
+    name: Reviewer (docs)
+    needs: gather
+    if: |
+      needs.gather.outputs.capped != 'true' &&
+      contains(fromJSON(needs.gather.outputs.roles_json), 'docs')
+    uses: ./.github/workflows/review-reviewer.yml
+    with:
+      role: docs
+      pr_number: ${{ inputs.pr_number }}
+      reviewed_sha: ${{ inputs.reviewed_sha }}
+      head_ref: ${{ inputs.head_ref }}
+      head_repo: ${{ inputs.head_repo }}
+      cycle: ${{ needs.gather.outputs.cycle }}
+      devcontainer_image: ghcr.io/nickborgersprobably/hide-my-list-devcontainer
+    secrets:
+      WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}
+
+  review-prompt:
+    name: Reviewer (prompt)
+    needs: gather
+    if: |
+      needs.gather.outputs.capped != 'true' &&
+      contains(fromJSON(needs.gather.outputs.roles_json), 'prompt')
+    uses: ./.github/workflows/review-reviewer.yml
+    with:
+      role: prompt
       pr_number: ${{ inputs.pr_number }}
       reviewed_sha: ${{ inputs.reviewed_sha }}
       head_ref: ${{ inputs.head_ref }}
@@ -148,7 +243,7 @@ jobs:
 
   fix:
     name: Apply reviewer-requested fixes
-    needs: [gather, reviewers]
+    needs: [gather, review-design, review-security, review-psych, review-docs, review-prompt]
     if: needs.gather.outputs.capped != 'true'
     uses: ./.github/workflows/review-fixer.yml
     with:
@@ -163,7 +258,7 @@ jobs:
 
   judge:
     name: Judge (read-only aggregator)
-    needs: [gather, reviewers, fix]
+    needs: [gather, review-design, review-security, review-psych, review-docs, review-prompt, fix]
     if: needs.gather.outputs.capped != 'true'
     uses: ./.github/workflows/review-judge.yml
     with:


### PR DESCRIPTION
**Critical, currently outage.** v2 is still 100% wedged after #358 — every run on every PR is `startup_failure` with no logs. #358 fixed one Phase 1 startup_failure cause (workflow-level concurrency referencing `inputs.*`) but a second cause was lurking behind it.

## Root cause (second bug)

`review-pipeline.yml` had a dynamic-matrix reusable-workflow caller:

```yaml
reviewers:
  needs: gather
  strategy:
    matrix:
      role: ${{ fromJSON(needs.gather.outputs.roles_json) }}
  uses: ./.github/workflows/review-reviewer.yml
```

GitHub Actions does **not** support this pattern. The `strategy.matrix` on a reusable-workflow caller (`uses:`) must be statically resolvable at workflow **load time**, before any job has run. `fromJSON` of a runtime-resolved `needs.*.outputs.*` value is not statically resolvable, so the validator rejects the workflow with `startup_failure` and no logs.

**And**: `matrix.*` context is not available in `jobs.<id>.if` on a reusable-workflow caller — only `github`, `inputs`, `needs`, and `vars` are. So the workaround "declare a static matrix and gate per-row from `matrix.role`" doesn't work either (actionlint catches that one locally — exit code 1 with `context "matrix" is not allowed here`).

## Fix

Replace the single matrix job with **five separate caller jobs**, one per role. Each has a hardcoded role string and an `if:` that runtime-checks `contains(fromJSON(needs.gather.outputs.roles_json), '<role>')`. The `if:` IS allowed to reference `needs.*.outputs.*` at job-schedule time — only the matrix dimensions have to be load-time resolvable.

Verbose (5 nearly-identical jobs in one file) but correct and minimal-cost: roles the classifier excludes simply skip with no Codex spend or devcontainer spin-up. The classifier in `gather` remains the single source of truth for role selection.

`judge.needs` updated to depend on the five new caller jobs instead of the removed `reviewers` matrix.

## Validation

- [x] `/tmp/actionlint .github/workflows/review-pipeline.yml` — clean
- [x] `bash scripts/validate-workflow-refs.sh` — clean
- [x] `node --test .github/scripts/review/aggregate.test.mjs` — 16/16 pass

## Why this slipped through (again)

Same lesson as #356: actionlint and `validate-workflow-refs.sh` don't catch GHA runtime-only validation rules. Both #356 and this one only surface under live execution. The right long-term answer is what #344 + #346 propose: a smoke-run job in CI that exercises the v2 entry workflow against a fixture, gated on changes to `.github/workflows/review-*.yml`. That would have caught both bugs at PR review time, before they shipped.

## Test plan

- [ ] CI workflow runs as usual (this PR is on a branch, so the v1 monolith reviews it because the variable is set repo-wide... wait. v1 is currently gated OFF. The v2 review on this PR will itself startup_failure until this PR merges. Recommend merging directly without waiting for v2 review on the PR that fixes v2.)
- [ ] After merge: post `/review` on a known PR and observe a non-`startup_failure` `review-entry` run, confirming v2 is unwedged