### PR TITLE
Restore security review routing for orchestration changes

### DIFF
--- a/.github/actions/review-classify/action.yml
+++ b/.github/actions/review-classify/action.yml
@@ -2,13 +2,14 @@
 name: Review pipeline file classifier
 description: >
   Single source of truth for "which reviewer roles apply to this SHA"
-  in the v2 review pipeline. Classifies the diff against origin/main
-  and emits a JSON list of applicable roles.
+  in the v2 review pipeline. Classifies the SHA-bound diff and emits
+  a JSON list of applicable roles.
 
   Today the rules are:
     - design:    always
     - docs:      always
-    - security:  unless docs_only (all changed files are inert docs)
+    - security:  always for workflow/action/review/runtime-script changes,
+                 otherwise unless docs_only (all changed files are inert docs)
     - psych:     unless config_only (pure CI/infrastructure config)
     - prompt:    unless config_only (pure CI/infrastructure config)
 
@@ -28,8 +29,11 @@ inputs:
     description: Base ref to diff against
     required: false
     default: origin/main
+  base_sha:
+    description: Immutable base SHA to diff against when available
+    required: false
   head_sha:
-    description: Head SHA being reviewed (informational; the diff is taken from working tree)
+    description: Head SHA being reviewed
     required: true
 
 outputs:
@@ -51,76 +55,9 @@ runs:
       shell: bash
       env:
         BASE_REF: ${{ inputs.base_ref }}
+        BASE_SHA: ${{ inputs.base_sha }}
         HEAD_SHA: ${{ inputs.head_sha }}
       run: |
         set -euo pipefail
 
