### PR TITLE
Drop GITHUB_TOKEN write declarations: v2 uses WORKFLOW_PAT for all writes

### DIFF
--- a/.github/workflows/review-entry.yml
+++ b/.github/workflows/review-entry.yml
@@ -18,24 +18,24 @@ on:
     types: [created]
 
 permissions:
-  # Reusable-workflow callees can only request a SUBSET of the
-  # caller's permissions. review-entry.yml is the top of the v2
-  # dispatch chain, so it must declare the UNION of every
-  # permission any downstream reusable workflow needs:
-  #   - review-reviewer.yml needs pull-requests: write to post
-  #     GitHub PR Reviews via review-publish
-  #   - review-fixer.yml needs contents: write to push the fixer
-  #     commit, plus pull-requests: write
-  #   - review-finalize.yml needs issues: write (label create) and
-  #     pull-requests: write (sticky comment + label apply)
-  #   - all stages need statuses: write to advance review/* state
-  # The downstream workflows still re-declare their narrower needs
-  # in their own permissions: blocks; this just ensures the chain
-  # validates at workflow load time.
-  contents: write
-  issues: write
-  pull-requests: write
-  statuses: write
+  # GITHUB_TOKEN is only used for `actions/checkout@v4` (read) and
+  # the `statuses:` updates the entry workflow does directly via
+  # the dedup action (which actually authenticates via WORKFLOW_PAT
+  # — see comment below).
+  #
+  # Every actual write operation in the v2 pipeline — posting PR
+  # Reviews, pushing fixer commits, applying labels, writing
+  # commit statuses — uses `secrets.WORKFLOW_PAT` per
+  # agentic-pipeline-learnings.md §2.3, NOT GITHUB_TOKEN. So the
+  # GITHUB_TOKEN scopes for the entire reusable graph can stay
+  # at minimum-privilege read.
+  #
+  # GH validates that reusable callees declare a SUBSET of the
+  # caller's permissions block, so this read-only declaration
+  # forces every downstream review-*.yml to also declare read-only.
+  contents: read
+  pull-requests: read
+  statuses: read
 
 concurrency:
   group: review-entry-v2-${{ github.event_name == 'issue_comment' && format('pr-{0}', github.event.issue.number) || github.event.pull_request.head.ref }}

--- a/.github/workflows/review-finalize.yml
+++ b/.github/workflows/review-finalize.yml
@@ -32,10 +32,13 @@ on:
         required: true
 
 permissions:
+  # Read-only GITHUB_TOKEN. The label create, sticky comment, and
+  # cycle-status write all authenticate via secrets.WORKFLOW_PAT,
+  # not GITHUB_TOKEN.
   contents: read
-  pull-requests: write
-  issues: write
-  statuses: write
+  pull-requests: read
+  issues: read
+  statuses: read
 
 jobs:
   finalize:

--- a/.github/workflows/review-fixer.yml
+++ b/.github/workflows/review-fixer.yml
@@ -44,9 +44,15 @@ on:
         required: true
 
 permissions:
-  contents: write
-  pull-requests: write
-  statuses: write
+  # Read-only GITHUB_TOKEN. The fixer's `git push` uses the
+  # WORKFLOW_PAT-authenticated remote (set up via the PR-branch
+  # actions/checkout step that passes token: secrets.WORKFLOW_PAT),
+  # not GITHUB_TOKEN. Same for the `gh api .../statuses` claim and
+  # any `gh pr` calls. Actions/checkout for the orchestration
+  # workspace only needs read.
+  contents: read
+  pull-requests: read
+  statuses: read
 
 env:
   PR_WORKSPACE_PATH: pr-head

--- a/.github/workflows/review-judge.yml
+++ b/.github/workflows/review-judge.yml
@@ -39,8 +39,13 @@ on:
 
 # Read-only by construction. Judge cannot push.
 permissions:
+  # Read-only GITHUB_TOKEN. The verdict commit-status write
+  # authenticates via secrets.WORKFLOW_PAT through review-state.
+  # The judge has no git credentials in scope and structurally
+  # cannot push — that's the property closing the autofix loop
+  # class from #336.
   contents: read
-  statuses: write
+  statuses: read
 
 jobs:
   judge:

--- a/.github/workflows/review-pipeline.yml
+++ b/.github/workflows/review-pipeline.yml
@@ -33,10 +33,14 @@ on:
         required: true
 
 permissions:
