### PR TITLE
Freeze v2 review diffs to the PR base SHA

### DIFF
--- a/.github/actions/review-classify/action.yml
+++ b/.github/actions/review-classify/action.yml
@@ -2,8 +2,9 @@
 name: Review pipeline file classifier
 description: >
   Single source of truth for "which reviewer roles apply to this SHA"
-  in the v2 review pipeline. Classifies the diff against origin/main
-  and emits a JSON list of applicable roles.
+  in the v2 review pipeline. Classifies the diff against the frozen
+  PR base SHA captured at entry time and emits a JSON list of
+  applicable roles.
 
   Today the rules are:
     - design:    always
@@ -24,8 +25,8 @@ description: >
   design/adhd-priorities.md, and .github/scripts/review/prompts/*.md.
 
 inputs:
-  base_ref:
-    description: Base ref to diff against
+  base_sha:
+    description: Frozen PR base revision to diff against
     required: false
     default: origin/main
   head_sha:
@@ -50,19 +51,20 @@ runs:
       id: classify
       shell: bash
       env:
-        BASE_REF: ${{ inputs.base_ref }}
+        BASE_SHA: ${{ inputs.base_sha }}
         HEAD_SHA: ${{ inputs.head_sha }}
       run: |
         set -euo pipefail
 
         git fetch origin main >/dev/null 2>&1 || true
 
-        FILES=$(git diff --name-only "${BASE_REF}"...HEAD 2>/dev/null || echo "")
+        FILES=$(git diff --name-only "${BASE_SHA}"...HEAD 2>/dev/null || echo "")
         if [ -z "$FILES" ]; then
           # No diff (e.g. empty PR). Classify as docs_only so only the
           # cheap reviewers run; the judge will produce a vacuous result
-          # and the orchestrator will fail closed.
-          echo "review-classify: empty diff for $HEAD_SHA"
+          # and the orchestrator will fail closed. This should be
+          # computed against the immutable PR base, not mutable main.
+          echo "review-classify: empty diff for $HEAD_SHA vs base $BASE_SHA"
         fi
 
         DOCS_ONLY=true

--- a/.github/scripts/review/prompts/_shared.md
+++ b/.github/scripts/review/prompts/_shared.md
@@ -18,7 +18,9 @@ review** — you must not edit files, run formatters, or push commits.
 
 ### What to do
 
-1. Read the diff: `git fetch origin main && git diff origin/main...HEAD`.
+1. Read the diff: `git diff "${PR_BASE_SHA}"...HEAD`. The frozen
+   `PR_BASE_SHA` is the only valid base for post-merge or delayed
+   review runs; do not rebase your review on current `origin/main`.
 2. Read inline PR review comments via
    `gh api repos/${REPO}/pulls/${PR_NUMBER}/comments` and any blocking
    change requests there must be folded into your `blocking_issues[]`

--- a/.github/scripts/review/prompts/design.md
+++ b/.github/scripts/review/prompts/design.md
@@ -33,8 +33,8 @@ Reference `docs/architecture.md` for system design context.
 
 ## Procedure
 
-1. `git fetch origin main && git diff origin/main...HEAD` — read the
-   full diff.
+1. `git diff "${PR_BASE_SHA}"...HEAD` — read the full diff from the
+   frozen PR base, not current `origin/main`.
 2. `gh api repos/${REPO}/pulls/${PR_NUMBER}/comments` — read inline
    comments. Any blocking change requests there must appear in your
    `blocking_issues[]` with `source: "inline_comment"`.

--- a/.github/scripts/review/prompts/docs.md
+++ b/.github/scripts/review/prompts/docs.md
@@ -30,7 +30,8 @@ Lens:
 
 ## Procedure
 
-1. `git diff origin/main...HEAD` — read the full diff.
+1. `git diff "${PR_BASE_SHA}"...HEAD` — read the full diff from the
+   frozen PR base.
 2. For each changed `.md` file, identify cross-references and
    double-check them.
 3. `gh api repos/${REPO}/pulls/${PR_NUMBER}/comments` — read inline

--- a/.github/scripts/review/prompts/prompt.md
+++ b/.github/scripts/review/prompts/prompt.md
@@ -37,7 +37,8 @@ If the diff does not touch any prompt or `.md` agent-spec file, set
 
 ## Procedure
 
-1. `git diff origin/main...HEAD` — read the full diff.
+1. `git diff "${PR_BASE_SHA}"...HEAD` — read the full diff from the
+   frozen PR base.
 2. For each changed prompt file, apply the lens above and
    cross-reference related prompts.
 3. `gh api repos/${REPO}/pulls/${PR_NUMBER}/comments` — read inline

--- a/.github/scripts/review/prompts/psych.md
+++ b/.github/scripts/review/prompts/psych.md
@@ -32,7 +32,8 @@ explaining why.
 
 ## Procedure
 
-1. `git diff origin/main...HEAD` — read the full diff.
+1. `git diff "${PR_BASE_SHA}"...HEAD` — read the full diff from the
+   frozen PR base.
 2. `gh api repos/${REPO}/pulls/${PR_NUMBER}/comments` — read inline
    comments. Fold any blocking ones into `blocking_issues[]` with
    `source: "inline_comment"`.

--- a/.github/scripts/review/prompts/security.md
+++ b/.github/scripts/review/prompts/security.md
@@ -40,7 +40,8 @@ apply it via your `fix_suggestions[]`.
 
 ## Procedure
 
-1. `git diff origin/main...HEAD` — read the full diff.
+1. `git diff "${PR_BASE_SHA}"...HEAD` — read the full diff from the
+   frozen PR base.
 2. `gh api repos/${REPO}/pulls/${PR_NUMBER}/comments` — read inline
    comments. Any blocking change requests there must appear in your
    `blocking_issues[]` with `source: "inline_comment"`.

--- a/.github/workflows/review-pipeline.yml
+++ b/.github/workflows/review-pipeline.yml
@@ -8,7 +8,9 @@ name: Review pipeline v2 — orchestrator
 #
 # State is SHA-keyed: every stage writes a review/* commit status on
 # the SHA it operated on. The cycle counter walks the commit chain
-# back to the PR base via review-state read-cycle.
+# back to the frozen PR base via review-state read-cycle, and all
+# diff-based routing must use that same immutable base SHA rather
+# than mutable origin/main.
 
 on:
   workflow_call:
@@ -105,7 +107,7 @@ jobs:
         if: steps.cap.outputs.capped != 'true'
         uses: ./.github/actions/review-classify
         with:
-          base_ref: origin/main
+          base_sha: ${{ inputs.base_sha }}
           head_sha: ${{ inputs.reviewed_sha }}
 
       - name: Stamp gather status
@@ -168,6 +170,7 @@ jobs:
       role: design
       pr_number: ${{ inputs.pr_number }}
       reviewed_sha: ${{ inputs.reviewed_sha }}
+      base_sha: ${{ inputs.base_sha }}
       head_ref: ${{ inputs.head_ref }}
       head_repo: ${{ inputs.head_repo }}
       cycle: ${{ needs.gather.outputs.cycle }}
@@ -186,6 +189,7 @@ jobs:
       role: security
       pr_number: ${{ inputs.pr_number }}
       reviewed_sha: ${{ inputs.reviewed_sha }}
+      base_sha: ${{ inputs.base_sha }}
       head_ref: ${{ inputs.head_ref }}
       head_repo: ${{ inputs.head_repo }}
       cycle: ${{ needs.gather.outputs.cycle }}
@@ -204,6 +208,7 @@ jobs:
       role: psych
       pr_number: ${{ inputs.pr_number }}
       reviewed_sha: ${{ inputs.reviewed_sha }}
+      base_sha: ${{ inputs.base_sha }}
       head_ref: ${{ inputs.head_ref }}
       head_repo: ${{ inputs.head_repo }}
       cycle: ${{ needs.gather.outputs.cycle }}
@@ -222,6 +227,7 @@ jobs:
       role: docs
       pr_number: ${{ inputs.pr_number }}
       reviewed_sha: ${{ inputs.reviewed_sha }}
+      base_sha: ${{ inputs.base_sha }}
       head_ref: ${{ inputs.head_ref }}
       head_repo: ${{ inputs.head_repo }}
       cycle: ${{ needs.gather.outputs.cycle }}
@@ -240,6 +246,7 @@ jobs:
       role: prompt
       pr_number: ${{ inputs.pr_number }}
       reviewed_sha: ${{ inputs.reviewed_sha }}
+      base_sha: ${{ inputs.base_sha }}
       head_ref: ${{ inputs.head_ref }}
       head_repo: ${{ inputs.head_repo }}
       cycle: ${{ needs.gather.outputs.cycle }}

--- a/.github/workflows/review-reviewer.yml
+++ b/.github/workflows/review-reviewer.yml
@@ -18,6 +18,9 @@ on:
       reviewed_sha:
         type: string
         required: true
+      base_sha:
+        type: string
+        required: true
       head_ref:
         type: string
         required: true
@@ -88,6 +91,8 @@ jobs:
           cycle: ${{ inputs.cycle }}
           read_only: 'true'
           workflow_pat: ${{ secrets.WORKFLOW_PAT }}
+          extra_env: |
+            PR_BASE_SHA=${{ inputs.base_sha }}
 
       - name: Validate reviewer artifact against schema
         env:

--- a/docs/agentic-pipeline-learnings.md
+++ b/docs/agentic-pipeline-learnings.md
@@ -46,7 +46,7 @@ Two meta-lessons span everything below:
 **Evidence:** #244, #234
 
 ### 1.7 Track immutable `reviewed_sha`, separate from the branch ref
-**Why:** Reviewers and fixers must check out the immutable `reviewed_sha`, not the mutable branch ref, because the branch may be deleted or advanced while the pipeline is still working. Any branch-writing stage must also re-read `origin/<head_ref>` immediately before push and refuse to publish if that tip no longer equals the frozen `reviewed_sha`; otherwise it can silently overwrite newer author commits with changes prepared against stale code.
+**Why:** Reviewers and fixers must check out the immutable `reviewed_sha`, not the mutable branch ref, because the branch may be deleted or advanced while the pipeline is still working. The same rule applies to diff computation: classifier routing and reviewer prompts must compare `${reviewed_sha}` against the frozen PR base SHA captured at entry time, not mutable `origin/main`, or post-merge/delayed runs can collapse to an empty diff and silently skip specialist coverage. Any branch-writing stage must also re-read `origin/<head_ref>` immediately before push and refuse to publish if that tip no longer equals the frozen `reviewed_sha`; otherwise it can silently overwrite newer author commits with changes prepared against stale code.
 **Before:** Post-merge follow-ups failed with "could not fetch ref".
 **Evidence:** #308, #351, #353, #354
 


### PR DESCRIPTION
Resolves #371

## Summary
- route v2 reviewer classification from the immutable PR base SHA captured by `review-entry.yml` instead of mutable `origin/main`
- pass the frozen base SHA through reviewer jobs so post-merge or delayed specialist reviews inspect the actual PR diff
- update reviewer guidance and pipeline learnings to document the frozen-base invariant for v2 routing

## Test Plan
- shellcheck scripts/*.sh
- yamllint .github/workflows/*.yml
- git diff --check

Generated with Codex