### PR TITLE
Align local hooks with required CI checks

### DIFF
--- a/.githooks/install-hooks.sh
+++ b/.githooks/install-hooks.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
-# Install git hooks by pointing core.hooksPath to .githooks/
+# Install git hooks for the current worktree.
 set -euo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
-git config core.hooksPath "$REPO_ROOT/.githooks"
-echo "Git hooks installed (core.hooksPath set to .githooks/)"
+git config extensions.worktreeConfig true
+git config --worktree core.hooksPath "$REPO_ROOT/.githooks"
+echo "Git hooks installed for this worktree (core.hooksPath=$REPO_ROOT/.githooks)"
+echo "Re-run this script in each new git worktree because hooksPath is stored per worktree."

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,58 +1,8 @@
 #!/usr/bin/env bash
-# Pre-commit hook: validates staged files by category.
+# Pre-commit hook: validates staged files with the shared required-check runner.
 # Install with: bash .githooks/install-hooks.sh
 
 set -euo pipefail
 
-# Get staged files (added, copied, modified — not deleted)
-STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
-
-if [ -z "$STAGED_FILES" ]; then
-  exit 0
-fi
-
-FAILED=0
-
-# --- Scripts: shellcheck ---
-SCRIPT_FILES=$(echo "$STAGED_FILES" | grep '^scripts/.*\.sh$' || true)
-if [ -n "$SCRIPT_FILES" ]; then
-  echo "Running shellcheck on staged scripts..."
-  if ! echo "$SCRIPT_FILES" | xargs shellcheck; then
-    FAILED=1
-  fi
-fi
-
-# --- Docs: mermaid rendering lint + mermaid syntax validation ---
-DOC_FILES=$(echo "$STAGED_FILES" | grep -E '^(docs/|design/|README\.md|AGENTS\.md)' | grep '\.md$' || true)
-if [ -n "$DOC_FILES" ]; then
-  echo "Running Mermaid rendering lint on staged docs..."
-  # shellcheck disable=SC2086
-  if ! bash scripts/lint-mermaid-rendering.sh $DOC_FILES; then
-    FAILED=1
-  fi
-
-  echo "Running Mermaid syntax validation on staged docs..."
-  # shellcheck disable=SC2086
-  if ! bash scripts/validate-mermaid.sh $DOC_FILES; then
-    FAILED=1
-  fi
-fi
-
-# --- Workflows: yamllint ---
-WORKFLOW_FILES=$(echo "$STAGED_FILES" | grep '^\.github/workflows/.*\.yml$' || true)
-if [ -n "$WORKFLOW_FILES" ]; then
-  if command -v yamllint &> /dev/null; then
-    echo "Running yamllint on staged workflows..."
-    if ! echo "$WORKFLOW_FILES" | xargs yamllint -d "{extends: default, rules: {line-length: disable, truthy: disable, comments-indentation: disable}}"; then
-      FAILED=1
-    fi
-  else
-    echo "WARNING: yamllint not installed, skipping workflow validation"
-  fi
-fi
-
-if [ "$FAILED" -ne 0 ]; then
-  echo ""
-  echo "Pre-commit checks failed. Fix the issues above before committing."
-  exit 1
-fi
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+"$REPO_ROOT/scripts/run-required-checks.sh" pre-commit

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Pre-push hook: runs the CI-equivalent deterministic checks for any
+# category touched by the commits being pushed.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+EMPTY_TREE="$(git hash-object -t tree /dev/null)"
+changed_files=()
+
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+  if [ -z "${local_sha:-}" ] || [ "$local_sha" = "0000000000000000000000000000000000000000" ]; then
+    continue
+  fi
+
+  if [ -z "${remote_sha:-}" ] || [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+    mapfile -t ref_files < <(git diff --name-only "$EMPTY_TREE" "$local_sha")
+  else
+    mapfile -t ref_files < <(git diff --name-only "$remote_sha" "$local_sha")
+  fi
+
+  if [ "${#ref_files[@]}" -gt 0 ]; then
+    changed_files+=("${ref_files[@]}")
+  fi
+done
+
+if [ "${#changed_files[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+RUN_REQUIRED_CHECKS_CHANGED_FILES="$(printf '%s\n' "${changed_files[@]}" | sed '/^$/d' | sort -u)"
+export RUN_REQUIRED_CHECKS_CHANGED_FILES
+"$REPO_ROOT/scripts/run-required-checks.sh" pre-push

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -63,15 +63,20 @@ jobs:
           filters: |
             scripts:
               - 'scripts/**'
+              - '.githooks/**'
             docs:
               - 'docs/**'
               - 'design/**'
               - 'README.md'
               - 'AGENTS.md'
+              - 'scripts/run-required-checks.sh'
             workflows:
               - '.github/workflows/**'
               - '.github/actions/**'
               - '.github/actionlint.yaml'
+              - '.yamllint'
+              - '.githooks/**'
+              - 'scripts/run-required-checks.sh'
               - 'scripts/validate-gh-cli-usage.sh'
               - 'scripts/validate-workflow-refs.sh'
             devcontainer:
@@ -88,18 +93,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run script validation
-        run: |
-          echo "=== Linting shell scripts ==="
-          find scripts/ -name '*.sh' -exec shellcheck {} +
-
-          echo "=== Checking script permissions ==="
-          find scripts/ -name '*.sh' | while read f; do
-            if [ ! -x "$f" ]; then
-              echo "ERROR: $f is not executable"
-              exit 1
-            fi
-          done
-          echo "All scripts have execute permission"
+        run: ./scripts/run-required-checks.sh ci-scripts
 
   doc-validation:
     name: Documentation Validation
@@ -121,46 +115,8 @@ jobs:
 
       - name: Run doc validation
         env:
-          CHANGED_FILES: ${{ needs.changes.outputs.docs_files }}
-        run: |
-          echo "=== Checking for broken internal links ==="
-          ERRORS=0
-          # Check markdown files for internal links and verify targets exist
-          find docs/ design/ -name '*.md' | while read f; do
-            # Extract relative links like [text](./file.md) or [text](../docs/file.md)
-            grep -oP '\[.*?\]\(\K[^)]+' "$f" 2>/dev/null | grep -v '^http' | while read link; do
-              # Resolve relative to the file's directory
-              dir=$(dirname "$f")
-              target="$dir/$link"
-              # Strip anchors
-              target=$(echo "$target" | cut -d'#' -f1)
-              if [ -n "$target" ] && [ ! -e "$target" ]; then
-                echo "BROKEN LINK in $f: $link (resolved to $target)"
-                ERRORS=$((ERRORS + 1))
-              fi
-            done
-          done
-          if [ "$ERRORS" -gt 0 ]; then
-            echo "$ERRORS broken links found"
-            exit 1
-          fi
-          echo "No broken internal links found"
-
-          echo "=== Linting Mermaid diagrams ==="
-          if [ -n "$CHANGED_FILES" ]; then
-            # shellcheck disable=SC2086
-            ./scripts/lint-mermaid-rendering.sh $CHANGED_FILES
-          else
-            echo "No changed doc files to lint"
-          fi
-
-          echo "=== Validating Mermaid diagrams ==="
-          if [ -n "$CHANGED_FILES" ]; then
-            # shellcheck disable=SC2086
-            ./scripts/validate-mermaid.sh $CHANGED_FILES
-          else
-            echo "No changed doc files to validate"
-          fi
+          RUN_REQUIRED_CHECKS_CHANGED_FILES: ${{ needs.changes.outputs.docs_files }}
+        run: ./scripts/run-required-checks.sh ci-docs
 
   workflow-validation:
     name: Workflow YAML Validation
@@ -176,8 +132,7 @@ jobs:
         run: pip3 install yamllint
 
       - name: Run workflow validation
-        run: |
-          yamllint -c .yamllint .github/workflows/*.yml
+        run: ./scripts/run-required-checks.sh ci-workflows
 
       - name: Install actionlint
         run: |
@@ -195,15 +150,6 @@ jobs:
             grep " ${ARCHIVE}$" "${CHECKSUMS}" | sha256sum -c -
           )
           sudo tar -xzf "${TMP_DIR}/${ARCHIVE}" -C /usr/local/bin actionlint
-
-      - name: Run actionlint
-        run: actionlint .github/workflows/*.yml
-
-      - name: Validate cross-file workflow references
-        run: ./scripts/validate-workflow-refs.sh
-
-      - name: Validate GitHub CLI usage in workflows
-        run: ./scripts/validate-gh-cli-usage.sh
 
   devcontainer-validation:
     name: Devcontainer Build Check

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -67,8 +67,12 @@ jobs:
             docs:
               - 'docs/**'
               - 'design/**'
+              - 'setup/**/*.md'
               - 'README.md'
               - 'AGENTS.md'
+              - 'scripts/check-doc-links.sh'
+              - 'scripts/lint-mermaid-rendering.sh'
+              - 'scripts/validate-mermaid.sh'
               - 'scripts/run-required-checks.sh'
             workflows:
               - '.github/workflows/**'

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -59,7 +59,7 @@ jobs:
         uses: dorny/paths-filter@v3
         id: filter
         with:
-          list-files: shell
+          list-files: json
           filters: |
             scripts:
               - 'scripts/**'
@@ -115,8 +115,13 @@ jobs:
 
       - name: Run doc validation
         env:
-          RUN_REQUIRED_CHECKS_CHANGED_FILES: ${{ needs.changes.outputs.docs_files }}
-        run: ./scripts/run-required-checks.sh ci-docs
+          DOCS_FILES_JSON: ${{ needs.changes.outputs.docs_files }}
+        run: |
+          RUN_REQUIRED_CHECKS_CHANGED_FILES="$(
+            node -e 'JSON.parse(process.env.DOCS_FILES_JSON).forEach((path) => console.log(path))'
+          )"
+          export RUN_REQUIRED_CHECKS_CHANGED_FILES
+          ./scripts/run-required-checks.sh ci-docs
 
   workflow-validation:
     name: Workflow YAML Validation
@@ -130,9 +135,6 @@ jobs:
 
       - name: Install yamllint
         run: pip3 install yamllint
-
-      - name: Run workflow validation
-        run: ./scripts/run-required-checks.sh ci-workflows
 
       - name: Install actionlint
         run: |
@@ -150,6 +152,9 @@ jobs:
             grep " ${ARCHIVE}$" "${CHECKSUMS}" | sha256sum -c -
           )
           sudo tar -xzf "${TMP_DIR}/${ARCHIVE}" -C /usr/local/bin actionlint
