### PR TITLE
review-pipeline: add always-runs cleanup-claim job (closes #368)

### DIFF
--- a/.github/workflows/review-pipeline.yml
+++ b/.github/workflows/review-pipeline.yml
@@ -287,3 +287,44 @@ jobs:
       verdict: ${{ needs.judge.outputs.verdict }}
     secrets:
       WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}
+
+  # Always-runs cleanup. Advances the `review/pipeline` commit status
+  # from `pending` (set by review-dedup at entry time) to a terminal
+  # state, regardless of whether any upstream job in the orchestrator
+  # succeeded, failed, or was skipped. Without this, a failed
+  # reviewer/fixer/judge run leaks the pending claim forever and
+  # blocks future re-claims (see #368).
+  #
+  # The dedup action only refuses claims when the existing state is
+  # `pending`, so any non-pending terminal value here is sufficient
+  # to allow the next event (push, /review) to start a fresh run.
+  cleanup-claim:
+    name: Cleanup pipeline claim
+    needs:
+      - gather
+      - cap-exhausted
+      - review-design
+      - review-security
+      - review-psych
+      - review-docs
+      - review-prompt
+      - fix
+      - judge
+      - finalize
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main (for composite actions)
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Advance review/pipeline claim to terminal
+        uses: ./.github/actions/review-state
+        with:
+          op: write-status
+          sha: ${{ inputs.reviewed_sha }}
+          context: review/pipeline
+          state: success
+          description: 'pipeline run completed'
+          github_token: ${{ secrets.WORKFLOW_PAT }}


### PR DESCRIPTION
Adds an `if: always()` cleanup job to the orchestrator that advances `review/pipeline` from `pending` to a terminal state regardless of whether any upstream job failed. Closes #368.

Without this, every failed run leaked the pending claim forever and blocked all future re-claims, making /review comments useless on any SHA that had a failed pipeline run.

Loop-impossibility is preserved: the fixer's push still triggers a synchronize event that hits a fresh pending claim and bails. cleanup-claim only runs at the very end of the orchestrator.