### PR TITLE
review-pipeline: allow skipped reviewers in fix/judge needs

### DIFF
--- a/.github/workflows/review-pipeline.yml
+++ b/.github/workflows/review-pipeline.yml
@@ -250,7 +250,17 @@ jobs:
   fix:
     name: Apply reviewer-requested fixes
     needs: [gather, review-design, review-security, review-psych, review-docs, review-prompt]
-    if: needs.gather.outputs.capped != 'true'
+    # GHA defaults dependent jobs to skipped if any `needs:` job is
+    # skipped — but per-role gating means several reviewers WILL be
+    # skipped on every run (psych/prompt for config-only diffs,
+    # security for docs-only, etc.). We allow skipped reviewers but
+    # block on actual failure or cancellation.
+    if: |
+      always() &&
+      needs.gather.outputs.capped != 'true' &&
+      needs.gather.result == 'success' &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled')
     uses: ./.github/workflows/review-fixer.yml
     with:
       pr_number: ${{ inputs.pr_number }}
@@ -265,7 +275,13 @@ jobs:
   judge:
     name: Judge (read-only aggregator)
     needs: [gather, review-design, review-security, review-psych, review-docs, review-prompt, fix]
-    if: needs.gather.outputs.capped != 'true'
+    if: |
+      always() &&
+      needs.gather.outputs.capped != 'true' &&
+      needs.gather.result == 'success' &&
+      needs.fix.result == 'success' &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled')
     uses: ./.github/workflows/review-judge.yml
     with:
       pr_number: ${{ inputs.pr_number }}
@@ -278,7 +294,11 @@ jobs:
   finalize:
     name: Finalize verdict
     needs: [gather, fix, judge]
-    if: needs.gather.outputs.capped != 'true'
+    if: |
+      always() &&
+      needs.gather.outputs.capped != 'true' &&
+      needs.gather.result == 'success' &&
+      needs.judge.result == 'success'
     uses: ./.github/workflows/review-finalize.yml
     with:
       pr_number: ${{ inputs.pr_number }}


### PR DESCRIPTION
Per-role reviewer gating means several reviewers will always be skipped per run (psych/prompt for config-only, security for docs-only). GHA defaulted fix/judge/finalize to skipped because their `needs:` included those skipped jobs.

Convert fix/judge/finalize `if:` blocks to the standard `always()`-based pattern that allows skipped needs but blocks on failure/cancelled.

Verified on PR #353: design+docs+security all succeeded and posted real review comments, but fix/judge/finalize were skipped because review-psych and review-prompt were skipped.