### PR TITLE
Route reminder delivery explicitly to Signal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ You are **hide-my-list**, an ADHD-informed task manager. The conversation *is* t
 2. Read `USER.md` — who you're helping
 3. Read `state.json` — current conversation state, active task, streak
 4. Read `memory/YYYY-MM-DD.md` (today + yesterday) for recent context
-5. Check for the reminder handoff file (default: `.reminder-signal`, overridable via `REMINDER_SIGNAL_FILE` in `.env`) — if it exists, read it and deliver each reminder to the user:
+5. Check for the reminder handoff file (default: `.reminder-signal`, overridable via `REMINDER_SIGNAL_FILE` in `.env`) — if it exists, read it and deliver each reminder to the user with the OpenClaw `message` tool targeting Signal (`action: send`, `channel: signal`) instead of replying into the current session:
    - Approximate reminders (next eligible poll, before missed threshold): casual delivery ("Hey, time to [task]")
    - Missed reminders (>15 min late): note the delay but don't shame ("This was due a bit ago — [task]")
    - After delivery, run `scripts/notion-cli.sh complete-reminder PAGE_ID sent|missed` for each item, then delete the handoff file

--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -8,7 +8,7 @@
   HANDOFF_FILE="$(bash -lc 'SCRIPT_DIR=$(cd "$(dirname scripts/check-reminders.sh)" && pwd); ROOT_DIR=$(cd "$SCRIPT_DIR/.." && pwd); source "$SCRIPT_DIR/load-env.sh" REMINDER_SIGNAL_FILE?; SIGNAL_BASENAME=${REMINDER_SIGNAL_FILE:-.reminder-signal}; case "$SIGNAL_BASENAME" in ""|"."|".."|*/*) echo "invalid REMINDER_SIGNAL_FILE" >&2; exit 1 ;; esac; printf "%s\n" "$ROOT_DIR/$SIGNAL_BASENAME"')"
   ```
 - This file is the reminder handoff written by `scripts/check-reminders.sh`
-- If `HANDOFF_FILE` still exists when heartbeat runs, treat it as undelivered reminder work: read it, send each reminder to the user, run `scripts/notion-cli.sh complete-reminder PAGE_ID sent|missed` based on the file, then delete that handoff file
+- If `HANDOFF_FILE` still exists when heartbeat runs, treat it as undelivered reminder work: read it, send each reminder with the OpenClaw `message` tool targeting Signal (`action: send`, `channel: signal`) instead of relying on heartbeat reply routing, run `scripts/notion-cli.sh complete-reminder PAGE_ID sent|missed` based on the file, then delete that handoff file
 - This is the hourly reminder-delivery backstop in the current design. The isolated `reminder-check` cron only writes the handoff file — it does not deliver. Delivery happens here (every 60 min) and opportunistically via the AGENTS.md startup check (on every user interaction).
 
 ### 2. Cron Job Health

--- a/docs/agent-capabilities.md
+++ b/docs/agent-capabilities.md
@@ -63,6 +63,7 @@ The heartbeat is a short built-in OpenClaw session configured in `openclaw.json`
 The heartbeat session has a narrower confirmed contract:
 
 - `exec` and `read` for script execution and repo inspection
+- `message` for explicit reminder delivery to Signal from `HEARTBEAT.md` Check 1
 - CronList, CronCreate, CronUpdate, and CronDelete for durable cron inspection, re-registration, drift correction, and stale-job cleanup required by `HEARTBEAT.md`
 
 ### Do not assume
@@ -70,7 +71,7 @@ The heartbeat session has a narrower confirmed contract:
 The repo should currently treat these capabilities as unconfirmed for heartbeat sessions:
 
 - `config.get`, `config.patch`, `config.schema.lookup`
-- proactive `message` tooling outside normal heartbeat output routing
+- broader proactive `message` workflows beyond explicit reminder delivery to Signal
 - gateway lifecycle tools
 - general repo-edit/write capabilities as part of routine heartbeat behavior
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -233,7 +233,7 @@ sequenceDiagram
 5. Reminder delivery happens through two separate mechanisms:
    - **AGENTS.md step 5** (opportunistic): every time the user starts a conversation, the main session checks for the handoff file and delivers immediately.
    - **HEARTBEAT.md Check 1** (hourly backstop): the heartbeat reads the handoff file every 60 minutes and delivers any stranded reminders.
-   Both delivery paths use `scripts/notion-cli.sh complete-reminder PAGE_ID sent|missed` to atomically set `Status` to `Completed`, `Reminder Status` to `sent` or `missed`, and `Completed At`.
+   Both delivery paths send the reminder with the OpenClaw `message` tool targeting `channel: signal`, then use `scripts/notion-cli.sh complete-reminder PAGE_ID sent|missed` to atomically set `Status` to `Completed`, `Reminder Status` to `sent` or `missed`, and `Completed At`.
 6. Reminders more than 15 minutes past due are flagged as `missed` but still delivered with a note.
 7. The cron job only fires when the agent is idle — it won't interrupt the user mid-task, which is better for ADHD focus.
 

--- a/docs/notion-schema.md
+++ b/docs/notion-schema.md
@@ -482,8 +482,8 @@ Tracks whether a scheduled reminder has been delivered.
 | Value | Description | Trigger |
 |-------|-------------|---------|
 | `pending` | Not yet delivered | Default on creation |
-| `sent` | Successfully delivered to user | Delivering session confirms delivery after the handoff-file reminder flow surfaces the reminder |
-| `missed` | Delivered after being more than 15 minutes late | Delivering session confirms late delivery using the scheduler's missed flag |
+| `sent` | Successfully delivered to user | Delivering session confirms delivery after sending the reminder through the OpenClaw `message` tool on `channel: signal` |
+| `missed` | Delivered after being more than 15 minutes late | Delivering session confirms late delivery after sending through the OpenClaw `message` tool on `channel: signal` using the scheduler's missed flag |
 
 **Note:** When a reminder is marked `sent` or `missed`, the task's main `Status` is also updated to `Completed` since the reminder action (notifying the user) is done.
 

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -40,7 +40,7 @@ OpenClaw's heartbeat is a built-in periodic trigger configured in `openclaw.json
 }
 ```
 
-Every 60 minutes, OpenClaw creates a short agent session that reads `HEARTBEAT.md` and executes the checks defined there. It uses a lighter model (Sonnet instead of Opus) since these are routine operational tasks. The `target` field controls where non-`HEARTBEAT_OK` output (such as reminder delivery) is routed; without it, `target` defaults to `"none"` and all heartbeat output is silently discarded ([openclaw/openclaw#29215](https://github.com/openclaw/openclaw/issues/29215)).
+Every 60 minutes, OpenClaw creates a short agent session that reads `HEARTBEAT.md` and executes the checks defined there. It uses a lighter model (Sonnet instead of Opus) since these are routine operational tasks. The `target` field controls where non-`HEARTBEAT_OK` heartbeat output is routed; without it, `target` defaults to `"none"` and all plain heartbeat output is silently discarded ([openclaw/openclaw#29215](https://github.com/openclaw/openclaw/issues/29215)). Reminder delivery itself should use the OpenClaw `message` tool with explicit Signal routing instead of relying on the heartbeat session's default output target.
 
 **Our usage:** The heartbeat serves two roles:
 1. **Reminder-delivery backstop:** The isolated `reminder-check` cron only writes `.reminder-signal` — it does not deliver to the user. Heartbeat Check 1 reads stranded signal files and delivers reminders every 60 minutes. (The AGENTS.md startup check provides faster opportunistic delivery when the user is active.)
@@ -123,7 +123,7 @@ The primary deployed surface today is Signal. OpenClaw handles:
 - Acknowledgment reactions
 - Session scoping (per-channel-peer)
 
-**Our role:** Zero for transport mechanics. We write conversational responses; OpenClaw delivers them. Interactive conversations use the normal main-agent routing path. Cron jobs run as isolated Haiku sessions (query-only, no user delivery). Reminder delivery reaches the user through the heartbeat and the main-session startup check.
+**Our role:** Zero for transport mechanics. We write conversational responses; OpenClaw delivers them. Interactive conversations use the normal main-agent routing path. Cron jobs run as isolated Haiku sessions (query-only, no user delivery). Reminder delivery reaches the user through the heartbeat and the main-session startup check, and both delivery paths should use the OpenClaw `message` tool with `channel: signal` instead of replying into whichever session is currently active.
 
 ## Model Routing (LiteLLM Proxy)
 

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -959,7 +959,7 @@ flowchart TD
 | Check-ins | Timer-based follow-ups | None (single delivery) |
 | Rejection | User can reject suggestion | N/A (delivered once) |
 
-Reminder delivery is separated from the cron query. The isolated `reminder-check` cron writes the handoff file and exits. Delivery happens through the heartbeat (HEARTBEAT.md Check 1, every 60 min) or the main-session startup check (AGENTS.md step 5, on every user interaction). If delivery fails, the handoff file is left in place for retry.
+Reminder delivery is separated from the cron query. The isolated `reminder-check` cron writes the handoff file and exits. Delivery happens through the heartbeat (HEARTBEAT.md Check 1, every 60 min) or the main-session startup check (AGENTS.md step 5, on every user interaction). Both delivery paths should use the OpenClaw `message` tool with `action: send` and `channel: signal` so the reminder reaches Signal even if the current session is on another surface. If delivery fails, the handoff file is left in place for retry.
 
 ### Timezone Handling
 

--- a/docs/user-interactions.md
+++ b/docs/user-interactions.md
@@ -781,7 +781,7 @@ sequenceDiagram
     end
 ```
 
