### PR TITLE
review-finalize: write merge-gate status via GITHUB_TOKEN (integration_id 15368)

### DIFF
--- a/.github/workflows/review-entry.yml
+++ b/.github/workflows/review-entry.yml
@@ -37,7 +37,7 @@ permissions:
   issues: read
   packages: read
   pull-requests: read
-  statuses: read
+  statuses: write
 
 concurrency:
   group: review-entry-v2-${{ github.event_name == 'issue_comment' && format('pr-{0}', github.event.issue.number) || github.event.pull_request.head.ref }}

--- a/.github/workflows/review-finalize.yml
+++ b/.github/workflows/review-finalize.yml
@@ -38,7 +38,7 @@ permissions:
   contents: read
   pull-requests: read
   issues: read
-  statuses: read
+  statuses: write
 
 jobs:
   finalize:
@@ -66,6 +66,34 @@ jobs:
           path: /tmp/verdict
           name: verdict-${{ inputs.post_fix_sha }}
 
+      # Write the v1-compatible "All Required Agent Reviews" merge-gate
+      # status using GITHUB_TOKEN (the Actions native integration,
+      # integration_id 15368). The repo's branch protection ruleset
+      # requires this exact context published by THAT specific
+      # integration; statuses written by a personal PAT (User type)
+      # do NOT satisfy the rule. v1's all-reviews-passed job used
+      # github-script with GITHUB_TOKEN, which is what we mirror here.
+      - name: Publish "All Required Agent Reviews" merge-gate status
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const verdict = ${{ toJSON(inputs.verdict) }};
+            const sha = ${{ toJSON(inputs.post_fix_sha) }};
+            const state = verdict === 'GO' ? 'success' : 'failure';
+            const description = verdict === 'GO'
+              ? 'v2 verdict: GO'
+              : 'v2 verdict: NO-GO; needs-human-review';
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha,
+              state,
+              context: 'All Required Agent Reviews',
+              description,
+            });
+            core.info(`Wrote All Required Agent Reviews=${state} on ${sha}`);
+
       - name: Apply NO-GO label and sticky comment
         if: inputs.verdict == 'NO-GO'
         env:
@@ -85,15 +113,6 @@ jobs:
             --description "Review pipeline v2 could not converge; human takeover needed" \
             --repo "$REPO" 2>/dev/null || true
           gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label needs-human-review
-
-          # Write the v1-compatible commit-status check as failure so
-          # branch protection sees a terminal state instead of forever
-          # pending. The PR still merges only after a human takes
-          # action; this just makes the GitHub UI honest.
-          gh api -X POST "repos/${REPO}/statuses/${POST_FIX_SHA}" \
-            -f state=failure \
-            -f context='All Required Agent Reviews' \
-            -f description='v2 verdict: NO-GO; needs-human-review' >/dev/null
 
           REASONS=$(jq -r '.reasons[]? // empty' /tmp/verdict/verdict-${{ inputs.post_fix_sha }}.json | sed 's/^/- /')
           BLOCKERS=$(jq -r '.unaddressed_blocker_ids[]? // empty' /tmp/verdict/verdict-${{ inputs.post_fix_sha }}.json | sed 's/^/- /')
@@ -147,16 +166,6 @@ jobs:
             --description "All required agent reviews passed (v2)" \
             --repo "$REPO" 2>/dev/null || true
           gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label agent-reviews-passed
-
-          # Write the v1-compatible commit-status check that branch
-          # protection expects. v1's all-reviews-passed job published
-          # this exact context name; v2 needs to write the same so
-          # PR merge gates and any external automation that keys on
-          # "All Required Agent Reviews" continue to work.
-          gh api -X POST "repos/${REPO}/statuses/${POST_FIX_SHA}" \
-            -f state=success \
-            -f context='All Required Agent Reviews' \
-            -f description='v2 verdict: GO' >/dev/null
 
           REASONS=$(jq -r '.reasons[]? // empty' /tmp/verdict/verdict-${{ inputs.post_fix_sha }}.json | sed 's/^/- /')
 

--- a/.github/workflows/review-pipeline.yml
+++ b/.github/workflows/review-pipeline.yml
@@ -42,7 +42,7 @@ permissions:
   issues: read
   packages: read
   pull-requests: read
-  statuses: read
+  statuses: write
 
 env:
   DEVCONTAINER_IMAGE: ghcr.io/nickborgersprobably/hide-my-list-devcontainer


### PR DESCRIPTION
PR #384 was BLOCKED with all status checks green. Branch protection requires `All Required Agent Reviews` to be authored by `integration_id: 15368` (GitHub Actions native integration). v2 was writing it via `gh api` with `WORKFLOW_PAT` (a personal token, type=User), which doesn't satisfy the integration_id constraint.

v1's all-reviews-passed used `actions/github-script` with the auto-issued `GITHUB_TOKEN`, which IS integration 15368. Mirror that for v2.

- Replaces inline `gh api .../statuses/...` writes for `All Required Agent Reviews` (both GO and NO-GO paths) with one dedicated `actions/github-script` step using `secrets.GITHUB_TOKEN`.
- Bumps `statuses: read` -> `statuses: write` on GITHUB_TOKEN in entry/pipeline/finalize.

Other v2 status writes (review/cycle, review/reviewer-*, review/pipeline) continue to use WORKFLOW_PAT — only this one merge-gate status needs the integration constraint.