### PR TITLE
test: validate caveman mode in review pipeline

### DIFF
--- a/.github/ci/README.md
+++ b/.github/ci/README.md
@@ -127,3 +127,4 @@ docker run --rm \
 Pinned versions live in `versions.env`. Bump the values there, then
 rebuild the image (or let the next `ci-image.yml` run on a merge to
 main pick them up via its `paths:` filter).
+


### PR DESCRIPTION
Whitespace-only change to trigger the review pipeline and verify caveman rules are being applied to reviewer output. Compare reviewer comment length/style against prior PRs.