### PR TITLE
Use message tool for reminder handoff delivery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,9 @@ You are **hide-my-list**, an ADHD-informed task manager. The conversation *is* t
 5. Check for the reminder handoff file (default: `.reminder-signal`, overridable via `REMINDER_SIGNAL_FILE` in `.env`) — if it exists, read it and deliver each reminder to the user:
    - Approximate reminders (next eligible poll, before missed threshold): casual delivery ("Hey, time to [task]")
    - Missed reminders (>15 min late): note the delay but don't shame ("This was due a bit ago — [task]")
-   - After delivery, run `scripts/notion-cli.sh complete-reminder PAGE_ID sent|missed` for each item, then delete the handoff file
+   - Deliver each reminder proactively with the `message` tool rather than relying on a plain assistant reply: use `action: send`, `channel: signal`, `target: <defaultTo from config>`, and the reminder text as the message body
+   - Only after the `message` tool succeeds for a reminder should you run `scripts/notion-cli.sh complete-reminder PAGE_ID sent|missed` for that item
+   - Only delete the handoff file after every reminder in it has been sent successfully and marked complete
    - If delivery fails, leave the handoff file in place for retry
 
 Then be ready. The user might add a task, ask for something to do, say they're done, or just chat.

--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -8,7 +8,11 @@
   HANDOFF_FILE="$(bash -lc 'SCRIPT_DIR=$(cd "$(dirname scripts/check-reminders.sh)" && pwd); ROOT_DIR=$(cd "$SCRIPT_DIR/.." && pwd); source "$SCRIPT_DIR/load-env.sh" REMINDER_SIGNAL_FILE?; SIGNAL_BASENAME=${REMINDER_SIGNAL_FILE:-.reminder-signal}; case "$SIGNAL_BASENAME" in ""|"."|".."|*/*) echo "invalid REMINDER_SIGNAL_FILE" >&2; exit 1 ;; esac; printf "%s\n" "$ROOT_DIR/$SIGNAL_BASENAME"')"
   ```
 - This file is the reminder handoff written by `scripts/check-reminders.sh`
-- If `HANDOFF_FILE` still exists when heartbeat runs, treat it as undelivered reminder work: read it, send each reminder to the user, run `scripts/notion-cli.sh complete-reminder PAGE_ID sent|missed` based on the file, then delete that handoff file
+- If `HANDOFF_FILE` still exists when heartbeat runs, treat it as undelivered reminder work: read it and proactively deliver each reminder with the `message` tool instead of a normal assistant reply
+- For each reminder delivery, use the `message` tool with `action: send`, `channel: signal`, `target: <defaultTo from config>`, and the reminder text as the message body. Heartbeat runs as an isolated session and has no user conversation to reply into.
+- Only after the `message` tool succeeds for a reminder should you run `scripts/notion-cli.sh complete-reminder PAGE_ID sent|missed` for that reminder
+- Only delete the handoff file after every reminder in it has been sent successfully and marked with `complete-reminder`
+- If any `message` send fails, do not mark that reminder complete and do not delete the handoff file; leave it in place for retry
 - This is the hourly reminder-delivery backstop in the current design. The isolated `reminder-check` cron only writes the handoff file — it does not deliver. Delivery happens here (every 60 min) and opportunistically via the AGENTS.md startup check (on every user interaction).
 
 ### 2. Cron Job Health

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -229,9 +229,10 @@ sequenceDiagram
 3. The cron job runs `scripts/check-reminders.sh` to query Notion for pending reminders where `remind_at <= now`.
 4. If due reminders are found, `check-reminders.sh` writes the reminder handoff file in the repo root (default filename: `.reminder-signal`, overridable via `REMINDER_SIGNAL_FILE` in `.env`). The isolated cron session then exits with `NO_REPLY` — it does not deliver reminders.
 5. Reminder delivery happens through two separate mechanisms:
-   - **AGENTS.md step 5** (opportunistic): every time the user starts a conversation, the main session checks for the handoff file and delivers immediately.
-   - **HEARTBEAT.md Check 1** (hourly backstop): the heartbeat reads the handoff file every 60 minutes and delivers any stranded reminders.
-   Both delivery paths use `scripts/notion-cli.sh complete-reminder PAGE_ID sent|missed` to atomically set `Status` to `Completed`, `Reminder Status` to `sent` or `missed`, and `Completed At`.
+   - **AGENTS.md step 5** (opportunistic): every time the user starts a conversation, the main session checks for the handoff file and proactively sends reminder messages via the `message` tool (`action: send`, `channel: signal`, `target: <defaultTo from config>`).
+   - **HEARTBEAT.md Check 1** (hourly backstop): the heartbeat reads the handoff file every 60 minutes and proactively sends any stranded reminders the same way. This explicit tool call is required because heartbeat is an isolated session with no active user conversation to reply into.
+   - Only after a `message` send succeeds does the delivering session run `scripts/notion-cli.sh complete-reminder PAGE_ID sent|missed` for that reminder, which atomically sets `Status` to `Completed`, `Reminder Status` to `sent` or `missed`, and `Completed At`.
+   - The handoff file is deleted only after every reminder in it has been sent successfully and marked complete; if a send fails, the file stays in place for retry.
 6. Reminders more than 15 minutes past due are flagged as `missed` but still delivered with a note.
 7. The cron job only fires when the agent is idle — it won't interrupt the user mid-task, which is better for ADHD focus.
 

--- a/docs/user-interactions.md
+++ b/docs/user-interactions.md
@@ -781,7 +781,9 @@ sequenceDiagram
     end
 ```
 