+
+      - name: Run workflow validation
+        run: ./scripts/run-required-checks.sh ci-workflows
 
   devcontainer-validation:
     name: Devcontainer Build Check

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -63,6 +63,7 @@ jobs:
           filters: |
             scripts:
               - 'scripts/**'
+              - 'setup/*.sh'
               - '.githooks/**'
             docs:
               - 'docs/**'
@@ -141,8 +142,6 @@ jobs:
       - name: Install yamllint
         run: pip3 install yamllint
 
-      - name: Validate PR Tests workflow tool ordering
-        run: ./scripts/validate-pr-tests-workflow.sh
       - name: Install actionlint
         run: |
           ACTIONLINT_VERSION=1.7.7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,8 +147,10 @@ These files support the development pipeline and are not part of the OpenClaw ag
 - `.github/actions/` — Composite actions used by workflows
 - `docs/agentic-pipeline-learnings.md` — Prescriptive review/CI pipeline contract and guardrail document
 - `scripts/create-deduped-workflow-failure-issue.sh` — Creates or reuses the canonical deduplicated GitHub Actions failure issue for the diagnosis workflow
+- `scripts/check-doc-links.sh` — Internal documentation link validator used by local hooks and CI doc checks
 - `scripts/get-latest-merge-decision-comment.sh` — Fetches the latest trusted merge-decision PR comment with retry logic to tolerate GitHub comment propagation lag
 - `scripts/pull-main.sh` — Branch sync helper
