### PR TITLE
fix(review-fixer): commit fixer changes on host, not in container

### DIFF
--- a/.github/actions/review-codex-run/action.yml
+++ b/.github/actions/review-codex-run/action.yml
@@ -173,11 +173,24 @@ runs:
         # workspace is bind-mounted from host → runner already (via
         # /tmp/runner-work), so files land at a path the subsequent
         # validate / publish / upload-artifact steps can read.
+        # GIT_CONFIG_COUNT / GIT_CONFIG_KEY_* / GIT_CONFIG_VALUE_*:
+        # tell git inside the container to trust /workspace as a
+        # safe.directory without needing to write any config files.
+        # The bind-mounted `.git/` is owned by the runner user
+        # (UID 1001) while the container runs as `ci` (UID 1000);
+        # without this env, every `git status` / `git diff` / etc.
+        # inside the container errors with "detected dubious
+        # ownership" and the agent wastes turns improvising a
+        # workaround. Env-config is read-only and ephemeral, so
+        # it leaves no trace in the workspace.
         docker run --rm \
           --network host \
           --workdir /workspace \
           -v "$WORKSPACE_HOST:/workspace" \
           --env-file "$CI_AGENT_ENV_FILE" \
+          -e GIT_CONFIG_COUNT=1 \
+          -e GIT_CONFIG_KEY_0=safe.directory \
+          -e GIT_CONFIG_VALUE_0=/workspace \
           "$CI_AGENT_IMAGE" \
           -lc '
             set -euo pipefail

--- a/.github/scripts/review/prompts/fixer.md
+++ b/.github/scripts/review/prompts/fixer.md
@@ -23,19 +23,28 @@ The reviewers and the judge are read-only.
    typecheck, and test repair are handled by upstream CI before the
    review pipeline runs. If you find a lint failure, the review
    pipeline shouldn't have started; abort and report.
-4. **Single commit.** If you make changes, make exactly one commit
-   with a message listing the namespaced blocker ids you addressed,
-   e.g.:
-
-   ```
-   review-pipeline-v2: apply fixes for security/sec-001, docs/doc-003
-
-   Addresses blockers requested by the security and docs reviewers.
-   ```
-
-5. **Do NOT push.** The workflow that invoked you handles the push
-   AFTER it claims the new SHA on `review/pipeline`. You only stage
-   the commit locally.
+4. **Do NOT touch `.git/`.** Do not run `git add`, `git commit`,
+   `git push`, `git config`, `git rebase`, or any other command that
+   writes under `.git/`. The pipeline commits and pushes after you
+   exit — the host runner owns `.git/` and is the only context with
+   write permission on it. Running git-write commands inside this
+   container fails with "cannot update the ref 'HEAD'" because the
+   bind-mounted `.git/` directory is owned by a different UID, and
+   forcing the commit from here leaves `.git/config` in a state the
+   runner cleanup step can't recover from (see PR #409 for the
+   analogous `.review-output/` permissions issue).
+5. **Read-only git is fine.** `git diff`, `git log`, `git status`,
+   `git show`, `git ls-files` etc. all work — they just read. The
+   container entrypoint already sets `safe.directory=/workspace` so
+   you don't need to add it yourself. Use these freely to understand
+   the diff, inspect files, and decide what to fix.
+6. **One logical fix batch, staged as working-tree changes.** Apply
+   fixes to the working tree (write files, edit text). Do NOT stage
+   them with `git add` — leave the changes unstaged. The host step
+   that runs after you captures every working-tree change (via
+   `git add -A`) and commits them as one commit. The commit message
+   it uses is built from your `addressed[]` list in the output JSON,
+   so list every blocker you actually addressed.
 
 ## Procedure
 
@@ -59,11 +68,12 @@ The reviewers and the judge are read-only.
    placeholder vs. prose paragraph).
 4. Apply fixes in your working tree. Run any tests the
    reviewers explicitly suggested. Do not run formatters or linters.
-5. If you made changes, `git add` only the files you actually
-   modified, then `git commit -m "..."` with the message format
-   above. Capture the resulting `git rev-parse HEAD` as the new SHA.
-   If you made no changes, the new SHA equals the input SHA.
-6. Write the result JSON.
+5. Leave your changes unstaged. Do NOT run `git add`, `git commit`,
+   or `git push`. The host step that runs after you commits whatever
+   is in the working tree and computes the new SHA itself.
+6. Write the result JSON. Set `new_sha` to `${REVIEWED_SHA}` — the
+   host commit step will patch the real post-commit SHA into the
+   JSON before the judge reads it.
 
 ## Output contract
 
