### PR TITLE
Force security review for review-pipeline workflow changes

### DIFF
--- a/.github/actions/review-classify/action.yml
+++ b/.github/actions/review-classify/action.yml
@@ -2,13 +2,15 @@
 name: Review pipeline file classifier
 description: >
   Single source of truth for "which reviewer roles apply to this SHA"
-  in the v2 review pipeline. Classifies the diff against origin/main
+  in the v2 review pipeline. Classifies the diff against the provided
+  PR base ref / SHA
   and emits a JSON list of applicable roles.
 
   Today the rules are:
     - design:    always
     - docs:      always
-    - security:  unless docs_only (all changed files are inert docs)
+    - security:  unless docs_only (all changed files are inert docs),
+                 OR always for review-orchestration / routing files
     - psych:     unless config_only (pure CI/infrastructure config)
     - prompt:    unless config_only (pure CI/infrastructure config)
 
@@ -29,7 +31,7 @@ inputs:
     required: false
     default: origin/main
   head_sha:
-    description: Head SHA being reviewed (informational; the diff is taken from working tree)
+    description: Head SHA being reviewed
     required: true
 
 outputs:
@@ -55,10 +57,14 @@ runs:
       run: |
         set -euo pipefail
 
-        git fetch origin main >/dev/null 2>&1 || true
+        FILES=""
+        DIFF_FAILED=false
+        if ! FILES=$(git diff --name-only "${BASE_REF}"..."${HEAD_SHA}" 2>/dev/null); then
+          DIFF_FAILED=true
+          echo "review-classify: failed to diff ${BASE_REF}...${HEAD_SHA}; failing closed"
+        fi
 
-        FILES=$(git diff --name-only "${BASE_REF}"...HEAD 2>/dev/null || echo "")
-        if [ -z "$FILES" ]; then
+        if [ "$DIFF_FAILED" = "false" ] && [ -z "$FILES" ]; then
           # No diff (e.g. empty PR). Classify as docs_only so only the
           # cheap reviewers run; the judge will produce a vacuous result
           # and the orchestrator will fail closed.
@@ -67,6 +73,13 @@ runs:
 
         DOCS_ONLY=true
         CONFIG_ONLY=true
+        FORCE_SECURITY=false
+
+        if [ "$DIFF_FAILED" = "true" ]; then
+          DOCS_ONLY=false
+          CONFIG_ONLY=false
+          FORCE_SECURITY=true
+        fi
 
         # Files that, despite being .md, are runtime spec (rule §1.9).
         is_spec_md() {
@@ -88,8 +101,26 @@ runs:
           esac
         }
 
