### PR TITLE
devcontainer: pass host ~/.bashrc through via bind mount

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,14 +14,17 @@
   "postCreateCommand": "bash .devcontainer/post-create.sh && bash .githooks/install-hooks.sh",
   "postStartCommand": "bash .devcontainer/fix-dns-order.sh && sudo chown -R \"$(id -u):$(id -g)\" /workspaces 2>/dev/null || true",
   "mounts": [
-    "source=${localEnv:HOME}/.claude,target=${localEnv:HOME}/.claude,type=bind,readonly,consistency=cached"
+    "source=${localEnv:HOME}/.claude,target=${localEnv:HOME}/.claude,type=bind,readonly,consistency=cached",
+    "source=${localEnv:HOME}/.bashrc,target=${localEnv:HOME}/.bashrc,type=bind,readonly,consistency=cached",
+    "source=${localEnv:HOME}/code/util/profile,target=${localEnv:HOME}/code/util/profile,type=bind,readonly,consistency=cached"
   ],
   "remoteEnv": {
     "OPENAI_API_KEY": "fake-key",
     "TERM": "xterm-256color",
     "LANG": "en_US.UTF-8",
     "EDITOR": "nano",
-    "CLAUDE_HOST_CONFIG_DIR": "${localEnv:HOME}/.claude"
+    "CLAUDE_HOST_CONFIG_DIR": "${localEnv:HOME}/.claude",
+    "HOST_BASHRC": "${localEnv:HOME}/.bashrc"
   },
   "customizations": {
     "vscode": {

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -83,6 +83,24 @@ if [ -n "${CLAUDE_HOST_CONFIG_DIR:-}" ] \
   done
 fi
 
+# Append a source line to the container user's .bashrc so the host ~/.bashrc
+# (bind-mounted read-only at the same absolute path) is loaded on top of the
+# container's baseline. Idempotent: re-running post-create won't duplicate
+# the line. The host .bashrc's internal `source .../code/util/profile` line
+# resolves via the matching bind mount.
+if [ -n "${HOST_BASHRC:-}" ] \
+   && [ -f "$HOST_BASHRC" ] \
+   && [ "$HOST_BASHRC" != "$HOME/.bashrc" ]; then
+  bashrc_mark="# host-bashrc-passthrough: $HOST_BASHRC"
+  if [ ! -f "$HOME/.bashrc" ] || ! grep -qF "$bashrc_mark" "$HOME/.bashrc"; then
+    {
+      printf '\n%s\n' "$bashrc_mark"
+      printf '[ -r "%s" ] && . "%s"\n' "$HOST_BASHRC" "$HOST_BASHRC"
+    } >> "$HOME/.bashrc"
+    echo "Wired host .bashrc passthrough into $HOME/.bashrc"
+  fi
+fi
+
 # Helper to read pinned versions from the Dockerfile (single source of truth)
 DEVCONTAINER_DOCKERFILE="$SCRIPT_DIR/Dockerfile"
 get_arg_version() {


### PR DESCRIPTION
## Summary
Mirrors the `~/.claude` passthrough pattern (#398) for the developer's host `~/.bashrc` and the single external file it sources, `~/code/util/profile`.

- **Read-only bind mount** of both files at the **same absolute path** inside the container, so the `source "/.../code/util/profile"` line inside the host `.bashrc` resolves verbatim — no path rewriting, no marker, no copy.
- **Idempotent append** to the container user's `$HOME/.bashrc` that loads the host file **on top of** the container's baseline. The baseline PS1 / bash-completion / history config is preserved; host customizations layer on top.
- **Live sync:** edits to `~/.bashrc` or `~/code/util/profile` on the host are reflected in new shells inside the container on next source.

## Files changed
- `.devcontainer/devcontainer.json` — adds two `mounts` entries (`~/.bashrc`, `~/code/util/profile`) and a `HOST_BASHRC` entry under `remoteEnv`.
- `.devcontainer/post-create.sh` — adds a ~15-line idempotent block after the existing `CLAUDE_HOST_CONFIG_DIR` block that appends `[ -r "$HOST_BASHRC" ] && . "$HOST_BASHRC"` to `$HOME/.bashrc` guarded by a marker comment so rebuilds don't duplicate.

## CI safety
- On runners without `~/.bashrc` or `~/code/util/profile`, Docker materializes the bind sources as empty directories on the runner host (ephemeral no-op). The per-file `-f` checks in post-create fail and nothing is appended. Automated pipelines see **no** behavior change.
- No Dockerfile change → no devcontainer image cache invalidation.
- Changes confined to `.devcontainer/` scripts and JSON; no OpenClaw spec files touched — treat as infra-only.

## Test plan
- [x] `bash -n .devcontainer/post-create.sh`
- [x] `devcontainer.json` parses as JSONC with 3 mounts and `HOST_BASHRC` in `remoteEnv`
- [ ] Rebuild-from-scratch on a dev machine: verify `tail ~/.bashrc` inside the container ends with the `# host-bashrc-passthrough: ...` marker + the source line, and `bash -ic 'declare -f mov_to_gif'` prints the function body (proving `util/profile` loaded through the host `.bashrc`)
- [ ] Idempotency: re-run `devcontainer up` without `--remove-existing-container`; `grep -c host-bashrc-passthrough ~/.bashrc` inside the container must return `1`
- [ ] Simulate CI by temporarily renaming `~/.bashrc` on host; rebuild; confirm container's `.bashrc` doesn't contain the marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)