-The `reminder-check` cron runs as an isolated Haiku session — it is query-only and does not deliver reminders. Delivery happens through two paths: the main-session startup check (AGENTS.md step 5, on every user interaction) and the heartbeat (HEARTBEAT.md Check 1, every 60 min). If delivery fails, the handoff file is left in place for retry.
+The `reminder-check` cron runs as an isolated Haiku session — it is query-only and does not deliver reminders. Delivery happens through two paths: the main-session startup check (AGENTS.md step 5, on every user interaction) and the heartbeat (HEARTBEAT.md Check 1, every 60 min). Both paths should use the OpenClaw `message` tool with `action: send` and `channel: signal` so reminders always route to Signal instead of the current conversation. If delivery fails, the handoff file is left in place for retry.
 
 ### Reminder Delivery Messages
 

--- a/setup/cron/heartbeat-check.md
+++ b/setup/cron/heartbeat-check.md
@@ -12,7 +12,7 @@ The heartbeat is not a cron job we create — it's a built-in OpenClaw feature c
 }
 ```
 
-The `target` field is required for reminder delivery. Without it, OpenClaw defaults to `"none"` and silently discards all heartbeat output — including reminders. Set it to `"signal"` (or whichever channel your user communicates on) so that non-`HEARTBEAT_OK` output is routed to the user.
+The `target` field is still useful for routing non-`HEARTBEAT_OK` heartbeat output. Without it, OpenClaw defaults to `"none"` and silently discards plain heartbeat output. Reminder delivery itself should not rely on that default routing: `HEARTBEAT.md` should send reminders with the OpenClaw `message` tool targeting `channel: signal`.
 
 ## Behavior
 


### PR DESCRIPTION
Resolves #402

## Summary
- update the startup reminder handoff instructions in `AGENTS.md` to require the OpenClaw `message` tool with `channel: signal`
- update the heartbeat reminder-delivery instructions and supporting architecture docs to stop relying on session-default reply routing
- document the narrowed heartbeat `message` capability so the operational contract matches the reminder flow

## Test Plan
- `shellcheck scripts/*.sh`
- `yamllint .github/workflows/*.yml`
- manually verify the updated docs consistently require explicit Signal routing for reminder delivery and that referenced relative doc links still resolve

Generated with Codex