### PR TITLE
review-pipeline-v2: stop re-review on GO, bound NO-GO retries at 2

### DIFF
--- a/.github/workflows/review-entry.yml
+++ b/.github/workflows/review-entry.yml
@@ -138,6 +138,7 @@ jobs:
       head_ref: ${{ steps.resolve.outputs.head_ref }}
       head_repo: ${{ steps.resolve.outputs.head_repo }}
       base_sha: ${{ steps.resolve.outputs.base_sha }}
+      terminal_verdict: ${{ steps.terminal.outputs.terminal_verdict }}
     steps:
       - name: Checkout main (for composite actions)
         uses: actions/checkout@v4
@@ -192,9 +193,47 @@ jobs:
             echo "base_sha=$BASE_SHA"
           } >> "$GITHUB_OUTPUT"
 
+      # Check whether the reviewed SHA has already been cleared GO by a
+      # prior cycle of the v2 pipeline. The finalize job writes the
+      # `All Required Agent Reviews` commit status with state=success
+      # on GO and state=failure on NO-GO (see review-finalize.yml:76-95).
+      # A prior-cycle GO on this exact commit means the pipeline already
+      # cleared it; re-running would only rediscover cross-doc drift the
+      # last cycle's fixer introduced. NO-GO deliberately does NOT
+      # short-circuit — we want the fixer to get additional attempts on
+      # stubborn blockers, bounded by the MAX cycle cap in
+      # review-pipeline.yml. This asymmetry is the point: "stop on
+      # success, keep trying on failure."
+      #
+      # Only applies to `pull_request` events. `issue_comment` (i.e.
+      # `/review`) is the human override and must always force a
+      # fresh cycle — see §1.13 in docs/agentic-pipeline-learnings.md.
+      - name: Check for prior GO verdict on reviewed SHA
+        id: terminal
+        if: |
+          steps.resolve.outputs.reviewed_sha != '' &&
+          github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ steps.resolve.outputs.reviewed_sha }}
+        run: |
+          set -euo pipefail
+          PRIOR=$(gh api "repos/${REPO}/commits/${SHA}/statuses" \
+            --jq '[.[] | select(.context == "All Required Agent Reviews" and .state == "success")] | first | .description // empty')
+          if [ -n "$PRIOR" ]; then
+            echo "review-entry: SHA ${SHA} already cleared GO by a prior cycle (${PRIOR}); skipping re-review (human override: post /review)"
+            echo "terminal_verdict=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "review-entry: SHA ${SHA} has no prior GO verdict; proceeding"
+            echo "terminal_verdict=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: SHA-keyed dedup claim
         id: dedup
-        if: steps.resolve.outputs.reviewed_sha != ''
+        if: |
+          steps.resolve.outputs.reviewed_sha != '' &&
+          steps.terminal.outputs.terminal_verdict != 'true'
         uses: ./.github/actions/review-dedup
         with:
           sha: ${{ steps.resolve.outputs.reviewed_sha }}
@@ -210,7 +249,11 @@ jobs:
   pipeline:
     name: Run review pipeline v2
     needs: [authorize, resolve]
-    if: vars.REVIEW_PIPELINE_V2 == 'true' && needs.authorize.outputs.authorized == 'true' && needs.resolve.outputs.should_run == 'true'
+    if: |
+      vars.REVIEW_PIPELINE_V2 == 'true' &&
+      needs.authorize.outputs.authorized == 'true' &&
+      needs.resolve.outputs.should_run == 'true' &&
+      needs.resolve.outputs.terminal_verdict != 'true'
     uses: ./.github/workflows/review-pipeline.yml
     with:
       pr_number: ${{ needs.resolve.outputs.pr_number }}

--- a/.github/workflows/review-pipeline.yml
+++ b/.github/workflows/review-pipeline.yml
@@ -91,7 +91,12 @@ jobs:
         id: cap
         env:
           NEXT: ${{ steps.cycle.outputs.cycle }}
-          MAX: '3'
+          # NO-GO retries only: MAX bounds the number of cycles the
+          # fixer gets on a PR whose cycle 1 did not converge. GO
+          # cycles are short-circuited in review-entry.yml after
+          # cycle 1 regardless of MAX — see §1.13 in
+          # docs/agentic-pipeline-learnings.md.
+          MAX: '2'
         run: |
           set -euo pipefail
           if [ "$NEXT" -gt "$MAX" ]; then

--- a/docs/agentic-pipeline-learnings.md
+++ b/docs/agentic-pipeline-learnings.md
@@ -77,6 +77,18 @@ Two meta-lessons span everything below:
 **Before:** Reviewer prompt markdown under `.github/scripts/review/prompts/*.md` was classified as config-only in v2, which would have skipped security, psych, and prompt review and no reviewer called it out.
 **Evidence:** #343, #349
 
