### PR TITLE
Restore heartbeat Signal target in setup template

### DIFF
--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -35,11 +35,12 @@ OpenClaw's heartbeat is a built-in periodic trigger configured in `openclaw.json
 ```json
 "heartbeat": {
   "every": "60m",
-  "model": "litellm/claude-sonnet-4-6"
+  "model": "litellm/claude-sonnet-4-6",
+  "target": "signal"
 }
 ```
 
-Every 60 minutes, OpenClaw creates a short agent session that reads `HEARTBEAT.md` and executes the checks defined there. It uses a lighter model (Sonnet instead of Opus) since these are routine operational tasks. Reminder delivery does not rely on `heartbeat.target`; Check 1 sends reminders explicitly with the OpenClaw `message` tool (`action: send`, `channel: signal`). The `target` field only controls where generic non-`HEARTBEAT_OK` heartbeat output is routed; without it, that generic heartbeat text defaults to `"none"` and is silently discarded ([openclaw/openclaw#29215](https://github.com/openclaw/openclaw/issues/29215)).
+Every 60 minutes, OpenClaw creates a short agent session that reads `HEARTBEAT.md` and executes the checks defined there. It uses a lighter model (Sonnet instead of Opus) since these are routine operational tasks. Reminder delivery does not rely on `heartbeat.target`; Check 1 sends reminders explicitly with the OpenClaw `message` tool (`action: send`, `channel: signal`). The `target` field only controls where generic non-`HEARTBEAT_OK` heartbeat output is routed; without it, that generic heartbeat text defaults to `"none"` and is silently discarded, so the production template keeps `target: "signal"` for operator-facing alerts ([openclaw/openclaw#29215](https://github.com/openclaw/openclaw/issues/29215)).
 
 **Our usage:** The heartbeat serves two roles:
 1. **Reminder-delivery backstop:** The isolated `reminder-check` cron only writes `.reminder-signal` — it does not deliver to the user. Heartbeat Check 1 reads stranded signal files, validates them, and delivers reminders to Signal with the `message` tool every 60 minutes. (The AGENTS.md startup check provides faster opportunistic delivery when the user is active.)

--- a/setup/README.md
+++ b/setup/README.md
@@ -136,7 +136,7 @@ Manual regression playbook:
 
 **Reminders not firing:**
 - Reminder delivery uses the OpenClaw `message` tool with `channel: signal` — it does not rely on `heartbeat.target` or session reply routing. Verify that the Signal channel is configured and enabled in `openclaw.json`.
-- `heartbeat.target` is optional and only affects where generic non-`HEARTBEAT_OK` heartbeat output is routed. If you want those operator-facing heartbeat messages to land in Signal too, set `heartbeat.target` to `"signal"`.
+- `heartbeat.target` is recommended for operator alerts, not for reminder delivery. Keep it set to `"signal"` so generic non-`HEARTBEAT_OK` heartbeat messages reach Signal instead of being discarded.
 - Check that the reminder-check cron is registered (ask the agent to check CronList)
 - Verify `.env` has correct `NOTION_API_KEY` and `NOTION_DATABASE_ID`
 - Run `scripts/check-reminders.sh` manually to test Notion connectivity

--- a/setup/cron/heartbeat-check.md
+++ b/setup/cron/heartbeat-check.md
@@ -7,11 +7,12 @@ The heartbeat is not a cron job we create — it's a built-in OpenClaw feature c
 ```json
 "heartbeat": {
   "every": "60m",
-  "model": "litellm/claude-sonnet-4-6"
+  "model": "litellm/claude-sonnet-4-6",
+  "target": "signal"
 }
 ```
 
-Reminder delivery does not depend on `heartbeat.target`. Heartbeat Check 1 sends reminders explicitly with the OpenClaw `message` tool (`action: send`, `channel: signal`). The `target` field only controls where generic non-`HEARTBEAT_OK` heartbeat output is routed; without it, that generic heartbeat text defaults to `"none"` and is silently discarded. Set `heartbeat.target` to `"signal"` only if you also want those operator-facing heartbeat messages routed there.
+Reminder delivery does not depend on `heartbeat.target`. Heartbeat Check 1 sends reminders explicitly with the OpenClaw `message` tool (`action: send`, `channel: signal`). The `target` field only controls where generic non-`HEARTBEAT_OK` heartbeat output is routed; without it, that generic heartbeat text defaults to `"none"` and is silently discarded. The production template sets `heartbeat.target` to `"signal"` so operator-facing heartbeat alerts reach the user there too.
 
 ## Behavior
 

--- a/setup/openclaw.json.template
+++ b/setup/openclaw.json.template
@@ -64,7 +64,8 @@
       },
       "heartbeat": {
         "every": "60m",
-        "model": "litellm/claude-sonnet-4-6"
+        "model": "litellm/claude-sonnet-4-6",
+        "target": "signal"
       },
       "maxConcurrent": 4,
       "subagents": {


### PR DESCRIPTION
Resolves #413

## Summary
- restore `heartbeat.target: "signal"` in the setup config template and heartbeat setup example
- keep the reminder-delivery clarification while documenting that the target is still recommended for operator-facing heartbeat alerts
- update setup troubleshooting to frame `heartbeat.target` as recommended for alerts, not required for reminders

## Test Plan
- `shellcheck scripts/*.sh`
- `yamllint .github/workflows/*.yml`
- `bash scripts/check-doc-links.sh`

Generated with Codex