+- `scripts/run-required-checks.sh` — Canonical local/CI runner for required script, doc, and workflow validations
 - `scripts/security-update.sh` — Security update automation
 - `scripts/validate-gh-cli-usage.sh` — GitHub CLI workflow usage validation
 - `scripts/validate-pr-tests-workflow.sh` — PR Tests workflow actionlint/setup-order validation

--- a/README.md
+++ b/README.md
@@ -58,8 +58,10 @@ bash .githooks/install-hooks.sh
 ```
 
 `core.hooksPath` is stored per worktree, so re-run that after each `git worktree add`.
-`pre-commit` handles the fast staged-file checks, and `pre-push` blocks the
-deterministic CI-equivalent checks before they reach GitHub.
+`pre-commit` handles the fast staged-file checks, and `pre-push` reruns the
+deterministic CI-equivalent checks for changed scripts, docs, and
+workflow-related paths, so those failures are caught locally before GitHub is
+the first place they fail.
 
 ## Research-informed design
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ cd ~/.openclaw/workspace && bash setup/bootstrap.sh
 
 See [setup/README.md](setup/README.md) for full setup instructions.
 
+## Git hooks
+
+Install the repo hooks in every worktree you plan to commit from:
+
+```bash
+bash .githooks/install-hooks.sh
+```
+
+`core.hooksPath` is stored per worktree, so re-run that after each `git worktree add`.
+
 ## Research-informed design
 
 Every feature is evaluated against ADHD clinical research:

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ See [docs/openclaw-integration.md](docs/openclaw-integration.md) for how the sys
 # Clone as OpenClaw workspace
 git clone https://github.com/NickBorgersProbably/hide-my-list.git ~/.openclaw/workspace
 
+# Install the repo-managed git hooks for this worktree
+cd ~/.openclaw/workspace && bash .githooks/install-hooks.sh
+
 # Create .env from .env.template and fill in the values you need
 cp ~/.openclaw/workspace/.env.template ~/.openclaw/workspace/.env
 
@@ -55,6 +58,8 @@ bash .githooks/install-hooks.sh
 ```
 
 `core.hooksPath` is stored per worktree, so re-run that after each `git worktree add`.
+`pre-commit` handles the fast staged-file checks, and `pre-push` blocks the
+deterministic CI-equivalent checks before they reach GitHub.
 
 ## Research-informed design
 

--- a/docs/agentic-pipeline-learnings.md
+++ b/docs/agentic-pipeline-learnings.md
@@ -110,7 +110,7 @@ Two meta-lessons span everything below:
 **Evidence:** #224, #226, #230, #248, #260, #270, #280
 
 ### 2.9 Validate workflows with `actionlint` + cross-file ref checks, and keep a devcontainer smoke test for container changes
-**Why:** Yamllint passes broken `uses:` refs, missing script paths, and local-action checkout races. The current `pr-tests.yml` path always runs `actionlint` plus `validate-workflow-refs.sh` for workflow changes, and it adds a devcontainer build smoke test when `.devcontainer/**` changes. If workflow changes start depending on new devcontainer behavior, extend that smoke-test trigger instead of assuming yamllint is enough.
+**Why:** Yamllint passes broken `uses:` refs, missing script paths, and local-action checkout races. The current `pr-tests.yml` path always runs the canonical local/CI runner in `scripts/run-required-checks.sh`, which includes `actionlint` plus `validate-workflow-refs.sh` for workflow changes, and it adds a devcontainer build smoke test when `.devcontainer/**` changes. If workflow changes start depending on new devcontainer behavior, extend that smoke-test trigger instead of assuming yamllint is enough.
 **Evidence:** #232, #207, #219
 
 ### 2.10 Scope env loading per script; fall back to `.env` for host `gh` auth

