### PR TITLE
devcontainer: create bind-mount placeholders to prevent host pollution

### DIFF
--- a/.devcontainer/init-host-credentials.sh
+++ b/.devcontainer/init-host-credentials.sh
@@ -7,6 +7,20 @@
 set -e
 cd "$(dirname "$0")"
 
+# Ensure every devcontainer.json bind-mount source exists before Docker
+# tries to resolve it. Missing bind-mount sources are dangerous: Docker
+# silently materializes them as root-owned directories on the host (on
+# Linux) or errors out at container start (on macOS / Docker Desktop).
+# Creating user-owned placeholders here is a cheap no-op when the files
+# already exist, and guarantees the devcontainer can spin up on any
+# contributor's machine. post-create.sh uses `-s` (non-empty) guards
+# before wiring anything in, so empty placeholders are installed but
+# never activated.
+[ -e "$HOME/.claude"           ] || mkdir -p "$HOME/.claude"
+[ -e "$HOME/.bashrc"           ] || touch    "$HOME/.bashrc"
+[ -d "$HOME/code/util"         ] || mkdir -p "$HOME/code/util"
+[ -e "$HOME/code/util/profile" ] || touch    "$HOME/code/util/profile"
+
 # GitHub CLI token
 gh auth token > .gh-token 2>/dev/null || true
 

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -87,9 +87,11 @@ fi
 # (bind-mounted read-only at the same absolute path) is loaded on top of the
 # container's baseline. Idempotent: re-running post-create won't duplicate
 # the line. The host .bashrc's internal `source .../code/util/profile` line
-# resolves via the matching bind mount.
+# resolves via the matching bind mount. Uses `-s` (non-empty) rather than
+# `-f` so an empty placeholder created by init-host-credentials.sh (for
+# contributors who don't have the host file) is a silent no-op.
 if [ -n "${HOST_BASHRC:-}" ] \
-   && [ -f "$HOST_BASHRC" ] \
+   && [ -s "$HOST_BASHRC" ] \
    && [ "$HOST_BASHRC" != "$HOME/.bashrc" ]; then
   bashrc_mark="# host-bashrc-passthrough: $HOST_BASHRC"
   if [ ! -f "$HOME/.bashrc" ] || ! grep -qF "$bashrc_mark" "$HOME/.bashrc"; then


### PR DESCRIPTION
## Summary
Fixes a latent host-pollution foot-gun introduced by the recent `~/.claude` and `~/.bashrc` passthrough PRs. Reported by the Codex review agent on NickBorgers/home-automation#963.

## The bug
`devcontainer.json` declares bind mounts with `source=${localEnv:HOME}/.claude`, `${localEnv:HOME}/.bashrc`, and `${localEnv:HOME}/code/util/profile`. When any of these source paths **don't exist on the contributor's host**, Docker's behavior is platform-dependent and bad:

- **Linux / Docker Engine:** silently materializes the missing source as an **empty root-owned directory** on the host. A contributor who never had `~/.bashrc` now has a root-owned directory at that path, and can no longer `touch ~/.bashrc` without first running `sudo rm -rf ~/.bashrc`. Same for `~/code/util/profile` — which additionally creates a `~/code/util/` sibling repo directory the contributor never cloned.
- **macOS / Docker Desktop:** the devcontainer fails to start entirely with an `invalid mount config` error. The contributor can't even enter the environment.

I verified the Linux case locally:

```
$ docker run --rm -v /tmp/nonexistent:/container/inside alpine ls -la /container/inside
(created /tmp/nonexistent as drwxr-xr-x root root)
```

## The fix
Two small changes, both in `.devcontainer/`:

1. **`init-host-credentials.sh`** (runs on the host via `initializeCommand`, before Docker resolves mounts) — ensure every bind-mount source exists as a user-owned empty placeholder if it's missing:

   ```bash
   [ -e "$HOME/.claude"           ] || mkdir -p "$HOME/.claude"
   [ -e "$HOME/.bashrc"           ] || touch    "$HOME/.bashrc"
   [ -d "$HOME/code/util"         ] || mkdir -p "$HOME/code/util"
   [ -e "$HOME/code/util/profile" ] || touch    "$HOME/code/util/profile"
   ```

2. **`post-create.sh`** — tighten the `HOST_BASHRC` guard from `-f` (exists as file) to `-s` (non-empty file) so an empty placeholder is a silent no-op instead of wiring a source line pointing at nothing. The `CLAUDE_HOST_CONFIG_DIR` loop already uses per-item `-e` checks, so an empty `~/.claude` placeholder naturally results in no symlinks.

## Trade-off
Contributors who don't have `~/.bashrc` or `~/code/util/profile` will find user-owned empty placeholder files at those paths after the first `devcontainer up`. The `.bashrc` case is a near-no-op (most Unix users already have one). The `util/profile` case does materialize a file outside this repo — mild, but strictly less invasive than Docker creating a root-owned directory there. Contributors can `rm` them if unwanted.

## CI impact
On CI runners that already didn't have these files, Docker was previously creating root-owned directories at job-time. The fix means CI runners now get user-owned empty files instead. No behavior change in the container (post-create still no-ops). Self-hosted runners (home-automation) benefit the most since their state persists across jobs — the fix stops accumulating root-owned directories over time.

## Test plan
- [x] `bash -n .devcontainer/init-host-credentials.sh`
- [x] `bash -n .devcontainer/post-create.sh`
- [ ] Rebuild-from-scratch on a dev machine that *does* have all three files: confirm existing files untouched and the passthrough still works
- [ ] Rebuild on a scratch machine without `~/code/util/profile`: confirm empty placeholder is created and container starts cleanly
- [ ] Inspect container `/home/vscode/.bashrc`: passthrough marker should NOT be present when host `.bashrc` is empty or missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)