### PR TITLE
Design reviewer: add agentic system awareness

### DIFF
--- a/.github/scripts/review/prompts/design.md
+++ b/.github/scripts/review/prompts/design.md
@@ -13,7 +13,12 @@ Focus on:
 
 1. **Intent fulfillment.** Does the PR solve the stated problem? Read
    the linked issue (if any) and compare against the diff. Gaps
-   between intent and delivery are blocking.
+   between intent and delivery are blocking **when the PR's approach
+   is wrong or misses something it could have included**. But when a
+   PR delivers a correct fix for part of the problem and a viable
+   enhancement path exists using the system's own agentic
+   capabilities, that enhancement belongs in a non-blocking note or
+   follow-up issue — not a blocker on the current fix.
 2. **Scope check.** Compare the PR title against the actual diff. If
    the title suggests a narrow fix but the diff introduces new
    abstractions or significant code beyond what the title implies,
@@ -29,7 +34,24 @@ Focus on:
    and the runtime scripts/config they reference. Treat contradictions
    as blocking.
 
-Reference `docs/architecture.md` for system design context.
+**Required context — read before reviewing:**
+
+- Read `docs/architecture.md` for the full system design.
+- **This is an agentic system.** The OpenClaw runtime is an intelligent
+  agent — it reads instructions, uses tools, and takes actions not
+  explicitly coded. It can modify its own config at runtime via
+  platform tools (`config.patch`, `config.apply`,
+  `config.schema.lookup`). Don't apply static-application reasoning
+  ("there's no code path for X, so X can't happen").
+- **`HEARTBEAT.md` is the self-healing pattern.** It runs every 60
+  minutes and already self-heals cron drift, validates environment,
+  and recovers workspace state. When a gap could be closed by adding
+  a heartbeat check, suggest it concretely as a non-blocking note —
+  don't block the PR with a vague demand for "a guard."
+- When suggesting fixes, name the specific mechanism (e.g., "add a
+  heartbeat check that verifies X via `config.schema.lookup` and
+  patches via `config.patch`"), not abstract requirements ("add an
+  in-product remediation path").
 
 ## Procedure
 


### PR DESCRIPTION
## Summary

- Fixes false-positive blocking from the design reviewer when reviewing platform config / deployment PRs (e.g., PR #390's `heartbeat.target` template fix was blocked with a vague demand for "an in-product guard")
- The reviewer applied static-application reasoning ("no code path for X → X can't happen") to an agentic system that can self-heal via HEARTBEAT.md checks and modify its own config via `config.patch`
- **Intent fulfillment** now distinguishes "the fix is wrong" (blocking) from "the fix could be enhanced using the system's own capabilities" (non-blocking note / follow-up issue)
- **Architecture reference** upgraded from a passive one-liner to a required-context block: explains that this is an agentic system, names HEARTBEAT.md as the self-healing pattern, and requires concrete mechanism suggestions instead of abstract demands

## Test plan

- [ ] Mentally replay PR #390 review against updated prompt — reviewer should approve with a non-blocking suggestion to add a heartbeat config check, not block
- [ ] Verify prompt still catches real design issues (e.g., missing scoring algorithm in a task-selection PR should still block)
- [ ] `bash scripts/run-required-checks.sh ci-docs` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)