--- a/scripts/check-doc-links.sh
+++ b/scripts/check-doc-links.sh
@@ -13,6 +13,7 @@ repo_root = Path(sys.argv[1]).resolve()
 scan_targets = [
     repo_root / "docs",
     repo_root / "design",
+    repo_root / "setup",
     repo_root / "README.md",
     repo_root / "AGENTS.md",
 ]
@@ -30,7 +31,7 @@ for file_path in files:
     content = file_path.read_text(encoding="utf-8")
     for raw_link in link_pattern.findall(content):
         link = raw_link.strip()
-        if not link or link.startswith(("http://", "https://", "mailto:", "#")):
+        if not link or link.startswith(("http://", "https://", "mailto:", "tel:", "#")):
             continue
 
         target = link.split("#", 1)[0].strip()

--- a/scripts/check-doc-links.sh
+++ b/scripts/check-doc-links.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+python3 - "$REPO_ROOT" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+repo_root = Path(sys.argv[1]).resolve()
+scan_targets = [
+    repo_root / "docs",
+    repo_root / "design",
+    repo_root / "README.md",
+    repo_root / "AGENTS.md",
+]
+link_pattern = re.compile(r"\[[^\]]*]\(([^)]+)\)")
+files = []
+errors = []
+
+for target in scan_targets:
+    if target.is_dir():
+        files.extend(sorted(target.rglob("*.md")))
+    elif target.is_file():
+        files.append(target)
+
+for file_path in files:
+    content = file_path.read_text(encoding="utf-8")
+    for raw_link in link_pattern.findall(content):
+        link = raw_link.strip()
+        if not link or link.startswith(("http://", "https://", "mailto:", "#")):
+            continue
+
+        target = link.split("#", 1)[0].strip()
+        if not target:
+            continue
+
+        resolved = (file_path.parent / target).resolve()
+        if not resolved.exists():
+            try:
+                display_target = resolved.relative_to(repo_root)
+            except ValueError:
+                display_target = resolved
+            errors.append(
+                f"BROKEN LINK in {file_path.relative_to(repo_root)}: "
+                f"{raw_link} (resolved to {display_target})"
+            )
+
+if errors:
+    for error in errors:
+        print(error)
+    print(f"{len(errors)} broken internal link(s) found")
+    sys.exit(1)
+
+print("No broken internal links found")
+PY

--- a/scripts/run-required-checks.sh
+++ b/scripts/run-required-checks.sh
@@ -6,6 +6,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
 readonly SCRIPT_PATH_PATTERN='^(scripts/.*\.sh|setup/.*\.sh|\.githooks/(install-hooks\.sh|pre-commit|pre-push))$'
+readonly SCRIPT_TRIGGER_PATH_PATTERN='^(scripts/.*|setup/.*\.sh|\.githooks/.*)$'
 readonly DOC_PATH_PATTERN='^(docs/.*\.md|design/.*\.md|setup/.*\.md|README\.md|AGENTS\.md)$'
 readonly DOC_HELPER_PATH_PATTERN='^(scripts/check-doc-links\.sh|scripts/lint-mermaid-rendering\.sh|scripts/validate-mermaid\.sh)$'
 readonly WORKFLOW_PATH_PATTERN='^(\.github/workflows/.*\.ya?ml|\.github/actions/.*\.ya?ml|\.github/actionlint\.yaml|\.yamllint|\.githooks/(install-hooks\.sh|pre-commit|pre-push)|scripts/validate-gh-cli-usage\.sh|scripts/validate-pr-tests-workflow\.sh|scripts/validate-workflow-refs\.sh)$'
