### PR TITLE
Add issues:read to v2 entry/pipeline permissions

### DIFF
--- a/.github/workflows/review-entry.yml
+++ b/.github/workflows/review-entry.yml
@@ -34,6 +34,7 @@ permissions:
   # caller's permissions block, so this read-only declaration
   # forces every downstream review-*.yml to also declare read-only.
   contents: read
+  issues: read
   pull-requests: read
   statuses: read
 

--- a/.github/workflows/review-pipeline.yml
+++ b/.github/workflows/review-pipeline.yml
@@ -39,6 +39,7 @@ permissions:
   # GITHUB_TOKEN; this declaration must be a subset of the
   # caller's (review-entry.yml) permissions.
   contents: read
+  issues: read
   pull-requests: read
   statuses: read
 


### PR DESCRIPTION
**Critical, currently outage.** Fifth Phase 1 startup_failure cause. Caught by scraping the GH UI annotation:

> Error calling workflow 'review-finalize.yml@<sha>'. The workflow is requesting 'issues: read', but is only allowed 'issues: none'.

## Root cause

`review-finalize.yml` declares `issues: read` in its permissions block. After #364 dropped every v2 workflow's GITHUB_TOKEN to read-only, neither `review-entry.yml` nor `review-pipeline.yml` listed `issues:` at all — and when a `permissions:` block is set explicitly, any unlisted scope defaults to `none`. So the chain became:

- entry: `issues: none` (default)
- pipeline: `issues: none` (default)
- finalize: `issues: read` ← exceeds parent

GH validates the entire reusable graph at workflow load time and rejects the dispatch.

## Fix

Add `issues: read` to both `review-entry.yml` and `review-pipeline.yml`. The actual label create / sticky comment / cycle status writes in finalize still flow through `WORKFLOW_PAT` per #364 — this just makes the static GITHUB_TOKEN scope check satisfied.

## Validation

- [x] `/tmp/actionlint` over both touched files: clean

## Same caveat as #361/#363/#364

v2 still cannot review this PR. Merge directly. After merge, post `/review` on a known PR and watch.

## The full chain so far (5 distinct Phase 1 bugs)

1. **#356 → #358**: workflow-level `concurrency:` referencing `inputs.*`
2. **#361**: dynamic `strategy.matrix` from `fromJSON(needs.*.outputs.*)` on a reusable-workflow caller
3. **#363**: reusable callee permissions exceed caller (wrong fix)
4. **#364**: drop all downstream `: write` to `: read`, since real writes use WORKFLOW_PAT (correct fix)
5. **This PR**: `issues:` scope omitted from upstream callers, defaulting to `none` and excluding finalize's `issues: read`

If there's a sixth one I'm going to start advocating for the smoke-test invariant from #346 on the spot.