### PR TITLE
Add regression guard for PR Tests actionlint setup order

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -72,6 +72,7 @@ jobs:
               - '.github/workflows/**'
               - '.github/actions/**'
               - '.github/actionlint.yaml'
+              - 'scripts/validate-pr-tests-workflow.sh'
               - 'scripts/validate-gh-cli-usage.sh'
               - 'scripts/validate-workflow-refs.sh'
             devcontainer:
@@ -178,6 +179,9 @@ jobs:
       - name: Run workflow validation
         run: |
           yamllint -c .yamllint .github/workflows/*.yml
+
+      - name: Validate PR Tests workflow tool ordering
+        run: ./scripts/validate-pr-tests-workflow.sh
 
       - name: Install actionlint
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,7 @@ These files support the development pipeline and are not part of the OpenClaw ag
 - `scripts/pull-main.sh` — Branch sync helper
 - `scripts/security-update.sh` — Security update automation
 - `scripts/validate-gh-cli-usage.sh` — GitHub CLI workflow usage validation
+- `scripts/validate-pr-tests-workflow.sh` — PR Tests workflow actionlint/setup-order validation
 - `scripts/validate-workflow-refs.sh` — Workflow reference validation
 - `scripts/validate-mermaid.sh`, `scripts/lint-mermaid-rendering.sh` — Diagram validation
 - `setup/` — Cron and setup documentation

--- a/scripts/validate-pr-tests-workflow.sh
+++ b/scripts/validate-pr-tests-workflow.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Guard against regressions in the PR Tests workflow where workflow
+# validation invokes actionlint-dependent checks before actionlint is
+# installed on the runner.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+python3 - "$REPO_ROOT" <<'PY'
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError as exc:
+    print(f"ERROR: PyYAML is required to validate pr-tests workflow ordering: {exc}")
+    sys.exit(1)
+
+
+repo_root = Path(sys.argv[1])
+workflow_path = repo_root / ".github" / "workflows" / "pr-tests.yml"
+
+try:
+    data = yaml.safe_load(workflow_path.read_text(encoding="utf-8")) or {}
+except yaml.YAMLError as exc:
+    print(f"ERROR: failed to parse {workflow_path.relative_to(repo_root)}: {exc}")
+    sys.exit(1)
+
+jobs = data.get("jobs")
+if not isinstance(jobs, dict):
+    print("ERROR: pr-tests.yml must define jobs")
+    sys.exit(1)
+
+job = jobs.get("workflow-validation")
+if not isinstance(job, dict):
+    print("ERROR: pr-tests.yml is missing the workflow-validation job")
+    sys.exit(1)
+
+steps = job.get("steps")
+if not isinstance(steps, list):
+    print("ERROR: workflow-validation job must define a steps list")
+    sys.exit(1)
+
+install_index = None
+errors = []
+
+
+def uses_actionlint(run_block: str) -> bool:
+    return "./scripts/run-required-checks.sh ci-workflows" in run_block or "actionlint " in run_block
+
+
+for index, step in enumerate(steps):
+    if not isinstance(step, dict):
+        continue
+
+    name = step.get("name", f"step #{index + 1}")
+    run_block = step.get("run")
+
+    if isinstance(name, str) and name == "Install actionlint":
+        install_index = index
+
+    if not isinstance(run_block, str) or not uses_actionlint(run_block):
+        continue
+
+    if install_index is None:
+        errors.append(
+            f"ERROR: workflow-validation step '{name}' uses actionlint before any 'Install actionlint' step."
+        )
+    elif index < install_index:
+        errors.append(
+            f"ERROR: workflow-validation step '{name}' appears before 'Install actionlint'."
+        )
+
+
+print("=== Checking PR Tests workflow validation step order ===")
+
+if errors:
+    for error in errors:
+        print(error)
+    print(f"FAILED: {len(errors)} pr-tests workflow ordering error(s) found")
+    sys.exit(1)
+
+print("PR Tests workflow installs actionlint before actionlint-dependent validation")
+PY


### PR DESCRIPTION
Resolves #383

## Summary
- add `scripts/validate-pr-tests-workflow.sh` to assert that the `workflow-validation` job in `pr-tests.yml` installs `actionlint` before any actionlint-dependent checks run
- run that guard in `pr-tests.yml` immediately after `yamllint`, so the workflow fails with a clear configuration error before any missing-tool runtime failure
- include the new validator script in the workflow change filter so edits to the guard re-run workflow validation

## Test Plan
- `shellcheck scripts/*.sh`
- `yamllint .github/workflows/*.yml`
- `./scripts/validate-pr-tests-workflow.sh`
- verified docs/design internal links resolve with the same relative-link logic used in CI

Generated with Codex