### PR TITLE
fix(review-codex-run): chmod 777 .review-output bind-mount target

### DIFF
--- a/.github/actions/review-codex-run/action.yml
+++ b/.github/actions/review-codex-run/action.yml
@@ -84,7 +84,19 @@ runs:
         # container (via -v $GITHUB_WORKSPACE:/workspace), files written
         # there from inside the container are visible to subsequent host
         # steps for upload-artifact and schema validation.
-        mkdir -p "${GITHUB_WORKSPACE}/${WORKSPACE_FOLDER}/.review-output"
+        #
+        # chmod 777: the runner user (typically UID 1001) creates this
+        # directory, but the container writes to it as the `ci` user
+        # (UID 1000). Without world-write, every reviewer fails with
+        # `PermissionError: [Errno 13] Permission denied:
+        # '.review-output/<role>-result.json'` — see the docs reviewer
+        # log on https://github.com/NickBorgersProbably/hide-my-list/actions/runs/24295328532.
+        # Agents improvise around the permission denial with sudo,
+        # which works on the image (NOPASSWD) but compounds shell
+        # escaping issues and still fails the verify step.
+        OUTPUT_DIR="${GITHUB_WORKSPACE}/${WORKSPACE_FOLDER}/.review-output"
+        mkdir -p "$OUTPUT_DIR"
+        chmod 777 "$OUTPUT_DIR"
 
     - name: Log in to GHCR
       shell: bash


### PR DESCRIPTION
## Summary

All 5 reviewers on #408 failed with:

\`\`\`
PermissionError: [Errno 13] Permission denied:
  '.review-output/<role>-result.json'
\`\`\`

Run: https://github.com/NickBorgersProbably/hide-my-list/actions/runs/24295328532

## Root cause

Same UID-mismatch we fought through on the home-automation CI split:

- The runner on dockergeneric runs as UID 1001
- \`.github/ci/Dockerfile\` creates a \`ci\` user at UID 1000 and runs the container as that user
- \`review-codex-run\` pre-creates \`\${WORKSPACE_FOLDER}/.review-output\` on the host (owned by UID 1001)
- The workspace is bind-mounted into the container
- Codex tries to \`open('.review-output/docs-result.json', 'w')\` as UID 1000 → \`Permission denied\`

The agents improvise around the denial with \`sudo install\` (the image grants NOPASSWD sudo), but the workaround compounds shell escaping issues in nested heredocs and still fails the downstream verify step.

## Fix

One line: \`chmod 777\` after \`mkdir -p\`. Same pattern \`run-ci-agent\` already uses for output-staging dirs in \`home-automation\` and \`home-automation-plus-security\`, just adapted to the workspace-direct-write topology that \`review-codex-run\` uses.

## Test plan

- [ ] Merge this and re-trigger #408's review pipeline. All 5 reviewers should complete without PermissionError and without sudo-install workarounds.
- [ ] Verify \`.review-output/<role>-result.json\` is created directly by the agent (no sudo fallback).
- [ ] Confirm the judge reads all 5 reviewer artifacts and produces a GO/NO-GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)