### PR TITLE
review/prompts: enforce 500-char summary cap

### DIFF
--- a/.github/scripts/review/prompts/_shared.md
+++ b/.github/scripts/review/prompts/_shared.md
@@ -39,13 +39,18 @@ fields:
   "reviewed_sha": "${REVIEWED_SHA}",
   "cycle": ${REVIEW_CYCLE},
   "decision": "approve | request_changes | comment | abstain",
-  "summary": "<one-paragraph summary>",
+  "summary": "<one-paragraph summary, MAX 500 characters>",
   "blocking_issues": [],
   "non_blocking_notes": [],
   "fix_suggestions": [],
   "followup_issues": []
 }
 ```
+
+The `summary` field is hard-capped at 500 characters by the schema
+validator. Keep it tight; put detail in `non_blocking_notes[]` or
+`blocking_issues[]` rather than expanding the summary. Validation will
+fail the job if you exceed this limit.
 
 Each `blocking_issues[]` entry must have a stable `id` (e.g.
 `"sec-001"`); the fixer addresses blockers by namespaced `role/id`

--- a/.github/scripts/review/prompts/_shared.md
+++ b/.github/scripts/review/prompts/_shared.md
@@ -39,7 +39,7 @@ fields:
   "reviewed_sha": "${REVIEWED_SHA}",
   "cycle": ${REVIEW_CYCLE},
   "decision": "approve | request_changes | comment | abstain",
-  "summary": "<one-paragraph summary, MAX 500 characters>",
+  "summary": "<one-paragraph summary>",
   "blocking_issues": [],
   "non_blocking_notes": [],
   "fix_suggestions": [],

--- a/.github/scripts/review/prompts/design.md
+++ b/.github/scripts/review/prompts/design.md
@@ -53,7 +53,7 @@ Write your verdict as JSON to `$OUTPUT_PATH` conforming to
   "reviewed_sha": "${REVIEWED_SHA}",
   "cycle": ${REVIEW_CYCLE},
   "decision": "approve | request_changes | comment | abstain",
-  "summary": "<one paragraph including explicit Scope check: PASS|FAIL>",
+  "summary": "<one paragraph including explicit Scope check: PASS|FAIL — MAX 500 characters; put detail in non_blocking_notes[] or blocking_issues[]>",
   "blocking_issues": [],
   "non_blocking_notes": [],
   "fix_suggestions": [],

--- a/.github/scripts/review/prompts/design.md
+++ b/.github/scripts/review/prompts/design.md
@@ -53,13 +53,17 @@ Write your verdict as JSON to `$OUTPUT_PATH` conforming to
   "reviewed_sha": "${REVIEWED_SHA}",
   "cycle": ${REVIEW_CYCLE},
   "decision": "approve | request_changes | comment | abstain",
-  "summary": "<one paragraph including explicit Scope check: PASS|FAIL — MAX 500 characters; put detail in non_blocking_notes[] or blocking_issues[]>",
+  "summary": "<one paragraph including explicit Scope check: PASS|FAIL>",
   "blocking_issues": [],
   "non_blocking_notes": [],
   "fix_suggestions": [],
   "followup_issues": []
 }
 ```
+
+Keep `summary` to 500 characters or fewer. The schema validator
+hard-fails longer summaries, so put detail in `blocking_issues[]` or
+`non_blocking_notes[]` instead.
 
 Each `blocking_issues[]` entry needs a stable `id` (e.g. `"d-001"`);
 the fixer addresses blockers by namespaced `role/id` (e.g.

--- a/.github/scripts/review/prompts/docs.md
+++ b/.github/scripts/review/prompts/docs.md
@@ -47,4 +47,8 @@ For each high-confidence blocker, emit a matching `fix_suggestions[]`
 entry — a doc fix is almost always `applicable: "manual"` unless it's
 a literal rename.
 
+Keep `summary` to 500 characters or fewer. The schema validator
+hard-fails longer summaries, so put detail in `blocking_issues[]` or
+`non_blocking_notes[]` instead.
+
 Do NOT push any changes. Do NOT post PR comments yourself.

--- a/.github/scripts/review/prompts/prompt.md
+++ b/.github/scripts/review/prompts/prompt.md
@@ -52,4 +52,8 @@ Write your verdict as JSON to `$OUTPUT_PATH` conforming to
 `role: "prompt"`. Each `blocking_issues[]` entry needs a stable `id`
 (e.g. `"prm-001"`).
 
+Keep `summary` to 500 characters or fewer. The schema validator
+hard-fails longer summaries, so put detail in `blocking_issues[]` or
+`non_blocking_notes[]` instead.
+
 Do NOT push any changes. Do NOT post PR comments yourself.

--- a/.github/scripts/review/prompts/psych.md
+++ b/.github/scripts/review/prompts/psych.md
@@ -46,6 +46,10 @@ Write your verdict as JSON to `$OUTPUT_PATH` conforming to
 `role: "psych"`. Each `blocking_issues[]` entry needs a stable `id`
 (e.g. `"psy-001"`).
 
+Keep `summary` to 500 characters or fewer. The schema validator
+hard-fails longer summaries, so put detail in `blocking_issues[]` or
+`non_blocking_notes[]` instead.
+
 When you flag something as blocking, cite the research basis or the
 canonical doc you're cross-referencing in the `message` field. Vague
 "this feels wrong" findings are non-blocking notes, not blockers.

--- a/.github/scripts/review/prompts/security.md
+++ b/.github/scripts/review/prompts/security.md
@@ -67,13 +67,17 @@ Write your verdict as JSON to `$OUTPUT_PATH` conforming to
   "reviewed_sha": "${REVIEWED_SHA}",
   "cycle": ${REVIEW_CYCLE},
   "decision": "approve | request_changes | comment | abstain",
-  "summary": "<one paragraph, MAX 500 characters>",
+  "summary": "<one paragraph>",
   "blocking_issues": [],
   "non_blocking_notes": [],
   "fix_suggestions": [],
   "followup_issues": []
 }
 ```
+
+Keep `summary` to 500 characters or fewer. The schema validator
+hard-fails longer summaries, so put detail in `blocking_issues[]` or
+`non_blocking_notes[]` instead.
 
 Each `blocking_issues[]` entry needs a stable `id` (e.g. `"sec-001"`).
 For each high-confidence blocker, emit a matching `fix_suggestions[]`

--- a/.github/scripts/review/prompts/security.md
+++ b/.github/scripts/review/prompts/security.md
@@ -67,7 +67,7 @@ Write your verdict as JSON to `$OUTPUT_PATH` conforming to
   "reviewed_sha": "${REVIEWED_SHA}",
   "cycle": ${REVIEW_CYCLE},
   "decision": "approve | request_changes | comment | abstain",
-  "summary": "<one paragraph>",
+  "summary": "<one paragraph, MAX 500 characters>",
   "blocking_issues": [],
   "non_blocking_notes": [],
   "fix_suggestions": [],


### PR DESCRIPTION
## Summary
- Codex security reviewer on PR #386 produced a 700+ char `summary`, failing ajv validation against `reviewer-v1.json` (`maxLength: 500`) after a clean review.
- Prompts only said "one paragraph" — surfaced the hard 500-char cap in `_shared.md` and the `security.md` placeholder so the model self-trims.

Failed run: https://github.com/NickBorgersProbably/hide-my-list/actions/runs/24139320773/job/70436139080

## Test plan
- [ ] Re-run security reviewer on PR #386 via `/review` and confirm artifact validates.