### PR TITLE
Add packages:read to v2 workflows that pull the devcontainer image

### DIFF
--- a/.github/workflows/review-entry.yml
+++ b/.github/workflows/review-entry.yml
@@ -35,6 +35,7 @@ permissions:
   # forces every downstream review-*.yml to also declare read-only.
   contents: read
   issues: read
+  packages: read
   pull-requests: read
   statuses: read
 

--- a/.github/workflows/review-fixer.yml
+++ b/.github/workflows/review-fixer.yml
@@ -51,6 +51,7 @@ permissions:
   # any `gh pr` calls. Actions/checkout for the orchestration
   # workspace only needs read.
   contents: read
+  packages: read
   pull-requests: read
   statuses: read
 

--- a/.github/workflows/review-pipeline.yml
+++ b/.github/workflows/review-pipeline.yml
@@ -40,6 +40,7 @@ permissions:
   # caller's (review-entry.yml) permissions.
   contents: read
   issues: read
+  packages: read
   pull-requests: read
   statuses: read
 

--- a/.github/workflows/review-reviewer.yml
+++ b/.github/workflows/review-reviewer.yml
@@ -40,6 +40,7 @@ permissions:
   # GITHUB_TOKEN (rule 2.3). The reviewer-setup composite action
   # uses GITHUB_TOKEN for actions/checkout only.
   contents: read
+  packages: read
   pull-requests: read
   statuses: read
 


### PR DESCRIPTION
Sixth Phase 1 startup_failure cause, surfaced as a runtime 403 from GHCR after #365 unblocked load-time validation:

\`\`\`
Error response from daemon: failed to resolve reference
"ghcr.io/nickborgersprobably/hide-my-list-devcontainer:latest":
unexpected status from HEAD request: 403 Forbidden
\`\`\`

## Cause

\`review-reviewer.yml\` and \`review-fixer.yml\` use \`docker/login-action@v3\` with \`password: \${{ secrets.GITHUB_TOKEN }}\` to authenticate against GHCR. After #364 dropped GITHUB_TOKEN to read-only and #365 added the missing \`issues: read\` scope, \`packages:\` was still implicitly \`none\` (explicit permissions blocks default unlisted scopes to none). GHCR rejected the manifest fetch.

## Fix

Add \`packages: read\` to the four v2 workflows that pull or transitively need to pull the devcontainer image:

- \`review-entry.yml\` (top of dispatch chain)
- \`review-pipeline.yml\` (orchestrator, intermediate)
- \`review-reviewer.yml\` (does the docker/login + pull)
- \`review-fixer.yml\` (does the docker/login + pull)

\`review-judge.yml\` and \`review-finalize.yml\` don't pull the devcontainer image — they're pure-runner steps — so they don't need \`packages: read\`.

## Validation

- [x] \`/tmp/actionlint\` over all six v2 workflows: clean

## Same caveat

This is now the **second** runtime bug after the orchestrator started actually running. Authorize → Resolve → Gather → role-gating all worked on PR #365. The reviewer jobs reach \`docker/login\` and fail there. Once this lands, the reviewers should successfully pull the image and reach the actual Codex invocation, and any new bugs from there are real reviewer prompt / Codex execution issues — different class entirely.

## Full chain to date

Load-time validation:
1. **#356 → #358**: workflow-level concurrency on \`inputs.*\`
2. **#361**: dynamic matrix on reusable-workflow caller
3. **#363**: caller permissions exceeded by callees (wrong fix)
4. **#364**: drop downstream writes to read since real writes use WORKFLOW_PAT
5. **#365**: add \`issues: read\` (was defaulted to none)
6. **This PR**: add \`packages: read\` (same class as #365, different scope)

If #344's smoke-run job had been in place, all six would have been caught at PR review time before any of them shipped.