@@ -74,13 +84,17 @@ Write your fix-result as JSON to `$OUTPUT_PATH` conforming to
 {
   "schema_version": "1",
   "input_sha": "${REVIEWED_SHA}",
-  "new_sha": "<git rev-parse HEAD after your commit, or ${REVIEWED_SHA} if no-op>",
+  "new_sha": "${REVIEWED_SHA}",
   "addressed": ["security/sec-001", "docs/doc-003"],
   "skipped": [
     { "id": "design/d-002", "reason": "fix touches three files; out of fixer scope" }
   ]
 }
 ```
+
+Always set `new_sha` to `${REVIEWED_SHA}` — the host commit step
+overwrites it with the real post-commit SHA before the judge reads
+the file.
 
 `addressed[]` and `skipped[].id` MUST be namespaced as
 `<role>/<id>`. The judge fails closed on bare ids — this prevents

--- a/.github/workflows/review-fixer.yml
+++ b/.github/workflows/review-fixer.yml
@@ -128,6 +128,60 @@ jobs:
             -s .github/scripts/review/schema/fix-result-v1.json \
             -d "$ARTIFACT"
 
+      # Commit the fixer's working-tree changes from the host runner
+      # rather than from inside the CI container. The container runs
+      # as UID 1000 (`ci` user) and the bind-mounted workspace's
+      # `.git/` directory is owned by the runner UID (1001), so any
+      # git-write operation from inside the container fails with
+      # "cannot update the ref 'HEAD': unable to append to
+      # '.git/logs/HEAD': Permission denied". Doing the commit on
+      # the host means git ops run as the workspace owner, which
+      # "just works". The fixer prompt has been updated to leave
+      # the working tree unstaged and set new_sha to REVIEWED_SHA;
+      # this step computes the real new_sha and patches it into the
+      # artifact so the downstream push step reads a consistent SHA.
+      - name: Commit fixer working-tree changes
+        id: commit
+        env:
+          ARTIFACT: ${{ steps.run.outputs.result_json }}
+          REVIEWED_SHA: ${{ inputs.reviewed_sha }}
+        working-directory: ${{ env.PR_WORKSPACE_PATH }}
+        run: |
+          set -euo pipefail
+
+          if git diff --quiet && git diff --cached --quiet; then
+            echo "fixer produced no working-tree changes; no commit needed"
+            echo "committed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Build the commit message from the fixer's addressed[] list.
+          # Matches the wording the old in-container commit used.
+          ADDRESSED=$(jq -r '.addressed | join(", ")' "$ARTIFACT")
+          if [ -z "$ADDRESSED" ]; then
+            echo "::error::fixer has working-tree changes but addressed[] is empty"
+            git status --short
+            exit 1
+          fi
+
+          git config user.name "hide-my-list-ci[bot]"
+          git config user.email "ci@hide-my-list.local"
+          git add -A
+          git commit -m "review-pipeline-v2: apply fixes for ${ADDRESSED}" \
+                     -m "Addresses blockers requested by the reviewers."
+
+          NEW_SHA=$(git rev-parse HEAD)
+          echo "committed=true" >> "$GITHUB_OUTPUT"
+          echo "new_sha=${NEW_SHA}" >> "$GITHUB_OUTPUT"
+
+          # Patch the fixer-result.json so the downstream Claim step
+          # (and the judge) read the real post-commit SHA instead of
+          # the placeholder the agent wrote. $ARTIFACT is an absolute
+          # host path emitted by the review-codex-run action.
+          TMP=$(mktemp)
+          jq --arg new_sha "$NEW_SHA" '.new_sha = $new_sha' "$ARTIFACT" > "$TMP"
+          mv "$TMP" "$ARTIFACT"
+
       - name: Claim new SHA, then push
         id: push
         env:


### PR DESCRIPTION
## Summary

PR #408's fixer step fails after #409 unblocks the reviewers:

\`\`\`
fatal: cannot update the ref 'HEAD':
  unable to append to '.git/logs/HEAD': Permission denied
\`\`\`

Full cascade: https://github.com/NickBorgersProbably/hide-my-list/actions/runs/24295612261/job/70940148164

## Root cause

Same UID mismatch #409 fixed for \`.review-output/\`, but now at \`.git/\`.

- The CI image runs the fixer as \`ci\` user (UID 1000)
- The workspace's \`.git/\` dir is owned by the runner user (UID 1001)
- Every git-write op (\`git commit\`, \`git config\`, \`git add\` to index) fails on permissions
- The fixer prompt asks the agent to commit anyway, so the agent improvises \`git config\` calls, fabricates a \`new_sha\` into \`fixer-result.json\` based on what the commit *would have been*, and exits zero
- Host \"Claim new SHA, then push\" reads the fabricated SHA, tries to push it, and crashes with \`fatal: 'origin' does not appear to be a git repository\` because the container's improvisation left \`.git/config\` in an unrecoverable state
- Post-job cleanup also trips: \`error: could not lock config file .git/config: Permission denied\`

## Fix

**Architectural:** stop doing git writes in the container. The container modifies the working tree; the host runs add/commit. This eliminates the permissions gymnastics entirely.

### Changes

1. **\`.github/scripts/review/prompts/fixer.md\`** — explicit \"do not touch \`.git/\`\". Lists the commands to avoid. Tells the agent to leave changes unstaged. \`new_sha\` in the output JSON is set to \`REVIEWED_SHA\` as a placeholder.

2. **\`.github/workflows/review-fixer.yml\`** — new \"Commit fixer working-tree changes\" step runs after the container exits, as the runner user. Checks for any working-tree diff, writes the commit as \`hide-my-list-ci[bot]\`, computes the real new_sha, and patches it into \`fixer-result.json\` via \`jq\` before the existing \"Claim new SHA, then push\" step reads it. Commit message format matches the old in-container commit, so judge behavior is unchanged.

3. **\`.github/actions/review-codex-run/action.yml\`** — pass \`GIT_CONFIG_COUNT\` / \`GIT_CONFIG_KEY_0=safe.directory\` / \`GIT_CONFIG_VALUE_0=/workspace\` via \`docker run -e\` so the container's read-only git commands (\`git diff\`, \`git status\`, etc.) work without the agent improvising \`safe.directory\` config. Env-config is ephemeral — leaves no trace in the workspace. Purely additive; helps every reviewer role too, not just fixer.

Side effect: the post-job cleanup \`.git/config\` permission error goes away because the container no longer tries to write there.

## Test plan

- [ ] Merge this and re-trigger #408's pipeline. Expect all 5 reviewers + fixer + judge to complete without git permission errors.
- [ ] Verify the fixer commit is authored by \`hide-my-list-ci[bot]\` and has the \`review-pipeline-v2: apply fixes for ...\` message.
- [ ] Verify the judge reads the patched \`fixer-result.json\` and sees the real post-commit SHA.
- [ ] Verify post-job cleanup doesn't print the old \`.git/config\` permission warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)