### PR TITLE
Add CI image bootstrap fallback for agent workflows

### DIFF
--- a/.github/actions/review-codex-run/action.yml
+++ b/.github/actions/review-codex-run/action.yml
@@ -95,10 +95,10 @@ runs:
         set -euo pipefail
         printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 
-    - name: Pull CI image
+    - name: Ensure CI image
       if: inputs.pull == 'true'
       shell: bash
-      run: docker pull "${{ inputs.image }}"
+      run: scripts/ensure-ci-image.sh "${{ inputs.image }}"
 
     - name: Stage env file
       id: stage-env

--- a/.github/ci/README.md
+++ b/.github/ci/README.md
@@ -44,7 +44,12 @@ shells out to `docker run` against the CI image. The other agent
 workflows (`codex`, `codex-diagnose-workflow-failure`,
 `review-coverage-evaluator`) invoke `docker run` inline.
 
-All of them follow the same topology rules learned from the
+All of them call `scripts/ensure-ci-image.sh` before launch. The helper
+tries `docker pull` first and, if the configured tag is missing in GHCR
+or otherwise unavailable, rebuilds the CI image locally from
+`.github/ci/Dockerfile` using the pinned versions in `versions.env`.
+
+They then follow the same topology rules learned from the
 home-automation refactor:
 
 - **Mount sources must be host-visible**. The runner is a container on

--- a/.github/workflows/codex-diagnose-workflow-failure.yml
+++ b/.github/workflows/codex-diagnose-workflow-failure.yml
@@ -126,8 +126,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pull CI image
-        run: docker pull "${CI_IMAGE}"
+      - name: Ensure CI image
+        run: scripts/ensure-ci-image.sh "${CI_IMAGE}"
 
       - name: Diagnose failure with Codex
         env:

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -264,8 +264,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pull CI image
-        run: docker pull "${CI_IMAGE}"
+      - name: Ensure CI image
+        run: scripts/ensure-ci-image.sh "${CI_IMAGE}"
 
       # Note: GH_TOKEN uses WORKFLOW_PAT because PRs created with GITHUB_TOKEN don't trigger workflows
       - name: Run Codex
@@ -416,9 +416,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pull CI image
+      - name: Ensure CI image
         if: steps.check-existing.outputs.skip != 'true'
-        run: docker pull "${CI_IMAGE}"
+        run: scripts/ensure-ci-image.sh "${CI_IMAGE}"
 
       # Note: GH_TOKEN uses WORKFLOW_PAT because PRs created with GITHUB_TOKEN don't trigger workflows
       - name: Resolve issue with Codex

--- a/.github/workflows/review-coverage-evaluator.yml
+++ b/.github/workflows/review-coverage-evaluator.yml
@@ -69,8 +69,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pull CI image
-        run: docker pull "${CI_IMAGE}"
+      - name: Ensure CI image
+        run: scripts/ensure-ci-image.sh "${CI_IMAGE}"
 
       - name: Evaluate review coverage with Codex
         env:

--- a/scripts/ensure-ci-image.sh
+++ b/scripts/ensure-ci-image.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <ci-image-ref>" >&2
+  exit 64
+fi
+
+CI_IMAGE="$1"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+VERSIONS_FILE="${REPO_ROOT}/.github/ci/versions.env"
+DOCKERFILE="${REPO_ROOT}/.github/ci/Dockerfile"
+
+if [ ! -f "$VERSIONS_FILE" ]; then
+  echo "ERROR: missing versions file at ${VERSIONS_FILE}" >&2
+  exit 1
+fi
+
+if [ ! -f "$DOCKERFILE" ]; then
+  echo "ERROR: missing CI Dockerfile at ${DOCKERFILE}" >&2
+  exit 1
+fi
+
+if docker pull "$CI_IMAGE"; then
+  echo "Using published CI image: ${CI_IMAGE}"
+  exit 0
+fi
+
+echo "::warning::Unable to pull ${CI_IMAGE}; building a local fallback from .github/ci/Dockerfile"
+
+set -a
+# shellcheck disable=SC1090
+source <(grep -Ev '^[[:space:]]*(#|$)' "$VERSIONS_FILE")
+set +a
+
+docker build \
+  --file "$DOCKERFILE" \
+  --tag "$CI_IMAGE" \
+  --build-arg "CLAUDE_CODE_VERSION=${CLAUDE_CODE_VERSION}" \
+  --build-arg "CODEX_CLI_VERSION=${CODEX_CLI_VERSION}" \
+  --build-arg "ACTIONLINT_VERSION=${ACTIONLINT_VERSION}" \
+  --build-arg "NODE_MAJOR=${NODE_MAJOR}" \
+  "$REPO_ROOT"
+
+echo "Built local fallback CI image: ${CI_IMAGE}"


### PR DESCRIPTION
Resolves #406

## Summary
- add `scripts/ensure-ci-image.sh` to pull the configured CI image and rebuild it locally from `.github/ci/Dockerfile` when the GHCR tag is missing
- switch Codex agent, workflow-diagnosis, review-coverage, and shared review runner paths to use the bootstrap helper instead of failing on a raw `docker pull`
- document the fallback behavior in `.github/ci/README.md`

## Test Plan
- `shellcheck scripts/*.sh`
- `yamllint .github/workflows/*.yml`
- `scripts/validate-workflow-refs.sh`
- `scripts/check-doc-links.sh`

Generated with Codex