### PR TITLE
Pass --spec=draft2020 to ajv-cli for reviewer + fix-result validation

### DIFF
--- a/.github/workflows/review-fixer.yml
+++ b/.github/workflows/review-fixer.yml
@@ -117,7 +117,12 @@ jobs:
           ARTIFACT: ${{ steps.run.outputs.result_json }}
         run: |
           set -euo pipefail
+          # Schema declares $schema: draft/2020-12. ajv-cli@5 needs an
+          # explicit --spec=draft2020 flag to register the meta-schema;
+          # without it the schema parse fails with "no schema with key
+          # or ref https://json-schema.org/draft/2020-12/schema".
           npx -y ajv-cli@5 validate \
+            --spec=draft2020 \
             -s .github/scripts/review/schema/fix-result-v1.json \
             -d "$ARTIFACT"
 

--- a/.github/workflows/review-reviewer.yml
+++ b/.github/workflows/review-reviewer.yml
@@ -94,7 +94,12 @@ jobs:
           ARTIFACT: ${{ steps.run.outputs.result_json }}
         run: |
           set -euo pipefail
+          # Schema declares $schema: draft/2020-12. ajv-cli@5 needs an
+          # explicit --spec=draft2020 flag to register the meta-schema;
+          # without it the schema parse fails with "no schema with key
+          # or ref https://json-schema.org/draft/2020-12/schema".
           npx -y ajv-cli@5 validate \
+            --spec=draft2020 \
             -s .github/scripts/review/schema/reviewer-v1.json \
             -d "$ARTIFACT"
 


### PR DESCRIPTION
**Runtime fix** — the v2 orchestrator now successfully runs reviewers in the devcontainer and Codex produces valid JSON verdicts on disk. The validator step then fails with:

\`\`\`
schema .github/scripts/review/schema/reviewer-v1.json is invalid
error: no schema with key or ref \"https://json-schema.org/draft/2020-12/schema\"
\`\`\`

## Cause

Both \`reviewer-v1.json\` and \`fix-result-v1.json\` declare \`\$schema: https://json-schema.org/draft/2020-12/schema\`. ajv-cli@5 supports draft 2020-12 but only when invoked with \`--spec=draft2020\`; without that flag it falls back to draft-07 and can't register the meta-schema reference.

## Fix

Pass \`--spec=draft2020\` in both \`review-reviewer.yml\` and \`review-fixer.yml\` ajv-cli invocations. The schemas don't change — they're correct as-is.

## Why this matters: we are past the architectural issues

Unlike the previous SIX v2 outage causes (#356/#358, #361, #363, #364, #365, #366), this one only fires **after** the orchestrator successfully:
- authorizes the trigger
- resolves the SHA
- dedup-claims it
- gathers context and classifies the diff
- dispatches the right reviewers via the per-role caller jobs
- pulls the devcontainer image from GHCR
- runs Codex against the standalone \`design.md\` prompt file
- captures Codex's structured JSON verdict to \`/tmp/design-result.json\`

Codex's actual design verdict on the run that surfaced this:

> decision: \`approve\`  
> summary: \"PR #353 implements issue #351 by switching the design, security, psych, docs, and prompt review jobs from mutable \`head_ref\` checkouts to immutable \`reviewed_sha\` checkouts, with the same guarded local-branch reattach pattern already used by \`merge-decision\`. Scope check: PASS; the diff stays within the review workflow and matches the title. No intent gaps, over-engineering, or spec-consistency problems found.\"

**The new pipeline IS reviewing PRs.** Architecture works. Remaining bugs are individual step issues like this one — much narrower blast radius.

## Validation

- [x] \`/tmp/actionlint\` over both touched files: clean