### PR TITLE
Add heartbeat.target to fix silent reminder delivery

### DIFF
--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -33,11 +33,12 @@ OpenClaw's heartbeat is a built-in periodic trigger configured in `openclaw.json
 ```json
 "heartbeat": {
   "every": "60m",
-  "model": "litellm/claude-sonnet-4-6"
+  "model": "litellm/claude-sonnet-4-6",
+  "target": "signal"
 }
 ```
 
-Every 60 minutes, OpenClaw creates a short agent session that reads `HEARTBEAT.md` and executes the checks defined there. It uses a lighter model (Sonnet instead of Opus) since these are routine operational tasks.
+Every 60 minutes, OpenClaw creates a short agent session that reads `HEARTBEAT.md` and executes the checks defined there. It uses a lighter model (Sonnet instead of Opus) since these are routine operational tasks. The `target` field controls where non-`HEARTBEAT_OK` output (such as reminder delivery) is routed; without it, `target` defaults to `"none"` and all heartbeat output is silently discarded ([openclaw/openclaw#29215](https://github.com/openclaw/openclaw/issues/29215)).
 
 **Our usage:** The heartbeat serves two roles:
 1. **Reminder-delivery backstop:** The isolated `reminder-check` cron only writes `.reminder-signal` — it does not deliver to the user. Heartbeat Check 1 reads stranded signal files and delivers reminders every 60 minutes. (The AGENTS.md startup check provides faster opportunistic delivery when the user is active.)

--- a/setup/README.md
+++ b/setup/README.md
@@ -135,6 +135,7 @@ Manual regression playbook:
 ## Troubleshooting
 
 **Reminders not firing:**
+- Check that `heartbeat.target` is set in `openclaw.json` (e.g. `"target": "signal"`). Without it, heartbeat output is silently discarded and reminders never reach the user.
 - Check that the reminder-check cron is registered (ask the agent to check CronList)
 - Verify `.env` has correct `NOTION_API_KEY` and `NOTION_DATABASE_ID`
 - Run `scripts/check-reminders.sh` manually to test Notion connectivity

--- a/setup/cron/heartbeat-check.md
+++ b/setup/cron/heartbeat-check.md
@@ -7,9 +7,12 @@ The heartbeat is not a cron job we create — it's a built-in OpenClaw feature c
 ```json
 "heartbeat": {
   "every": "60m",
-  "model": "litellm/claude-sonnet-4-6"
+  "model": "litellm/claude-sonnet-4-6",
+  "target": "signal"
 }
 ```
+
+The `target` field is required for reminder delivery. Without it, OpenClaw defaults to `"none"` and silently discards all heartbeat output — including reminders. Set it to `"signal"` (or whichever channel your user communicates on) so that non-`HEARTBEAT_OK` output is routed to the user.
 
 ## Behavior
 

--- a/setup/openclaw.json.template
+++ b/setup/openclaw.json.template
@@ -64,7 +64,8 @@
       },
       "heartbeat": {
         "every": "60m",
-        "model": "litellm/claude-sonnet-4-6"
+        "model": "litellm/claude-sonnet-4-6",
+        "target": "signal"
       },
       "maxConcurrent": 4,
       "subagents": {


### PR DESCRIPTION
## Summary

- Adds `"target": "signal"` to the heartbeat config in `setup/openclaw.json.template` so heartbeat output is routed to the user instead of silently discarded
- Documents the `target` requirement in `setup/cron/heartbeat-check.md` and `docs/openclaw-integration.md`
- Adds `heartbeat.target` check to the "Reminders not firing" troubleshooting section in `setup/README.md`

**Root cause:** OpenClaw's `heartbeat.target` defaults to `"none"`, which drops all heartbeat output — including reminder delivery from HEARTBEAT.md Check 1. This is a known platform behavior ([openclaw/openclaw#29215](https://github.com/openclaw/openclaw/issues/29215)). No prompt changes are needed; the config template was simply missing the field.

**Note:** The live `openclaw.json` on the deployment also needs `"target": "signal"` added to the heartbeat block for the fix to take effect.

Closes #389

## Test plan
- [ ] Verify JSON template is valid: `python3 -c "import json; json.load(open('setup/openclaw.json.template'))"`
- [ ] Verify no broken doc links: `bash scripts/check-doc-links.sh`
- [ ] After deploying the config change, trigger a test reminder and confirm it arrives on Signal via the heartbeat path

🤖 Generated with [Claude Code](https://claude.com/claude-code)