+  # Read-only GITHUB_TOKEN. Every actual write in this graph
+  # authenticates via secrets.WORKFLOW_PAT (rule 2.3), not
+  # GITHUB_TOKEN. The downstream callees are also read-only on
+  # GITHUB_TOKEN; this declaration must be a subset of the
+  # caller's (review-entry.yml) permissions.
   contents: read
-  pull-requests: write
-  statuses: write
-  issues: write
+  pull-requests: read
+  statuses: read
 
 env:
   DEVCONTAINER_IMAGE: ghcr.io/nickborgersprobably/hide-my-list-devcontainer

--- a/.github/workflows/review-reviewer.yml
+++ b/.github/workflows/review-reviewer.yml
@@ -35,9 +35,13 @@ on:
         required: true
 
 permissions:
+  # Read-only GITHUB_TOKEN. Posting GitHub PR Reviews via
+  # review-publish authenticates with secrets.WORKFLOW_PAT, not
+  # GITHUB_TOKEN (rule 2.3). The reviewer-setup composite action
+  # uses GITHUB_TOKEN for actions/checkout only.
   contents: read
-  pull-requests: write
-  statuses: write
+  pull-requests: read
+  statuses: read
 
 env:
   PR_WORKSPACE_PATH: pr-head


### PR DESCRIPTION
**Critical, currently outage.** Follow-up to #363, which merged with only the first commit on the branch — the *wrong* approach. The corrected commit was pushed seconds after the merge happened and never landed on main. v2 is still wedged.

## What #363 actually did (the wrong fix)

#363 merged commit `54da38a` only, which escalated `review-entry.yml`'s `GITHUB_TOKEN` permissions to `*: write` so the downstream callees' write declarations would be a valid subset.

**That was wrong.** Every actual write operation in v2 already authenticates via `secrets.WORKFLOW_PAT` per agentic-pipeline-learnings.md §2.3, **not** GITHUB_TOKEN. The downstream `permissions: write` declarations are lying about what's needed.

After #363 merged, the next `review-entry` run still failed:

> Error calling workflow 'review-fixer.yml@<sha>'. The workflow is requesting 'contents: write', but is only allowed 'contents: read'.

(My #363 second commit reverted the entry-side escalation back to `read`, so the chain still doesn't validate without also dropping the downstream write declarations.)

## This PR

Lands the corrected approach as a single commit:

| File | Change |
|---|---|
| `review-entry.yml` | revert prior `*: write` escalation back to `*: read` |
| `review-pipeline.yml` | `pull-requests/statuses/issues: write` → `: read` |
| `review-reviewer.yml` | `pull-requests/statuses: write` → `: read` |
| `review-fixer.yml` | `contents/pull-requests/statuses: write` → `: read` |
| `review-judge.yml` | `statuses: write` → `: read` |
| `review-finalize.yml` | `pull-requests/issues/statuses: write` → `: read` |

Audit (every write confirmed to use WORKFLOW_PAT, not GITHUB_TOKEN):

| Operation | Token used |
|---|---|
| `gh pr review --body-file` (post PR Review) | `${{ inputs.workflow_pat }}` |
| `git push` (fixer commit) | checkout `token: secrets.WORKFLOW_PAT` → PAT-authed remote |
| `gh api .../statuses` (fixer SHA claim, finalize cycle) | `secrets.WORKFLOW_PAT` |
| `gh pr edit/comment` (NO-GO label + sticky) | `secrets.WORKFLOW_PAT` |
| `review-state` writes | input `github_token` = `secrets.WORKFLOW_PAT` |
| `review-dedup` claim | input `github_token` = `secrets.WORKFLOW_PAT` |

`GITHUB_TOKEN` is only used by `actions/checkout@v4` for the read-only main checkout in each job. So the entire v2 graph can declare `GITHUB_TOKEN` as read-only.

## Strictly more secure than #363's approach

A bug or compromise in any v2 step **cannot** use `GITHUB_TOKEN` to push, comment, or label — the token literally has no scopes for that. The only way to write anything is by explicitly receiving the PAT through the `secrets:` block, which the design audits at every job boundary.

## Validation

- [x] `/tmp/actionlint` over all six v2 workflows: clean
- [x] `bash scripts/validate-workflow-refs.sh`: clean

## Same caveat as #361/#363

v2 still cannot review this PR. Merge directly. After merge, post `/review` on a known PR and the next `review-entry` run should land on `gather` for the first time since the variable was flipped.

Resolves the v2 outage chain begun by #356.