+### 1.13 Stop on GO, keep retrying on NO-GO: asymmetric cycle control
+**Why:** Rule 1.4 claims "re-review-loops-from-autofix are impossible by construction" because the fixer claims its output SHA on `review/pipeline` before pushing, so the `synchronize` event hits a `pending` dedup state and exits. That's true only when the synchronize handler runs concurrently with the fixer. In practice, the `review-entry-v2-<head_ref>` concurrency group on `review-entry.yml` serializes the synchronize event behind the still-running cycle. When cycle N's `cleanup-claim` advances the post-fix SHA from `pending` → `success`, the queued cycle N+1 entry passes dedup (which only refuses `pending`) and runs a fresh review on the exact SHA cycle N already finalized. On drift-sensitive PRs (anything touching spec-critical Markdown), cycle N+1's reviewers legitimately find new cross-doc drift introduced by cycle N's fixer — see PR NickBorgersProbably/hide-my-list#397, which burned 3 full cycles with monotonically diminishing blocker counts (6 → 3 → 1).
+
+The fix is split by verdict:
+
+- **GO cycle is terminal.** `review-entry.yml` refuses to dispatch the pipeline when the reviewed SHA already carries an `All Required Agent Reviews = success` commit status (written by `review-finalize.yml:76-95` on GO only). GO means the pipeline is done with this SHA; a fresh cycle would only rediscover drift introduced by the prior fixer. `/review` comments bypass the check (`issue_comment` events are event-gated out) so humans can force a re-review manually.
+- **NO-GO cycle retries.** The `All Required Agent Reviews` status on NO-GO is `failure`, which does not match the GO-only short-circuit, so the `synchronize` event from the fixer's push continues into a fresh cycle. This is deliberate: NO-GO means "fixer could not address all blockers this round," and giving the fixer another attempt sometimes knocks stubborn drift out. The retry is bounded by `MAX` in `review-pipeline.yml` (currently `2`, i.e. up to one NO-GO retry). `cap-exhausted` on NO-GO correctly finalizes the PR as NO-GO with `needs-human-review`; a cycle 2 GO cleanly replaces the cycle 1 NO-GO label.
+
+Why **not** just lower `MAX` to `1`: `cap-exhausted` hard-codes `verdict='NO-GO'` (`review-pipeline.yml:131`). With `MAX=1`, every cycle-1 GO would be followed by a synchronize event firing cycle 2, which caps immediately and stamps NO-GO on the current HEAD — clobbering the cycle 1 GO. Safely lowering `MAX` to 1 would require also rewriting `cap-exhausted` to inherit the parent SHA's verdict, which duplicates what the GO short-circuit already does more cheaply at the entry layer. And `MAX=1` would also remove the NO-GO retry capability described above.
+**Before:** PR #397 posted three full Merge Decisions and ~15 reviewer comments for a single docs-only PR that was already GO at cycle 1. Pipeline cost and reviewer signal-to-noise both suffered.
+**Evidence:** #397
+
 ---
 
 ## 2. CI Runtime Infrastructure


### PR DESCRIPTION
## Summary

- **GO cycle is terminal.** `review-entry.yml` now refuses to dispatch the pipeline when the reviewed SHA already carries `All Required Agent Reviews = success` from a prior cycle. `/review` comments bypass the check as the human override.
- **NO-GO still retries**, bounded by `MAX` in `review-pipeline.yml` (now `2`, down from `3`). Gives the fixer one additional attempt on stubborn blockers.
- New §1.13 in `docs/agentic-pipeline-learnings.md` documents the loop mechanism, the correction to §1.4's "impossible by construction" claim, and why `MAX=1` was rejected.

## Why

PR #397 burned 3 review cycles with monotonically diminishing blocker counts (6 → 3 → 1), producing ~15 reviewer comments and 3 Merge Decisions for a docs-only PR that was already GO at cycle 1. Root cause: each fixer push creates a new SHA, the `synchronize` event is queued behind cycle N on the `review-entry-v2-<head_ref>` concurrency group, and by the time it runs dedup the `review/pipeline` claim has been advanced from `pending` to `success` by `cleanup-claim`. Dedup only refuses `pending`, so cycle N+1 starts fresh on the exact SHA cycle N finalized. On drift-sensitive PRs, cycle N+1 reviewers legitimately find new cross-doc drift introduced by cycle N's fixer.

§1.4 claims "re-review-loops-from-autofix are impossible by construction" — that holds only when the synchronize handler runs concurrently with the fixer, not when it's queued behind the concurrency group.

## Why not just lower MAX to 1

`cap-exhausted` hard-codes `verdict: 'NO-GO'` (`review-pipeline.yml:131`). With `MAX=1`, every cycle-1 GO would be followed by a spurious cycle 2 that caps immediately and stamps NO-GO on the current HEAD, clobbering the cycle 1 GO. And `MAX=1` would remove NO-GO retries entirely. Safely lowering `MAX` to 1 would require also rewriting `cap-exhausted` to inherit the parent SHA's verdict, which duplicates what the GO short-circuit already does more cheaply at the entry layer.

## Test plan

- [ ] Open a test PR that trips blocking docs-as-spec drift; confirm cycle 1 runs, fixer pushes, judge GO, finalize posts Merge Decision.
- [ ] Confirm the synchronize event for the fixer's commit enters `review-entry`, logs `review-entry: SHA ... already cleared GO by a prior cycle (cycle 1); skipping re-review`, and the `pipeline` job is skipped. PR ends with 1 Merge Decision comment instead of 3.
- [ ] Post `/review` on the same terminal SHA; confirm full fresh cycle runs (issue_comment bypass).
- [ ] Push a manual commit on top (non-fixer); confirm the new SHA has no prior status and runs cycle 1 normally.
- [ ] Force a cycle 1 NO-GO scenario (unaddressed blocker beyond fixer scope); confirm cycle 2 runs, and cycle 3 caps into NO-GO with `needs-human-review` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)