-The `reminder-check` cron runs as an isolated Haiku session — it is query-only and does not deliver reminders. Delivery happens through two paths: the main-session startup check (AGENTS.md step 5, on every user interaction) and the heartbeat (HEARTBEAT.md Check 1, every 60 min). If delivery fails, the handoff file is left in place for retry.
+The `reminder-check` cron runs as an isolated Haiku session — it is query-only and does not deliver reminders. Delivery happens through two paths: the main-session startup check (AGENTS.md step 5, on every user interaction) and the heartbeat (HEARTBEAT.md Check 1, every 60 min).
+
+Both delivery paths must use the `message` tool to proactively send the reminder over Signal with `action: send`, `channel: signal`, and `target: <defaultTo from config>`. They must not rely on a normal assistant reply for delivery. Only after the send succeeds should the agent call `scripts/notion-cli.sh complete-reminder PAGE_ID sent|missed`; if the send fails, the handoff file is left in place for retry.
 
 ### Reminder Delivery Messages
 

--- a/setup/cron/heartbeat-check.md
+++ b/setup/cron/heartbeat-check.md
@@ -22,10 +22,10 @@ Every 60 minutes, OpenClaw runs the agent with `HEARTBEAT.md` as context. The ag
 5. Verify environment is intact
 6. Pull main if flagged
 
-Uses a lighter model (Sonnet) since these are routine operational checks. Heartbeat also participates in reminder delivery by processing stranded handoff files, so its hourly cadence is part of the production reminder-latency tradeoff.
+Uses a lighter model (Sonnet) since these are routine operational checks. Heartbeat also participates in reminder delivery by processing stranded handoff files and proactively sending them through the `message` tool to Signal, so its hourly cadence is part of the production reminder-latency tradeoff.
 
 ## Notes
 
 - The heartbeat is the safety net for cron job expiry and spec drift. If a cron job auto-expires after 7 days, the next heartbeat re-registers it. If a live job's effective registration drifts from the `CronCreate` block in `setup/cron/` (for example `name`, `durable`, `schedule`, `prompt`, `sessionTarget`, `model`, an unexpected direct-delivery `to`, `payload.kind`, or `timeout-seconds`), the next heartbeat patches it back to the spec. `HEARTBEAT.md` defines the authoritative comparison contract.
-- The heartbeat is also the hourly backstop for reminder delivery. The isolated `reminder-check` cron only writes `.reminder-signal`; heartbeat Check 1 reads and delivers stranded reminders.
+- The heartbeat is also the hourly backstop for reminder delivery. The isolated `reminder-check` cron only writes `.reminder-signal`; heartbeat Check 1 reads stranded reminders, delivers them with the `message` tool (`action: send`, `channel: signal`, `target: <defaultTo from config>`), and only then marks them complete.
 - The heartbeat itself is managed by OpenClaw and does not expire.

--- a/setup/cron/reminder-check.md
+++ b/setup/cron/reminder-check.md
@@ -19,10 +19,10 @@ CronCreate:
 This job runs as an isolated Haiku session. It is query-only: it runs the check script, which writes the reminder handoff file (default filename: `.reminder-signal`, overridable via `REMINDER_SIGNAL_FILE` in `.env`) if any reminders are due, and then exits. It does not deliver reminders to the user.
 
 **Reminder delivery** is handled separately by two mechanisms:
-1. **AGENTS.md step 5** (opportunistic): every time the user interacts, the main session checks for the handoff file and delivers immediately.
-2. **HEARTBEAT.md Check 1** (hourly backstop): the heartbeat reads the handoff file every 60 minutes and delivers any stranded reminders.
+1. **AGENTS.md step 5** (opportunistic): every time the user interacts, the main session checks for the handoff file and proactively sends reminders immediately.
+2. **HEARTBEAT.md Check 1** (hourly backstop): the heartbeat reads the handoff file every 60 minutes and proactively sends any stranded reminders.
 
-Both delivery paths use `scripts/notion-cli.sh complete-reminder PAGE_ID sent|missed` to atomically set Notion `Status` to `Completed`, `Reminder Status` to `sent` or `missed`, and `Completed At`.
+Both delivery paths do that delivery with the `message` tool (`action: send`, `channel: signal`, `target: <defaultTo from config>`), then call `scripts/notion-cli.sh complete-reminder PAGE_ID sent|missed` only after the send succeeds so Notion `Status`, `Reminder Status`, and `Completed At` reflect confirmed delivery rather than attempted delivery.
 
 This separation is a deliberate design choice. The previous architecture ran reminder-check on `sessionTarget: main`, which loaded the full Opus agent context (~200k tokens) for a job that 95% of the time just runs a script and finds nothing. Moving to isolated Haiku cuts per-run cost by orders of magnitude. The trade-off is that fully idle worst-case delivery latency is now up to about 75 minutes: up to 15 minutes for this cron to write the handoff file, then up to another 60 minutes for heartbeat to deliver it if the user does not interact first. In practice, many reminders still deliver on the next user interaction. The current system already can't interrupt mid-conversation (cron only fires when the REPL is idle), so the practical difference is small.
 


### PR DESCRIPTION
Resolves #389

## Summary
- update `HEARTBEAT.md` so stranded reminder handoffs must be delivered with the `message` tool to Signal using the configured `defaultTo` target
- update `AGENTS.md` and the reminder architecture docs so reminders are only marked complete and the handoff file is only deleted after a successful send
- keep retry semantics explicit for both heartbeat and startup delivery paths

## Test Plan
- run `shellcheck scripts/*.sh`
- run `yamllint .github/workflows/*.yml`
- run `scripts/check-doc-links.sh`

Generated with Codex