@@ -123,10 +124,12 @@ run_executable_check() {
 
 run_script_validation() {
   local -a script_targets=()
+  local -a executable_targets=()
 
   mapfile -t script_targets < <(filter_existing_files scripts/*.sh setup/*.sh .githooks/install-hooks.sh .githooks/pre-commit .githooks/pre-push)
+  mapfile -t executable_targets < <(filter_existing_files scripts/*.sh .githooks/install-hooks.sh .githooks/pre-commit .githooks/pre-push)
   run_shellcheck "${script_targets[@]}"
-  run_executable_check "${script_targets[@]}"
+  run_executable_check "${executable_targets[@]}"
 }
 
 run_doc_link_check() {
@@ -290,7 +293,7 @@ run_pre_push() {
 
   trap 'echo ""; echo "Pre-push checks failed. Fix the issues above before pushing."' ERR
 
-  if canonical_runner_changed || has_changed_path "$SCRIPT_PATH_PATTERN"; then
+  if canonical_runner_changed || has_changed_path "$SCRIPT_TRIGGER_PATH_PATTERN"; then
     run_script_validation
   fi
 

--- a/scripts/run-required-checks.sh
+++ b/scripts/run-required-checks.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
-readonly SCRIPT_PATH_PATTERN='^(scripts/.*\.sh|\.githooks/(install-hooks\.sh|pre-commit|pre-push))$'
+readonly SCRIPT_PATH_PATTERN='^(scripts/.*\.sh|setup/.*\.sh|\.githooks/(install-hooks\.sh|pre-commit|pre-push))$'
 readonly DOC_PATH_PATTERN='^(docs/.*\.md|design/.*\.md|setup/.*\.md|README\.md|AGENTS\.md)$'
 readonly DOC_HELPER_PATH_PATTERN='^(scripts/check-doc-links\.sh|scripts/lint-mermaid-rendering\.sh|scripts/validate-mermaid\.sh)$'
 readonly WORKFLOW_PATH_PATTERN='^(\.github/workflows/.*\.ya?ml|\.github/actions/.*\.ya?ml|\.github/actionlint\.yaml|\.yamllint|\.githooks/(install-hooks\.sh|pre-commit|pre-push)|scripts/validate-gh-cli-usage\.sh|scripts/validate-pr-tests-workflow\.sh|scripts/validate-workflow-refs\.sh)$'
@@ -124,7 +124,7 @@ run_executable_check() {
 run_script_validation() {
   local -a script_targets=()
 
-  mapfile -t script_targets < <(filter_existing_files scripts/*.sh .githooks/install-hooks.sh .githooks/pre-commit .githooks/pre-push)
+  mapfile -t script_targets < <(filter_existing_files scripts/*.sh setup/*.sh .githooks/install-hooks.sh .githooks/pre-commit .githooks/pre-push)
   run_shellcheck "${script_targets[@]}"
   run_executable_check "${script_targets[@]}"
 }

--- a/scripts/run-required-checks.sh
+++ b/scripts/run-required-checks.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+readonly SCRIPT_PATH_PATTERN='^(scripts/.*\.sh|\.githooks/(install-hooks\.sh|pre-commit|pre-push))$'
+readonly DOC_PATH_PATTERN='^(docs/.*\.md|design/.*\.md|README\.md|AGENTS\.md)$'
+readonly WORKFLOW_PATH_PATTERN='^(\.github/workflows/.*\.ya?ml|\.github/actions/.*\.ya?ml|\.github/actionlint\.yaml|\.yamllint|scripts/validate-gh-cli-usage\.sh|scripts/validate-workflow-refs\.sh)$'
+readonly CANONICAL_RUNNER='scripts/run-required-checks.sh'
+
+changed_files=()
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/run-required-checks.sh <mode>
+
+Modes:
+  pre-commit    Fast checks for staged files only.
+  pre-push      Required deterministic checks for changed categories.
+  ci-scripts    CI-equivalent shell/script validation.
+  ci-docs       CI-equivalent documentation validation.
+  ci-workflows  CI-equivalent workflow validation.
+EOF
+}
+
+require_command() {
+  local cmd="$1"
+
+  if command -v "$cmd" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  echo "ERROR: required command '$cmd' is not installed."
+  echo "Install the repo devcontainer or the local tooling before committing/pushing."
+  exit 1
+}
+
+load_changed_files_from_env() {
+  if [ -z "${RUN_REQUIRED_CHECKS_CHANGED_FILES:-}" ]; then
+    changed_files=()
+    return 0
+  fi
+
+  mapfile -t changed_files < <(printf '%s\n' "$RUN_REQUIRED_CHECKS_CHANGED_FILES" | sed '/^$/d' | sort -u)
+}
+
+load_staged_files() {
+  mapfile -t changed_files < <(git diff --cached --name-only | sed '/^$/d' | sort -u)
+}
+
+has_changed_path() {
+  local pattern="$1"
+
+  if [ "${#changed_files[@]}" -eq 0 ]; then
+    return 1
+  fi
+
+  printf '%s\n' "${changed_files[@]}" | grep -Eq "$pattern"
+}
+
+canonical_runner_changed() {
+  has_changed_path "^${CANONICAL_RUNNER}$"
+}
+
+filter_existing_files() {
+  local path
+
+  for path in "$@"; do
+    if [ -f "$path" ]; then
+      printf '%s\n' "$path"
+    fi
+  done
+}
+
+collect_matching_changed_files() {
+  local pattern="$1"
+
+  if [ "${#changed_files[@]}" -eq 0 ]; then
+    return 0
+  fi
+
+  printf '%s\n' "${changed_files[@]}" | grep -E "$pattern" || true
+}
+
+run_shellcheck() {
+  local -a targets=("$@")
+
+  if [ "${#targets[@]}" -eq 0 ]; then
+    return 0
+  fi
+
+  require_command shellcheck
+  echo "=== Linting shell scripts ==="
+  shellcheck "${targets[@]}"
+}
+
+run_executable_check() {
+  local -a targets=("$@")
+  local failed=0
+  local path
+
+  if [ "${#targets[@]}" -eq 0 ]; then
+    return 0
+  fi
+
+  echo "=== Checking script permissions ==="
+  for path in "${targets[@]}"; do
+    if [ ! -x "$path" ]; then
+      echo "ERROR: $path is not executable"
+      failed=1
+    fi
+  done
+
+  if [ "$failed" -ne 0 ]; then
+    return 1
+  fi
+
+  echo "All scripts have execute permission"
+}
+
+run_script_validation() {
+  local -a script_targets=()
+
+  mapfile -t script_targets < <(filter_existing_files scripts/*.sh .githooks/install-hooks.sh .githooks/pre-commit .githooks/pre-push)
+  run_shellcheck "${script_targets[@]}"
+  run_executable_check "${script_targets[@]}"
+}
+
+run_doc_link_check() {
+  require_command python3
+  echo "=== Checking for broken internal links ==="
+  "$REPO_ROOT/scripts/check-doc-links.sh"
+}
+
+build_doc_targets() {
+  local -a doc_targets=()
+
+  if [ "${#changed_files[@]}" -eq 0 ] || canonical_runner_changed; then
+    for target in docs design README.md AGENTS.md; do
+      if [ -e "$target" ]; then
+        doc_targets+=("$target")
+      fi
+    done
+    printf '%s\n' "${doc_targets[@]}"
+    return 0
+  fi
+
+  mapfile -t doc_targets < <(collect_matching_changed_files "$DOC_PATH_PATTERN" | while IFS= read -r path; do
+    if [ -f "$path" ]; then
+      printf '%s\n' "$path"
+    fi
+  done)
+
+  printf '%s\n' "${doc_targets[@]}"
+}
+
+run_doc_validation() {
+  local -a doc_targets=()
+
+  run_doc_link_check
+  mapfile -t doc_targets < <(build_doc_targets)
+
+  if [ "${#doc_targets[@]}" -eq 0 ]; then
+    echo "No changed doc files to lint"
+    echo "No changed doc files to validate"
+    return 0
+  fi
+
+  echo "=== Linting Mermaid diagrams ==="
+  "$REPO_ROOT/scripts/lint-mermaid-rendering.sh" "${doc_targets[@]}"
+
+  echo "=== Validating Mermaid diagrams ==="
+  "$REPO_ROOT/scripts/validate-mermaid.sh" "${doc_targets[@]}"
+}
+
+run_yamllint() {
+  local -a workflow_targets=()
+
+  mapfile -t workflow_targets < <(filter_existing_files .github/workflows/*.yml .github/workflows/*.yaml)
+  if [ "${#workflow_targets[@]}" -eq 0 ]; then
+    echo "No workflow YAML files found"
+    return 0
+  fi
+
+  require_command yamllint
+  echo "=== Linting workflow YAML ==="
+  yamllint -c .yamllint "${workflow_targets[@]}"
+}
+
+run_actionlint() {
+  local -a workflow_targets=()
+
+  mapfile -t workflow_targets < <(filter_existing_files .github/workflows/*.yml .github/workflows/*.yaml)
+  if [ "${#workflow_targets[@]}" -eq 0 ]; then
+    echo "No workflow YAML files found"
+    return 0
+  fi
+
+  require_command actionlint
+  echo "=== Running actionlint ==="
+  actionlint "${workflow_targets[@]}"
+}
+
+run_workflow_validation() {
+  run_yamllint
+  require_command python3
+  run_actionlint
+  echo "=== Validating cross-file workflow references ==="
+  "$REPO_ROOT/scripts/validate-workflow-refs.sh"
+  echo "=== Validating GitHub CLI usage in workflows ==="
+  "$REPO_ROOT/scripts/validate-gh-cli-usage.sh"
+}
+
+run_pre_commit_script_checks() {
+  local -a targets=()
+
+  mapfile -t targets < <(collect_matching_changed_files "$SCRIPT_PATH_PATTERN" | while IFS= read -r path; do
+    if [ -f "$path" ]; then
+      printf '%s\n' "$path"
+    fi
+  done)
+
+  if [ "${#targets[@]}" -eq 0 ]; then
+    return 0
+  fi
+
+  run_shellcheck "${targets[@]}"
+  run_executable_check "${targets[@]}"
+}
+
+run_pre_commit_doc_checks() {
+  local -a targets=()
+
+  mapfile -t targets < <(collect_matching_changed_files "$DOC_PATH_PATTERN" | while IFS= read -r path; do
+    if [ -f "$path" ]; then
+      printf '%s\n' "$path"
+    fi
+  done)
+
+  if [ "${#targets[@]}" -eq 0 ]; then
+    return 0
+  fi
+
+  echo "=== Linting Mermaid diagrams for staged docs ==="
+  "$REPO_ROOT/scripts/lint-mermaid-rendering.sh" "${targets[@]}"
+  echo "=== Validating Mermaid diagrams for staged docs ==="
+  "$REPO_ROOT/scripts/validate-mermaid.sh" "${targets[@]}"
+}
+
+run_pre_commit_workflow_checks() {
+  local -a targets=()
+
+  mapfile -t targets < <(collect_matching_changed_files '^\.github/workflows/.*\.ya?ml$' | while IFS= read -r path; do
+    if [ -f "$path" ]; then
+      printf '%s\n' "$path"
+    fi
+  done)
+
+  if [ "${#targets[@]}" -eq 0 ]; then
+    return 0
+  fi
+
+  require_command yamllint
+  echo "=== Linting staged workflow YAML ==="
+  yamllint -c .yamllint "${targets[@]}"
+}
+
+run_pre_commit() {
+  load_staged_files
+  if [ "${#changed_files[@]}" -eq 0 ]; then
+    exit 0
+  fi
+
+  trap 'echo ""; echo "Pre-commit checks failed. Fix the issues above before committing."' ERR
+  run_pre_commit_script_checks
+  run_pre_commit_doc_checks
+  run_pre_commit_workflow_checks
+}
+
+run_pre_push() {
+  load_changed_files_from_env
+  if [ "${#changed_files[@]}" -eq 0 ]; then
+    exit 0
+  fi
+
+  trap 'echo ""; echo "Pre-push checks failed. Fix the issues above before pushing."' ERR
+
+  if canonical_runner_changed || has_changed_path "$SCRIPT_PATH_PATTERN"; then
+    run_script_validation
+  fi
+
+  if canonical_runner_changed || has_changed_path "$DOC_PATH_PATTERN"; then
+    run_doc_validation
+  fi
+
+  if canonical_runner_changed || has_changed_path "$WORKFLOW_PATH_PATTERN"; then
+    run_workflow_validation
+  fi
+}
+
+mode="${1:-}"
+case "$mode" in
+  pre-commit)
+    run_pre_commit
+    ;;
+  pre-push)
+    run_pre_push
+    ;;
+  ci-scripts)
+    run_script_validation
+    ;;
+  ci-docs)
+    load_changed_files_from_env
+    run_doc_validation
+    ;;
+  ci-workflows)
+    run_workflow_validation
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/scripts/run-required-checks.sh
+++ b/scripts/run-required-checks.sh
@@ -6,8 +6,9 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
 readonly SCRIPT_PATH_PATTERN='^(scripts/.*\.sh|\.githooks/(install-hooks\.sh|pre-commit|pre-push))$'
-readonly DOC_PATH_PATTERN='^(docs/.*\.md|design/.*\.md|README\.md|AGENTS\.md)$'
-readonly WORKFLOW_PATH_PATTERN='^(\.github/workflows/.*\.ya?ml|\.github/actions/.*\.ya?ml|\.github/actionlint\.yaml|\.yamllint|scripts/validate-gh-cli-usage\.sh|scripts/validate-workflow-refs\.sh)$'
+readonly DOC_PATH_PATTERN='^(docs/.*\.md|design/.*\.md|setup/.*\.md|README\.md|AGENTS\.md)$'
+readonly DOC_HELPER_PATH_PATTERN='^(scripts/check-doc-links\.sh|scripts/lint-mermaid-rendering\.sh|scripts/validate-mermaid\.sh)$'
+readonly WORKFLOW_PATH_PATTERN='^(\.github/workflows/.*\.ya?ml|\.github/actions/.*\.ya?ml|\.github/actionlint\.yaml|\.yamllint|\.githooks/(install-hooks\.sh|pre-commit|pre-push)|scripts/validate-gh-cli-usage\.sh|scripts/validate-workflow-refs\.sh)$'
 readonly CANONICAL_RUNNER='scripts/run-required-checks.sh'
 
 changed_files=()
@@ -137,8 +138,8 @@ run_doc_link_check() {
 build_doc_targets() {
   local -a doc_targets=()
 
-  if [ "${#changed_files[@]}" -eq 0 ] || canonical_runner_changed; then
-    for target in docs design README.md AGENTS.md; do
+  if [ "${#changed_files[@]}" -eq 0 ] || canonical_runner_changed || has_changed_path "$DOC_HELPER_PATH_PATTERN"; then
+    for target in docs design setup README.md AGENTS.md; do
       if [ -e "$target" ]; then
         doc_targets+=("$target")
       fi
@@ -291,7 +292,7 @@ run_pre_push() {
     run_script_validation
   fi
 
-  if canonical_runner_changed || has_changed_path "$DOC_PATH_PATTERN"; then
+  if canonical_runner_changed || has_changed_path "$DOC_PATH_PATTERN" || has_changed_path "$DOC_HELPER_PATH_PATTERN"; then
     run_doc_validation
   fi
 

--- a/setup/README.md
+++ b/setup/README.md
@@ -22,7 +22,17 @@
    git checkout main
    ```
 
-2. Create the `.env` file:
+2. Install the repo-managed git hooks for this worktree:
+   ```bash
+   cd ~/.openclaw/workspace
+   bash .githooks/install-hooks.sh
+   ```
+
+   `pre-commit` handles the fast staged-file checks, and `pre-push` reruns the
+   deterministic CI-equivalent checks for changed scripts, docs, and
+   workflow-related paths before GitHub is the first place they fail.
+
+3. Create the `.env` file:
    ```bash
    cp ~/.openclaw/workspace/.env.template ~/.openclaw/workspace/.env
    # Then edit ~/.openclaw/workspace/.env with the values you need
@@ -35,28 +45,25 @@
    that includes the Notion, reminder, and GitHub-auth helpers. Normal runtime
    setups should leave it unset and keep using `~/.openclaw/workspace/.env`.
 
-3. Run bootstrap:
+4. Run bootstrap:
    ```bash
    cd ~/.openclaw/workspace
    bash setup/bootstrap.sh
    ```
 
-   Bootstrap installs the repo git hooks for the current worktree by setting
-   `core.hooksPath` to `.githooks/`.
-
-4. Configure OpenClaw:
+5. Configure OpenClaw:
    ```bash
    # Copy and customize the config template
    cp setup/openclaw.json.template ~/.openclaw/openclaw.json
    # Edit ~/.openclaw/openclaw.json — replace all {{PLACEHOLDER}} values
    ```
 
-5. Start the gateway:
+6. Start the gateway:
    ```bash
    openclaw gateway
    ```
 
-6. Register cron jobs (from within an agent session or via the control UI):
+7. Register cron jobs (from within an agent session or via the control UI):
    - See `setup/cron/reminder-check.md` for the reminder polling job
    - See `setup/cron/pull-main.md` for automatic workspace sync
    - The heartbeat is built-in and configured in `openclaw.json`

--- a/setup/README.md
+++ b/setup/README.md
@@ -41,6 +41,9 @@
    bash setup/bootstrap.sh
    ```
 
+   Bootstrap installs the repo git hooks for the current worktree by setting
+   `core.hooksPath` to `.githooks/`.
+
 4. Configure OpenClaw:
    ```bash
    # Copy and customize the config template
@@ -100,6 +103,27 @@ git pull origin main
 ```
 
 The agent reads docs on every interaction, so changes take effect immediately. No restart needed unless `openclaw.json` changed.
+
+## Contributor Hooks
+
+Install hooks in every worktree before committing:
+
+```bash
+bash .githooks/install-hooks.sh
+```
+
+The hook contract is:
+- `pre-commit` runs fast staged-file checks.
+- `pre-push` reruns the deterministic CI-equivalent checks for any changed category, so a bad local push is rejected before GitHub is the first place it fails.
+
+`core.hooksPath` is stored per worktree, so `git worktree add` requires re-running `bash .githooks/install-hooks.sh` inside the new worktree.
+
+Manual regression playbook:
+1. Run `bash .githooks/install-hooks.sh`.
+2. Create a feature branch.
+3. Introduce a deliberate workflow lint error, such as an invalid GitHub Actions expression in `.github/workflows/pr-tests.yml`.
+4. Commit the change and run `git push origin HEAD`.
+5. Confirm that `pre-push` rejects the push locally with the same deterministic diagnostic CI would have produced.
 
 ## Troubleshooting
 

--- a/setup/README.md
+++ b/setup/README.md
@@ -114,7 +114,7 @@ bash .githooks/install-hooks.sh
 
 The hook contract is:
 - `pre-commit` runs fast staged-file checks.
-- `pre-push` reruns the deterministic CI-equivalent checks for any changed category, so a bad local push is rejected before GitHub is the first place it fails.
+- `pre-push` reruns the deterministic CI-equivalent checks for changed scripts, docs, and workflow-related paths, so those failures are caught locally before GitHub is the first place they fail.
 
 `core.hooksPath` is stored per worktree, so `git worktree add` requires re-running `bash .githooks/install-hooks.sh` inside the new worktree.
 

--- a/setup/bootstrap.sh
+++ b/setup/bootstrap.sh
@@ -95,6 +95,12 @@ mkdir -p "$ROOT_DIR/rewards"
 echo "Ensured runtime directories exist"
 echo ""
 
+# --- Git hooks ---
+
+echo "Installing git hooks for this worktree..."
+bash "$ROOT_DIR/.githooks/install-hooks.sh"
+echo ""
+
 # --- Notion connectivity ---
 
 echo "Testing Notion connectivity..."


### PR DESCRIPTION
Resolves #344

## Summary
- centralize the deterministic local CI-equivalent checks in `scripts/run-required-checks.sh`
- wire `.githooks/pre-commit`, `.githooks/pre-push`, and `pr-tests.yml` to that shared runner so hooks and CI cannot drift independently
- expand hook/CI onboarding and validation docs, including per-worktree `core.hooksPath` notes and a manual pre-push regression playbook

## Test Plan
- `shellcheck scripts/*.sh`
- `yamllint .github/workflows/*.yml`
- `shellcheck .githooks/pre-commit .githooks/pre-push .githooks/install-hooks.sh`
- `./scripts/run-required-checks.sh ci-scripts`
- `RUN_REQUIRED_CHECKS_CHANGED_FILES=$'README.md\nsetup/README.md\nscripts/check-doc-links.sh\nscripts/lint-mermaid-rendering.sh\nscripts/validate-mermaid.sh\nscripts/run-required-checks.sh' ./scripts/run-required-checks.sh ci-docs`
- `./scripts/run-required-checks.sh ci-workflows`
- dry-run `.githooks/pre-push` with the rebased branch ref update
- `git push -u origin codex/issue-344`

Generated with Codex