+        # Review-orchestration files are CI control-plane surface.
+        # Security/infra review owns routing and gating regressions for
+        # these files even when the PR is otherwise workflow/config-only.
+        is_security_routing_file() {
+          case "$1" in
+            .github/workflows/review-*.yml) return 0 ;;
+            .github/workflows/codex-code-review.yml) return 0 ;;
+            .github/actions/review-classify/*) return 0 ;;
+            .github/scripts/review/prompts/*.md) return 0 ;;
+            .github/scripts/review/*.mjs) return 0 ;;
+            *) return 1 ;;
+          esac
+        }
+
         while IFS= read -r f; do
           [ -z "$f" ] && continue
+
+          if is_security_routing_file "$f"; then
+            FORCE_SECURITY=true
+          fi
 
           # Anything outside config/CI invalidates config_only.
           case "$f" in
@@ -110,7 +141,7 @@ runs:
         done <<< "$FILES"
 
         ROLES='["design","docs"]'
-        if [ "$DOCS_ONLY" != "true" ]; then
+        if [ "$DOCS_ONLY" != "true" ] || [ "$FORCE_SECURITY" = "true" ]; then
           ROLES=$(echo "$ROLES" | jq -c '. + ["security"]')
         fi
         if [ "$CONFIG_ONLY" != "true" ]; then

--- a/.github/scripts/review/prompts/_shared.md
+++ b/.github/scripts/review/prompts/_shared.md
@@ -18,7 +18,8 @@ review** — you must not edit files, run formatters, or push commits.
 
 ### What to do
 
-1. Read the diff: `git fetch origin main && git diff origin/main...HEAD`.
+1. Read the diff against the frozen PR base SHA:
+   `git diff "${REVIEW_BASE_SHA}...HEAD"`.
 2. Read inline PR review comments via
    `gh api repos/${REPO}/pulls/${PR_NUMBER}/comments` and any blocking
    change requests there must be folded into your `blocking_issues[]`

--- a/.github/scripts/review/prompts/design.md
+++ b/.github/scripts/review/prompts/design.md
@@ -33,8 +33,8 @@ Reference `docs/architecture.md` for system design context.
 
 ## Procedure
 
-1. `git fetch origin main && git diff origin/main...HEAD` — read the
-   full diff.
+1. `git diff "${REVIEW_BASE_SHA}...HEAD"` — read the full diff against
+   the frozen PR base SHA.
 2. `gh api repos/${REPO}/pulls/${PR_NUMBER}/comments` — read inline
    comments. Any blocking change requests there must appear in your
    `blocking_issues[]` with `source: "inline_comment"`.

--- a/.github/scripts/review/prompts/docs.md
+++ b/.github/scripts/review/prompts/docs.md
@@ -30,7 +30,8 @@ Lens:
 
 ## Procedure
 
-1. `git diff origin/main...HEAD` — read the full diff.
+1. `git diff "${REVIEW_BASE_SHA}...HEAD"` — read the full diff against
+   the frozen PR base SHA.
 2. For each changed `.md` file, identify cross-references and
    double-check them.
 3. `gh api repos/${REPO}/pulls/${PR_NUMBER}/comments` — read inline

--- a/.github/scripts/review/prompts/prompt.md
+++ b/.github/scripts/review/prompts/prompt.md
@@ -37,7 +37,8 @@ If the diff does not touch any prompt or `.md` agent-spec file, set
 
 ## Procedure
 
-1. `git diff origin/main...HEAD` — read the full diff.
+1. `git diff "${REVIEW_BASE_SHA}...HEAD"` — read the full diff against
+   the frozen PR base SHA.
 2. For each changed prompt file, apply the lens above and
    cross-reference related prompts.
 3. `gh api repos/${REPO}/pulls/${PR_NUMBER}/comments` — read inline

--- a/.github/scripts/review/prompts/psych.md
+++ b/.github/scripts/review/prompts/psych.md
@@ -32,7 +32,8 @@ explaining why.
 
 ## Procedure
 
-1. `git diff origin/main...HEAD` — read the full diff.
+1. `git diff "${REVIEW_BASE_SHA}...HEAD"` — read the full diff against
+   the frozen PR base SHA.
 2. `gh api repos/${REPO}/pulls/${PR_NUMBER}/comments` — read inline
    comments. Fold any blocking ones into `blocking_issues[]` with
    `source: "inline_comment"`.

--- a/.github/scripts/review/prompts/security.md
+++ b/.github/scripts/review/prompts/security.md
@@ -40,7 +40,8 @@ apply it via your `fix_suggestions[]`.
 
 ## Procedure
 
-1. `git diff origin/main...HEAD` — read the full diff.
+1. `git diff "${REVIEW_BASE_SHA}...HEAD"` — read the full diff against
+   the frozen PR base SHA.
 2. `gh api repos/${REPO}/pulls/${PR_NUMBER}/comments` — read inline
    comments. Any blocking change requests there must appear in your
    `blocking_issues[]` with `source: "inline_comment"`.

--- a/.github/workflows/review-pipeline.yml
+++ b/.github/workflows/review-pipeline.yml
@@ -168,6 +168,7 @@ jobs:
       role: design
       pr_number: ${{ inputs.pr_number }}
       reviewed_sha: ${{ inputs.reviewed_sha }}
+      base_sha: ${{ inputs.base_sha }}
       head_ref: ${{ inputs.head_ref }}
       head_repo: ${{ inputs.head_repo }}
       cycle: ${{ needs.gather.outputs.cycle }}
@@ -186,6 +187,7 @@ jobs:
       role: security
       pr_number: ${{ inputs.pr_number }}
       reviewed_sha: ${{ inputs.reviewed_sha }}
+      base_sha: ${{ inputs.base_sha }}
       head_ref: ${{ inputs.head_ref }}
       head_repo: ${{ inputs.head_repo }}
       cycle: ${{ needs.gather.outputs.cycle }}
@@ -204,6 +206,7 @@ jobs:
       role: psych
       pr_number: ${{ inputs.pr_number }}
       reviewed_sha: ${{ inputs.reviewed_sha }}
+      base_sha: ${{ inputs.base_sha }}
       head_ref: ${{ inputs.head_ref }}
       head_repo: ${{ inputs.head_repo }}
       cycle: ${{ needs.gather.outputs.cycle }}
@@ -222,6 +225,7 @@ jobs:
       role: docs
       pr_number: ${{ inputs.pr_number }}
       reviewed_sha: ${{ inputs.reviewed_sha }}
+      base_sha: ${{ inputs.base_sha }}
       head_ref: ${{ inputs.head_ref }}
       head_repo: ${{ inputs.head_repo }}
       cycle: ${{ needs.gather.outputs.cycle }}
@@ -240,6 +244,7 @@ jobs:
       role: prompt
       pr_number: ${{ inputs.pr_number }}
       reviewed_sha: ${{ inputs.reviewed_sha }}
+      base_sha: ${{ inputs.base_sha }}
       head_ref: ${{ inputs.head_ref }}
       head_repo: ${{ inputs.head_repo }}
       cycle: ${{ needs.gather.outputs.cycle }}

--- a/.github/workflows/review-pipeline.yml
+++ b/.github/workflows/review-pipeline.yml
@@ -105,7 +105,7 @@ jobs:
         if: steps.cap.outputs.capped != 'true'
         uses: ./.github/actions/review-classify
         with:
-          base_ref: origin/main
+          base_ref: ${{ inputs.base_sha }}
           head_sha: ${{ inputs.reviewed_sha }}
 
       - name: Stamp gather status

--- a/.github/workflows/review-reviewer.yml
+++ b/.github/workflows/review-reviewer.yml
@@ -18,6 +18,9 @@ on:
       reviewed_sha:
         type: string
         required: true
+      base_sha:
+        type: string
+        required: true
       head_ref:
         type: string
         required: true
@@ -88,6 +91,8 @@ jobs:
           cycle: ${{ inputs.cycle }}
           read_only: 'true'
           workflow_pat: ${{ secrets.WORKFLOW_PAT }}
+          extra_env: |
+            REVIEW_BASE_SHA=${{ inputs.base_sha }}
 
       - name: Validate reviewer artifact against schema
         env:

--- a/docs/agentic-pipeline-learnings.md
+++ b/docs/agentic-pipeline-learnings.md
@@ -73,7 +73,7 @@ Two meta-lessons span everything below:
 **Evidence:** #339, #338, #337
 
 ### 1.12 Security/infra review explicitly owns reviewer-routing regressions
-**Why:** Review-pipeline dispatch and classifier changes can silently narrow who reviews future PRs while the workflow still "works." When a PR touches classifier, dispatch, or gating logic, the Security & Infrastructure reviewer must compare the proposed routing against the current pipeline behavior and flag any unintended loss of specialist coverage. Regressions that drop coverage for prompt/spec files, including `.github/scripts/review/prompts/*.md`, are blocking unless the PR explicitly documents and justifies the change.
+**Why:** Review-pipeline dispatch and classifier changes can silently narrow who reviews future PRs while the workflow still "works." When a PR touches classifier, dispatch, or gating logic, the Security & Infrastructure reviewer must compare the proposed routing against the current pipeline behavior and flag any unintended loss of specialist coverage. Regressions that drop coverage for prompt/spec files, including `.github/scripts/review/prompts/*.md`, are blocking unless the PR explicitly documents and justifies the change. In v2, review-orchestration files must therefore force security review even when the PR is otherwise workflow-only or config-only.
 **Before:** Reviewer prompt markdown under `.github/scripts/review/prompts/*.md` was classified as config-only in v2, which would have skipped security, psych, and prompt review and no reviewer called it out.
 **Evidence:** #343, #349
 


### PR DESCRIPTION
Resolves #382

## Summary
- force the classifier to include the security reviewer for review orchestration and reviewer-routing files, even on workflow-only/config-only PRs
- classify against the frozen PR base SHA instead of relying on `origin/main`, and fail closed to broader review coverage if diff classification breaks
- document the v2 guardrail in `docs/agentic-pipeline-learnings.md`

## Test Plan
- `shellcheck scripts/*.sh`
- `yamllint .github/workflows/*.yml`
- `./scripts/validate-workflow-refs.sh`

Generated with Codex