-        git fetch origin main >/dev/null 2>&1 || true
-
-        FILES=$(git diff --name-only "${BASE_REF}"...HEAD 2>/dev/null || echo "")
-        if [ -z "$FILES" ]; then
-          # No diff (e.g. empty PR). Classify as docs_only so only the
-          # cheap reviewers run; the judge will produce a vacuous result
-          # and the orchestrator will fail closed.
-          echo "review-classify: empty diff for $HEAD_SHA"
-        fi
-
-        DOCS_ONLY=true
-        CONFIG_ONLY=true
-
-        # Files that, despite being .md, are runtime spec (rule §1.9).
-        is_spec_md() {
-          case "$1" in
-            AGENTS.md|SOUL.md|TOOLS.md|HEARTBEAT.md|IDENTITY.md) return 0 ;;
-            setup/cron/*) return 0 ;;
-            design/adhd-priorities.md) return 0 ;;
-            docs/ai-prompts.md|docs/task-lifecycle.md|docs/notion-schema.md|docs/architecture.md|docs/user-interactions.md|docs/user-preferences.md|docs/reward-system.md|docs/openclaw-integration.md) return 0 ;;
-            *) return 1 ;;
-          esac
-        }
-
-        # Reviewer prompts are executable routing/spec surface even
-        # though they live under .github/ and end in .md.
-        is_review_prompt_md() {
-          case "$1" in
-            .github/scripts/review/prompts/*.md) return 0 ;;
-            *) return 1 ;;
-          esac
-        }
-
-        while IFS= read -r f; do
-          [ -z "$f" ] && continue
-
-          # Anything outside config/CI invalidates config_only.
-          case "$f" in
-            .github/scripts/review/prompts/*.md) CONFIG_ONLY=false ;;
-            .github/*|.devcontainer/*|scripts/*) ;;
-            *) CONFIG_ONLY=false ;;
-          esac
-
-          # Spec MDs and any non-doc/design file invalidate docs_only.
-          if is_spec_md "$f" || is_review_prompt_md "$f"; then
-            DOCS_ONLY=false
-          else
-            case "$f" in
-              docs/*.md|design/*.md|README.md|*.md) ;;
-              *) DOCS_ONLY=false ;;
-            esac
-          fi
-        done <<< "$FILES"
-
-        ROLES='["design","docs"]'
-        if [ "$DOCS_ONLY" != "true" ]; then
-          ROLES=$(echo "$ROLES" | jq -c '. + ["security"]')
-        fi
-        if [ "$CONFIG_ONLY" != "true" ]; then
-          ROLES=$(echo "$ROLES" | jq -c '. + ["psych","prompt"]')
-        fi
-
-        {
-          echo "roles_json=$ROLES"
-          echo "docs_only=$DOCS_ONLY"
-          echo "config_only=$CONFIG_ONLY"
-        } >> "$GITHUB_OUTPUT"
-
-        echo "review-classify: roles=$ROLES docs_only=$DOCS_ONLY config_only=$CONFIG_ONLY"
+        node .github/scripts/review/classify.mjs

--- a/.github/scripts/review/classify.mjs
+++ b/.github/scripts/review/classify.mjs
@@ -94,7 +94,7 @@ export function getChangedFiles({ baseSha = "", baseRef = "", headSha, cwd = pro
 
   const diffArgs = ["diff", "--name-only"];
   if (baseSha) {
-    diffArgs.push(baseSha, headSha);
+    diffArgs.push(`${baseSha}...${headSha}`);
   } else if (baseRef) {
     diffArgs.push(`${baseRef}...${headSha}`);
   } else {

--- a/.github/scripts/review/classify.mjs
+++ b/.github/scripts/review/classify.mjs
@@ -1,0 +1,145 @@
+import { execFileSync } from "node:child_process";
+import { appendFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const SPEC_MDS = new Set([
+  "AGENTS.md",
+  "SOUL.md",
+  "TOOLS.md",
+  "HEARTBEAT.md",
+  "IDENTITY.md",
+  "design/adhd-priorities.md",
+  "docs/ai-prompts.md",
+  "docs/task-lifecycle.md",
+  "docs/notion-schema.md",
+  "docs/architecture.md",
+  "docs/user-interactions.md",
+  "docs/user-preferences.md",
+  "docs/reward-system.md",
+  "docs/openclaw-integration.md",
+]);
+
+export function isSpecMd(file) {
+  return SPEC_MDS.has(file) || file.startsWith("setup/cron/");
+}
+
+export function isReviewPromptMd(file) {
+  return file.startsWith(".github/scripts/review/prompts/") && file.endsWith(".md");
+}
+
+export function isConfigOnlyPath(file) {
+  if (isReviewPromptMd(file)) {
+    return false;
+  }
+
+  return (
+    file.startsWith(".github/") ||
+    file.startsWith(".devcontainer/") ||
+    file.startsWith("scripts/")
+  );
+}
+
+export function isInertDoc(file) {
+  return file === "README.md" || file.endsWith(".md");
+}
+
+export function requiresSecurityReview(file) {
+  return (
+    file.startsWith(".github/workflows/") ||
+    file.startsWith(".github/actions/") ||
+    file.startsWith(".github/scripts/review/") ||
+    file.startsWith("scripts/")
+  );
+}
+
+export function classifyFiles(files) {
+  let docsOnly = true;
+  let configOnly = true;
+  let securityForced = false;
+
+  for (const file of files.filter(Boolean)) {
+    if (requiresSecurityReview(file)) {
+      securityForced = true;
+    }
+
+    if (!isConfigOnlyPath(file)) {
+      configOnly = false;
+    }
+
+    if ((isSpecMd(file) || isReviewPromptMd(file)) || !isInertDoc(file)) {
+      docsOnly = false;
+    }
+  }
+
+  const roles = ["design", "docs"];
+  if (securityForced || !docsOnly) {
+    roles.push("security");
+  }
+  if (!configOnly) {
+    roles.push("psych", "prompt");
+  }
+
+  return {
+    roles,
+    rolesJson: JSON.stringify(roles),
+    docsOnly,
+    configOnly,
+  };
+}
+
+export function getChangedFiles({ baseSha = "", baseRef = "", headSha, cwd = process.cwd() }) {
+  if (!headSha) {
+    throw new Error("review-classify: HEAD_SHA is required");
+  }
+
+  const diffArgs = ["diff", "--name-only"];
+  if (baseSha) {
+    diffArgs.push(baseSha, headSha);
+  } else if (baseRef) {
+    diffArgs.push(`${baseRef}...${headSha}`);
+  } else {
+    throw new Error("review-classify: BASE_SHA or BASE_REF is required");
+  }
+
+  const stdout = execFileSync("git", diffArgs, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  return stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function emitOutputs({ rolesJson, docsOnly, configOnly }, githubOutput) {
+  if (!githubOutput) {
+    return;
+  }
+
+  appendFileSync(
+    githubOutput,
+    `roles_json=${rolesJson}\ndocs_only=${docsOnly}\nconfig_only=${configOnly}\n`,
+    "utf8"
+  );
+}
+
+function main() {
+  const { BASE_SHA = "", BASE_REF = "", HEAD_SHA = "", GITHUB_OUTPUT = "" } = process.env;
+  const files = getChangedFiles({ baseSha: BASE_SHA, baseRef: BASE_REF, headSha: HEAD_SHA });
+  const result = classifyFiles(files);
+
+  if (files.length === 0) {
+    console.log(`review-classify: empty diff for ${HEAD_SHA}`);
+  }
+
+  emitOutputs(result, GITHUB_OUTPUT);
+  console.log(
+    `review-classify: roles=${result.rolesJson} docs_only=${result.docsOnly} config_only=${result.configOnly}`
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/.github/scripts/review/classify.test.mjs
+++ b/.github/scripts/review/classify.test.mjs
@@ -1,0 +1,86 @@
+import { execFileSync } from "node:child_process";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { classifyFiles, getChangedFiles } from "./classify.mjs";
+
+function initRepo() {
+  const cwd = mkdtempSync(join(tmpdir(), "review-classify-"));
+  execFileSync("git", ["init", "-b", "main"], { cwd, stdio: "ignore" });
+  execFileSync("git", ["config", "user.name", "Codex"], { cwd, stdio: "ignore" });
+  execFileSync("git", ["config", "user.email", "codex@example.com"], {
+    cwd,
+    stdio: "ignore",
+  });
+
+  mkdirSync(join(cwd, ".github", "workflows"), { recursive: true });
+  writeFileSync(join(cwd, ".github", "workflows", "review-pipeline.yml"), "name: review\n");
+  execFileSync("git", ["add", "."], { cwd, stdio: "ignore" });
+  execFileSync("git", ["commit", "-m", "base"], { cwd, stdio: "ignore" });
+
+  const baseSha = execFileSync("git", ["rev-parse", "HEAD"], {
+    cwd,
+    encoding: "utf8",
+  }).trim();
+
+  writeFileSync(
+    join(cwd, ".github", "workflows", "review-pipeline.yml"),
+    "name: review\npermissions:\n  contents: read\n"
+  );
+  execFileSync("git", ["add", "."], { cwd, stdio: "ignore" });
+  execFileSync("git", ["commit", "-m", "change workflow"], { cwd, stdio: "ignore" });
+
+  const headSha = execFileSync("git", ["rev-parse", "HEAD"], {
+    cwd,
+    encoding: "utf8",
+  }).trim();
+
+  return { cwd, baseSha, headSha };
+}
+
+test("workflow orchestration files force security review", () => {
+  const result = classifyFiles([".github/workflows/review-fixer.yml"]);
+  assert.deepEqual(result.roles, ["design", "docs", "security"]);
+  assert.equal(result.docsOnly, false);
+  assert.equal(result.configOnly, true);
+});
+
+test("workflow permission changes still force security review", () => {
+  const result = classifyFiles([".github/workflows/review-pipeline.yml"]);
+  assert.deepEqual(result.roles, ["design", "docs", "security"]);
+});
+
+test("local action changes force security review", () => {
+  const result = classifyFiles([".github/actions/review-publish/action.yml"]);
+  assert.deepEqual(result.roles, ["design", "docs", "security"]);
+});
+
+test("review prompt markdown keeps docs/prompt routing and also includes security", () => {
+  const result = classifyFiles([".github/scripts/review/prompts/security.md"]);
+  assert.deepEqual(result.roles, ["design", "docs", "security", "psych", "prompt"]);
+  assert.equal(result.docsOnly, false);
+  assert.equal(result.configOnly, false);
+});
+
+test("runtime scripts force security review", () => {
+  const result = classifyFiles(["scripts/notion-cli.sh"]);
+  assert.deepEqual(result.roles, ["design", "docs", "security"]);
+});
+
+test("inert docs stay docs-only but still route psych/prompt", () => {
+  const result = classifyFiles(["docs/faq.md", "README.md"]);
+  assert.deepEqual(result.roles, ["design", "docs", "psych", "prompt"]);
+  assert.equal(result.docsOnly, true);
+  assert.equal(result.configOnly, false);
+});
+
+test("SHA-bound diff returns changed files for workflow changes", (t) => {
+  const { cwd, baseSha, headSha } = initRepo();
+  t.after(() => rmSync(cwd, { recursive: true, force: true }));
+
+  const files = getChangedFiles({ cwd, baseSha, headSha });
+  assert.deepEqual(files, [".github/workflows/review-pipeline.yml"]);
+});

--- a/.github/scripts/review/classify.test.mjs
+++ b/.github/scripts/review/classify.test.mjs
@@ -84,3 +84,45 @@ test("SHA-bound diff returns changed files for workflow changes", (t) => {
   const files = getChangedFiles({ cwd, baseSha, headSha });
   assert.deepEqual(files, [".github/workflows/review-pipeline.yml"]);
 });
+
+test("SHA-bound diff keeps PR semantics when the base branch advances", (t) => {
+  const cwd = mkdtempSync(join(tmpdir(), "review-classify-diverged-"));
+  t.after(() => rmSync(cwd, { recursive: true, force: true }));
+
+  execFileSync("git", ["init", "-b", "main"], { cwd, stdio: "ignore" });
+  execFileSync("git", ["config", "user.name", "Codex"], { cwd, stdio: "ignore" });
+  execFileSync("git", ["config", "user.email", "codex@example.com"], {
+    cwd,
+    stdio: "ignore",
+  });
+
+  writeFileSync(join(cwd, "README.md"), "base\n");
+  execFileSync("git", ["add", "README.md"], { cwd, stdio: "ignore" });
+  execFileSync("git", ["commit", "-m", "base"], { cwd, stdio: "ignore" });
+
+  execFileSync("git", ["checkout", "-b", "feature"], { cwd, stdio: "ignore" });
+  mkdirSync(join(cwd, "docs"), { recursive: true });
+  writeFileSync(join(cwd, "docs", "feature.md"), "feature change\n");
+  execFileSync("git", ["add", "docs/feature.md"], { cwd, stdio: "ignore" });
+  execFileSync("git", ["commit", "-m", "feature change"], { cwd, stdio: "ignore" });
+  const headSha = execFileSync("git", ["rev-parse", "HEAD"], {
+    cwd,
+    encoding: "utf8",
+  }).trim();
+
+  execFileSync("git", ["checkout", "main"], { cwd, stdio: "ignore" });
+  mkdirSync(join(cwd, ".github", "workflows"), { recursive: true });
+  writeFileSync(join(cwd, ".github", "workflows", "review-pipeline.yml"), "name: main-only\n");
+  execFileSync("git", ["add", ".github/workflows/review-pipeline.yml"], {
+    cwd,
+    stdio: "ignore",
+  });
+  execFileSync("git", ["commit", "-m", "main only change"], { cwd, stdio: "ignore" });
+  const baseSha = execFileSync("git", ["rev-parse", "HEAD"], {
+    cwd,
+    encoding: "utf8",
+  }).trim();
+
+  const files = getChangedFiles({ cwd, baseSha, headSha });
+  assert.deepEqual(files, ["docs/feature.md"]);
+});

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -71,6 +71,7 @@ jobs:
             workflows:
               - '.github/workflows/**'
               - '.github/actions/**'
+              - '.github/scripts/review/**'
               - '.github/actionlint.yaml'
               - 'scripts/validate-gh-cli-usage.sh'
               - 'scripts/validate-workflow-refs.sh'
@@ -198,6 +199,9 @@ jobs:
 
       - name: Run actionlint
         run: actionlint .github/workflows/*.yml
+
+      - name: Run review pipeline unit tests
+        run: node --test .github/scripts/review/*.test.mjs
 
       - name: Validate cross-file workflow references
         run: ./scripts/validate-workflow-refs.sh

--- a/.github/workflows/review-pipeline.yml
+++ b/.github/workflows/review-pipeline.yml
@@ -106,6 +106,7 @@ jobs:
         uses: ./.github/actions/review-classify
         with:
           base_ref: origin/main
+          base_sha: ${{ inputs.base_sha }}
           head_sha: ${{ inputs.reviewed_sha }}
 
       - name: Stamp gather status


### PR DESCRIPTION
Resolves #378

## Summary
- replace the inline review classifier shell with a tested Node classifier module
- diff reviewer routing against immutable `base_sha`/`head_sha` so classifier failures no longer collapse to an empty diff
- force the `security` reviewer for workflow, local action, review orchestration, and runtime script changes
- add regression tests for the issue paths and run review-pipeline unit tests from `pr-tests.yml`

## Test Plan
- `node --test .github/scripts/review/*.test.mjs`
- `shellcheck scripts/*.sh`
- `yamllint .github/workflows/*.yml`
- `./scripts/validate-workflow-refs.sh`
- `./scripts/validate-gh-cli-usage.sh`
- doc internal link sanity check across `docs/` and `design/`

Generated with Codex