### PR TITLE
Document session capability boundaries for OpenClaw runtime

### DIFF
--- a/.github/actions/review-classify/action.yml
+++ b/.github/actions/review-classify/action.yml
@@ -22,8 +22,13 @@ description: >
   See agentic-pipeline-learnings.md §1.9 and §1.12: spec-critical
   and reviewer-prompt .md files must NOT be classified as inert docs
   or config just because they end in .md. The classifier carves out
-  AGENTS.md, SOUL.md, TOOLS.md, HEARTBEAT.md, setup/cron/*,
-  design/adhd-priorities.md, and .github/scripts/review/prompts/*.md.
+  AGENTS.md, SOUL.md, TOOLS.md, HEARTBEAT.md, IDENTITY.md,
+  setup/cron/*, design/adhd-priorities.md, docs/ai-prompts.md,
+  docs/task-lifecycle.md, docs/notion-schema.md,
+  docs/architecture.md, docs/agent-capabilities.md,
+  docs/user-interactions.md, docs/user-preferences.md,
+  docs/reward-system.md, docs/openclaw-integration.md, and
+  .github/scripts/review/prompts/*.md.
 
 inputs:
   base_ref:

--- a/.github/actions/review-classify/action.yml
+++ b/.github/actions/review-classify/action.yml
@@ -87,7 +87,7 @@ runs:
             AGENTS.md|SOUL.md|TOOLS.md|HEARTBEAT.md|IDENTITY.md) return 0 ;;
             setup/cron/*) return 0 ;;
             design/adhd-priorities.md) return 0 ;;
-            docs/ai-prompts.md|docs/task-lifecycle.md|docs/notion-schema.md|docs/architecture.md|docs/user-interactions.md|docs/user-preferences.md|docs/reward-system.md|docs/openclaw-integration.md) return 0 ;;
+            docs/ai-prompts.md|docs/task-lifecycle.md|docs/notion-schema.md|docs/architecture.md|docs/agent-capabilities.md|docs/user-interactions.md|docs/user-preferences.md|docs/reward-system.md|docs/openclaw-integration.md) return 0 ;;
             *) return 1 ;;
           esac
         }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,7 @@ These files define how the OpenClaw agent behaves — they *are* the application
 - `HEARTBEAT.md` — Periodic health check procedures
 - `docs/ai-prompts.md` — The prompt architecture (core of the application)
 - `docs/architecture.md` — System design and data flow specification
+- `docs/agent-capabilities.md` — Session roles and runtime tool-boundary source of truth
 - `docs/task-lifecycle.md` — Task states: Pending → In Progress → Completed (with rejection/breakdown flows)
 - `docs/notion-schema.md` — Notion database schema
 - `docs/user-interactions.md` — Conversation patterns and intent detection rules

--- a/DEV-AGENTS.md
+++ b/DEV-AGENTS.md
@@ -24,6 +24,7 @@ These files define how the OpenClaw agent behaves — they *are* the application
 - `HEARTBEAT.md` — Periodic health check procedures
 - `docs/ai-prompts.md` — The prompt architecture (core of the application)
 - `docs/architecture.md` — System design and data flow specification
+- `docs/agent-capabilities.md` — Session roles and runtime tool-boundary source of truth
 - `docs/task-lifecycle.md` — Task states: Pending → In Progress → Completed (with rejection/breakdown flows)
 - `docs/notion-schema.md` — Notion database schema
 - `docs/user-interactions.md` — Conversation patterns and intent detection rules

--- a/docs/agent-capabilities.md
+++ b/docs/agent-capabilities.md
@@ -1,0 +1,145 @@
+# Agent Capabilities and Operational Boundaries
+
+This document defines the runtime roles inside hide-my-list's OpenClaw deployment. It exists to answer a specific question that the other docs only implied: which session is allowed to do which kind of work.
+
+Use this as the source of truth when updating `AGENTS.md`, `HEARTBEAT.md`, `setup/cron/`, or any operational doc that assumes a tool contract.
+
+## Why This Exists
+
+hide-my-list runs through multiple OpenClaw session types:
+
+- the **main agent** the user talks to
+- the built-in **heartbeat** session that runs `HEARTBEAT.md`
+- isolated **durable cron sessions** such as `reminder-check` and `pull-main`
+
+Those sessions do not have the same responsibilities, and they should not be assumed to have the same tools. In particular, config patching belongs to the main agent unless another session's access is explicitly confirmed.
+
+## Session Summary
+
+| Session | Trigger | User-facing | Primary responsibility |
+|---------|---------|-------------|------------------------|
+| Main agent | User message / normal conversation startup | Yes | Run the product, manage tasks, handle operator actions that need richer tools |
+| Heartbeat session | Built-in OpenClaw heartbeat every 60 minutes | Usually no; may deliver reminders | Backstop operational health and stranded reminder delivery |
+| Isolated cron session | Durable cron schedule in `setup/cron/` | No | Cheap script-first background work with narrow scope |
+
+## Main Agent
+
+The main agent is the primary OpenClaw session for hide-my-list. It is the conversation the user actually experiences. It loads the repo bootstrap files (`AGENTS.md`, `SOUL.md`, `USER.md`, `MEMORY.md`, `TOOLS.md`, and related docs), runs the intent flow, and owns the product behavior.
+
+### Confirmed tool contract
+
+The main agent is the only session type with a confirmed contract for the following operational tools:
+
+- `config.get`, `config.patch`, `config.schema.lookup` for reading and patching `~/.openclaw/openclaw.json`
+- Cron management tools for listing, creating, updating, and manually running jobs
+- `message` for proactive outbound delivery across configured channels
+- `exec`, `read`, `edit`, `write` for repo files, logs, and scripts
+- Gateway lifecycle/config tools such as restart and config inspection
+
+### Operational responsibilities
+
+The main agent is responsible for:
+
+- running the normal hide-my-list conversation loop and all task-management behavior
+- performing the startup checks in `AGENTS.md`, including opportunistic reminder delivery from the handoff file on every user interaction
+- calling `scripts/notion-cli.sh complete-reminder PAGE_ID sent|missed` after successful reminder delivery, then removing the handoff file
+- applying OpenClaw config changes that require `config.patch`, including config-drift repair after template changes
+- handling operator/debugging work that depends on richer tools, such as reading logs, inspecting config, adjusting cron registrations, or filing GitHub issues that describe runtime failures
+
+### Explicit boundary
+
+If a workflow needs `config.get`, `config.patch`, or any other `openclaw.json` mutation, treat that as a **main-agent responsibility**. Heartbeat and isolated cron sessions must not be assumed to have those tools.
+
+## Heartbeat Session
+
+The heartbeat is a short built-in OpenClaw session configured in `openclaw.json` and driven by `HEARTBEAT.md`. In this repo it runs every 60 minutes with a lighter model than the main agent.
+
+### Confirmed tool contract
+
+The heartbeat session has a narrower confirmed contract:
+
+- `exec` and `read` for script execution and repo inspection
+- Cron registration tools used by `HEARTBEAT.md` for drift correction and re-registration, specifically the ability to inspect and patch durable cron jobs
+
+### Do not assume
+
+The repo should currently treat these capabilities as unconfirmed for heartbeat sessions:
+
+- `config.get`, `config.patch`, `config.schema.lookup`
+- proactive `message` tooling outside normal heartbeat output routing
+- gateway lifecycle tools
+- general repo-edit/write capabilities as part of routine heartbeat behavior
+
+Until those are explicitly confirmed, heartbeat instructions must not depend on them.
+
+### Operational responsibilities
+
+The heartbeat is responsible for:
+
+- reading the reminder handoff file and delivering stranded reminders as the hourly backstop
+- completing delivered reminders in Notion with `scripts/notion-cli.sh complete-reminder PAGE_ID sent|missed`
+- verifying that durable cron jobs still exist and still match the canonical specs in `setup/cron/`
+- checking Notion connectivity and basic environment health
+- retrying dirty-pull recovery when `.pull-dirty` indicates the isolated cron could not finish the recovery path
+
+### Explicit boundary
+
+Heartbeat is an **operations backstop**, not the primary control plane. It should keep the existing system healthy, but it should not be the place where repo docs assume config mutation, broad gateway control, or user-conversation logic.
+
+## Isolated Cron Sessions
+
+Isolated cron sessions are durable OpenClaw jobs registered from `setup/cron/` with `sessionTarget: isolated`, `payload.kind: agentTurn`, and a lightweight model. They exist to run cheap background work without loading the main conversational context.
+
+### Shared tool assumptions
+
+Isolated cron prompts should assume only what they need for narrow script execution:
+
+- `exec` and `read` for running scripts and checking simple repo state
+- no direct user-delivery responsibility
+- no assumption of `config.patch`, gateway control, or full cron-admin authority
+
+Every isolated cron job should stay silent unless its prompt explicitly requires a status reply, and the current jobs intentionally end with `NO_REPLY`.
+
+### `reminder-check`
+
+`reminder-check` is query-only. Its responsibility is:
+
+- run `scripts/check-reminders.sh`
+- discover due reminders
+- write the repo-root reminder handoff file for another session to deliver later
+
+It is not responsible for:
+
+- sending the reminder to the user
+- calling `complete-reminder`
+- deleting the handoff file after discovery
+
+### `pull-main`
+
+`pull-main` is workspace-maintenance only. Its responsibility is:
+
+- run `scripts/pull-main.sh`
+- keep the local checkout aligned with `origin/main`
+- let the script handle dirty-pull recovery, including GitHub issue creation when needed
+
+It is not responsible for:
+
+- reapplying cron specs after a pull
+- patching OpenClaw config
+- handling user-facing messaging
+
+## Operational Split That Other Docs Should Follow
+
+When writing or reviewing runtime docs, keep these boundaries intact:
+
+- **Conversation and config mutation:** main agent
+- **Hourly health checks and stranded reminder delivery:** heartbeat
+- **Cheap background polling or sync work:** isolated cron sessions
+
+That means:
+
+- reminder discovery can happen in isolated cron, but reminder delivery stays with the main agent startup path or heartbeat
+- cron drift correction belongs to heartbeat, not the isolated cron jobs themselves
+- `openclaw.json` drift repair belongs to the main agent unless heartbeat access to config tools is explicitly confirmed later
+
+If the platform changes and new tools become available to heartbeat or isolated cron sessions, update this document first, then update `HEARTBEAT.md` or `setup/cron/` to rely on that new contract.

--- a/docs/agent-capabilities.md
+++ b/docs/agent-capabilities.md
@@ -28,10 +28,10 @@ The main agent is the primary OpenClaw session for hide-my-list. It is the conve
 
 ### Confirmed tool contract
 
-The main agent is the only session type with a confirmed contract for the following operational tools:
+The main agent is the only session type with a confirmed contract for the following higher-authority operational tools:
 
 - `config.get`, `config.patch`, `config.schema.lookup` for reading and patching `~/.openclaw/openclaw.json`
-- Cron management tools for listing, creating, updating, and manually running jobs
+- Full cron administration, including manual runs and broader job management beyond heartbeat's narrower drift-correction scope
 - `message` for proactive outbound delivery across configured channels
 - `exec`, `read`, `edit`, `write` for repo files, logs, and scripts
 - Gateway lifecycle/config tools such as restart and config inspection
@@ -49,6 +49,8 @@ The main agent is responsible for:
 ### Explicit boundary
 
 If a workflow needs `config.get`, `config.patch`, or any other `openclaw.json` mutation, treat that as a **main-agent responsibility**. Heartbeat and isolated cron sessions must not be assumed to have those tools.
+
+Tool availability does not override `AGENTS.md` safety policy. External actions still require user approval, OpenClaw prompt/spec files still go through the GitHub issue -> PR -> review path instead of direct runtime edits, and direct writes remain limited to the `AGENTS.md` allowlist except for the documented dirty-pull recovery path.
 
 ## Heartbeat Session
 

--- a/docs/agent-capabilities.md
+++ b/docs/agent-capabilities.md
@@ -33,8 +33,10 @@ The main agent is the only session type with a confirmed contract for the follow
 - `config.get`, `config.patch`, `config.schema.lookup` for reading and patching `~/.openclaw/openclaw.json`
 - Full cron administration, including manual runs and broader job management beyond heartbeat's narrower drift-correction scope
 - `message` for proactive outbound delivery across configured channels
-- `exec`, `read`, `edit`, `write` for repo files, logs, and scripts
+- `edit` and `write` for repo files and other direct workspace mutation
 - Gateway lifecycle/config tools such as restart and config inspection
+
+`exec` and `read` are also confirmed for heartbeat and isolated cron sessions under narrower scopes. The main agent remains the only session that should assume the broader operator workflows in this section.
 
 ### Operational responsibilities
 
@@ -61,7 +63,7 @@ The heartbeat is a short built-in OpenClaw session configured in `openclaw.json`
 The heartbeat session has a narrower confirmed contract:
 
 - `exec` and `read` for script execution and repo inspection
-- Cron registration tools used by `HEARTBEAT.md` for drift correction and re-registration, specifically the ability to inspect and patch durable cron jobs
+- CronList, CronCreate, CronUpdate, and CronDelete for durable cron inspection, re-registration, drift correction, and stale-job cleanup required by `HEARTBEAT.md`
 
 ### Do not assume
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,6 +9,8 @@ title: System Architecture
 
 hide-my-list is an AI-powered task manager where users never directly view their task list. The system uses conversational AI to intake tasks, intelligently label them, and surface the right task at the right time based on user mood, available time, and task urgency.
 
+For the runtime ownership split between the main agent, heartbeat, and isolated cron jobs, see [Agent Capabilities](agent-capabilities.md).
+
 ## High-Level Architecture
 
 ```mermaid

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ An AI-powered task manager where users never directly view their task list. The 
 
 ## Documentation
 
+- [Agent Capabilities](agent-capabilities.md) - Session roles, tool boundaries, and operational ownership across main agent, heartbeat, and isolated cron
 - [Architecture](architecture.md) - System architecture, components, and data flow
 - [Agentic Pipeline Learnings](agentic-pipeline-learnings.md) - Prescriptive lessons from the agentic review and CI pipeline
 - [OpenClaw Integration](openclaw-integration.md) - How the repo maps onto the OpenClaw runtime

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -2,6 +2,8 @@
 
 This document explains how hide-my-list's design leverages (and doesn't leverage) OpenClaw's architecture. It's meant to help contributors understand which pieces are ours, which are OpenClaw's, and where the boundaries are.
 
+For the session-by-session tool contract and operational ownership split between the main agent, heartbeat, and isolated cron jobs, see [Agent Capabilities](agent-capabilities.md).
+
 ## The Core Idea
 
 hide-my-list has no server, no UI framework, no database ORM. The entire application is a set of markdown files that an AI agent reads and follows. OpenClaw is the runtime that makes this work — it provides the agent session, messaging channels, scheduling, and lifecycle management.
@@ -44,6 +46,8 @@ Every 60 minutes, OpenClaw creates a short agent session that reads `HEARTBEAT.m
 1. **Reminder-delivery backstop:** The isolated `reminder-check` cron only writes `.reminder-signal` — it does not deliver to the user. Heartbeat Check 1 reads stranded signal files and delivers reminders every 60 minutes. (The AGENTS.md startup check provides faster opportunistic delivery when the user is active.)
 2. **Cron system safety net:** Verify that durable cron jobs still match the canonical `CronCreate` specs in `setup/cron/`: if a job expired, heartbeat re-registers it; if a live job drifted from its spec, heartbeat patches it back into compliance. The comparison covers the full effective registration contract, including `name`, `durable`, `schedule`, `prompt`, `sessionTarget`, `model`, the absence of any direct-delivery `to`, `payload.kind`, and `timeout-seconds`. `HEARTBEAT.md` is the authoritative comparison checklist.
 
+Heartbeat is intentionally not the place to assume `config.patch` access. Config mutation remains a main-agent responsibility unless heartbeat support for those tools is explicitly confirmed and documented in [Agent Capabilities](agent-capabilities.md).
+
 Heartbeat also checks Notion connectivity and environment health. Production deployments should treat this as hourly infrastructure hygiene.
 
 This backstop remains part of the design because OpenClaw does not currently expose a post-delivery acknowledgment hook for `announce`. Without that hook, an announce-only cron would have to mark reminders `sent` or `missed` before the platform could prove delivery succeeded, which would break durable retry if the turn died in between.
@@ -82,6 +86,8 @@ OpenClaw provides `CronCreate` for scheduling recurring agent prompts. With `dur
 **The 7-day expiry problem:** Recurring cron jobs auto-expire after 7 days. The heartbeat catches this and re-registers the missing jobs. It also corrects spec drift caused by manual hotfixes or stale re-registration prompts by comparing the live job against the canonical `CronCreate` block and patching any mismatched registration fields. This is a platform constraint we work around rather than a feature we chose.
 
 **Current registration contract:** Both `reminder-check` and `pull-main` run as isolated Haiku sessions with `sessionTarget: isolated`, `model: litellm/claude-haiku-4-5`, `payload.kind: agentTurn`, and `timeout-seconds: 60`. This is a deliberate design choice that separates cheap query work from user-facing delivery. The previous architecture used `sessionTarget: main`, which loaded the full Opus agent context (~200k tokens) for routine script work. Moving to isolated Haiku cuts per-run cost by orders of magnitude. Reminder delivery is handled by the heartbeat (HEARTBEAT.md Check 1, every 60 min) and the main-session startup check (AGENTS.md step 5, on every user interaction). In the fully idle case, worst-case delivery latency is up to about 75 minutes: up to 15 minutes for `reminder-check` to write the handoff file, then up to another 60 minutes for heartbeat to deliver it if no user interaction happens first. The cron prompts end with `NO_REPLY` since they never produce user-facing output. Until OpenClaw exposes a post-delivery acknowledgment hook, this split flow is also the durability boundary that keeps failed reminder deliveries retryable.
+
+These isolated cron sessions are intentionally narrow. They are script runners, not a substitute for the main agent or heartbeat control paths. The detailed ownership split is documented in [Agent Capabilities](agent-capabilities.md).
 
 ### Production Timing Recommendation
 

--- a/setup/cron/pull-main.md
+++ b/setup/cron/pull-main.md
@@ -16,7 +16,7 @@ CronCreate:
   timeout-seconds: 60
 ```
 
-This job runs as an isolated Haiku session. It executes the pull script and reports status. Cron spec re-application after pulls is handled by the heartbeat drift correction (HEARTBEAT.md Check 2b), not by this job — an isolated session cannot reliably call CronList/CronUpdate.
+This job runs as an isolated Haiku maintenance session. It executes `scripts/pull-main.sh` and stays silent (`NO_REPLY`). Cron spec re-application after pulls is handled by the heartbeat drift correction (HEARTBEAT.md Check 2b), not by this job — an isolated session cannot reliably call CronList/CronUpdate.
 
 ## Prompt
 


### PR DESCRIPTION
Resolves #396

## Summary
- add `docs/agent-capabilities.md` as the source of truth for main-agent, heartbeat, and isolated-cron responsibilities and tool boundaries
- document that `openclaw.json` config mutation remains a main-agent responsibility unless heartbeat access is explicitly confirmed
- link the new contract doc from the docs index, architecture overview, and OpenClaw integration guide

## Test Plan
- shellcheck scripts/*.sh
- yamllint .github/workflows/*.yml
- bash scripts/check-doc-links.sh

Generated with Codex