### PR TITLE
run-devcontainer: strip mounts alongside initializeCommand

### DIFF
--- a/.github/actions/run-devcontainer/action.yml
+++ b/.github/actions/run-devcontainer/action.yml
@@ -90,6 +90,16 @@ runs:
 
         config.pop("build", None)
         config.pop("initializeCommand", None)
+        # mounts in devcontainer.json (e.g. host ~/.claude, ~/.bashrc,
+        # ~/code/util/profile passthroughs for dev machines) depend on
+        # initializeCommand to create placeholder sources when the host
+        # files are missing. Since we strip initializeCommand above, any
+        # mount whose source doesn't exist on the runner would cause
+        # `docker run --mount type=bind ...` to fail with "bind source
+        # path does not exist". Strip mounts too — this CI path never
+        # benefits from host passthroughs anyway (GitHub-hosted runners
+        # don't carry a developer's ~/.claude etc.).
+        config.pop("mounts", None)
 
         config["image"] = image
 


### PR DESCRIPTION
## Summary
Fixes a regression introduced by the `~/.bashrc` / `~/code/util/profile` bind-mount passthrough (#399) combined with the custom `run-devcontainer` composite action stripping `initializeCommand`.

## Observed failure
[Codex Agent run #24287495547 / resolve-issue job](https://github.com/NickBorgersProbably/hide-my-list/actions/runs/24287495547/job/70919263292), on `main` at commit `1744d8d` — after #398/#399/#400 were all merged:

```
docker: Error response from daemon: invalid mount config for type "bind":
bind source path does not exist: /home/runner/.claude
```

## Root cause
`.github/actions/run-devcontainer/action.yml` writes an override `devcontainer.json` that strips `build` and `initializeCommand` and swaps in a pre-built image. That's intentional — CI doesn't need host-credential staging, and the composite action is designed to avoid a `devcontainers/ci` post-step cleanup crash.

But when `~/.claude`, `~/.bashrc`, and `~/code/util/profile` bind mounts were added to `devcontainer.json` in #398 and #399, those mount entries are **kept** in the override config. The source paths are guaranteed by `initializeCommand` (which creates user-owned placeholders via `init-host-credentials.sh` for contributors / CI runners that don't have the real files on disk). Since the composite action strips `initializeCommand`, `init-host-credentials.sh` never runs on the runner, the host paths don't get materialized, and Docker errors out trying to bind a non-existent source.

This wasn't caught by the earlier `.claude` audit because `devcontainers/ci@v0.3` (used by the PR Tests workflow) strips `mounts` from `devcontainer.json` before launching the container — so that code path is immune. The custom composite action is a **different** CI path that the audit didn't cover.

## Fix
Pop `mounts` alongside `initializeCommand` in the override-config builder (`.github/actions/run-devcontainer/action.yml:92`). Three-line change plus comment explaining the rationale.

## Why stripping mounts is safe here
Those three bind mounts (`~/.claude`, `~/.bashrc`, `~/code/util/profile`) are developer-machine passthroughs for carrying personal Claude Code settings, shell aliases, and docker-wrapper functions into the devcontainer. **None of them have useful content on a GitHub-hosted runner** — the runner doesn't carry any developer's personal config. Removing the mounts in this CI path is strictly behavior-neutral for the container and fixes the startup error.

## Scope
This composite action is used by four workflows, all of which benefit from the fix:
- `codex.yml` (Codex Agent — the failing one)
- `codex-code-review.yml`
- `codex-diagnose-workflow-failure.yml`
- `review-coverage-evaluator.yml`

## Test plan
- [x] YAML validates
- [ ] Merge and confirm the next Codex Agent run (triggered by an open issue) successfully starts the devcontainer instead of failing on the bind-mount config
- [ ] Confirm `codex-code-review`, `codex-diagnose-workflow-failure`, and `review-coverage-evaluator` runs continue to succeed (they were already passing because their invocations happened to not exercise the bind-mount path until #398/#399 merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)