### PR TITLE
Fix review-codex-run composite action YAML parsing

### DIFF
--- a/.github/actions/review-codex-run/action.yml
+++ b/.github/actions/review-codex-run/action.yml
@@ -214,36 +214,7 @@ runs:
           -e GIT_CONFIG_KEY_0=safe.directory \
           -e GIT_CONFIG_VALUE_0=/workspace \
           "$CI_AGENT_IMAGE" \
-          -lc '
-            set -euo pipefail
-
-            source .devcontainer/configure-codex.sh
-
-            if [ ! -f "$REVIEW_PROMPT_PATH" ]; then
-              echo "::error::review-codex-run: prompt file not found at $REVIEW_PROMPT_PATH"
-              exit 1
-            fi
-            PROMPT_BODY=$(cat "$REVIEW_PROMPT_PATH")
-
-            mkdir -p "$(dirname "$OUTPUT_PATH")"
-
-            # The prompt body instructs Codex to write its structured
-            # result JSON to $OUTPUT_PATH and conform to the schema in
-            # .github/scripts/review/schema/.
-            timeout 30m codex exec \
-              --json \
-              --dangerously-bypass-approvals-and-sandbox \
-              "$PROMPT_BODY" \
-              < /dev/null 2>&1 \
-              | tee "$OUTPUT_LOG_PATH"
-
-            if [ ! -s "$OUTPUT_PATH" ]; then
-              echo "::error::review-codex-run: prompt did not produce $OUTPUT_PATH"
-              exit 1
-            fi
-
-            echo "review-codex-run: ${REVIEW_ROLE} produced $OUTPUT_PATH"
-          '
+          -lc '.github/actions/review-codex-run/run-in-container.sh'
 
     - name: Clean up staged env file
       if: always()

--- a/.github/actions/review-codex-run/run-in-container.sh
+++ b/.github/actions/review-codex-run/run-in-container.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck disable=SC1091
+source .devcontainer/configure-codex.sh
+
+if [ ! -f "$REVIEW_PROMPT_PATH" ]; then
+  echo "::error::review-codex-run: prompt file not found at $REVIEW_PROMPT_PATH"
+  exit 1
+fi
+
+PROMPT_BODY=$(cat "$REVIEW_PROMPT_PATH")
+
+mkdir -p "$(dirname "$OUTPUT_PATH")"
+
+# The prompt body instructs Codex to write its structured
+# result JSON to $OUTPUT_PATH and conform to the schema in
+# .github/scripts/review/schema/.
+timeout 30m codex exec \
+  --json \
+  --dangerously-bypass-approvals-and-sandbox \
+  "$PROMPT_BODY" \
+  < /dev/null 2>&1 \
+  | tee "$OUTPUT_LOG_PATH"
+
+if [ ! -s "$OUTPUT_PATH" ]; then
+  echo "::error::review-codex-run: prompt did not produce $OUTPUT_PATH"
+  exit 1
+fi
+
+echo "review-codex-run: ${REVIEW_ROLE} produced $OUTPUT_PATH"


### PR DESCRIPTION
Resolves #424

## Summary
- move the container-side Codex execution logic out of `.github/actions/review-codex-run/action.yml` into a checked-in helper script
- update the composite action to call the helper script instead of embedding a long inline `docker ... -lc` shell payload
- keep the existing review pipeline behavior unchanged while making the action metadata easier for GitHub Actions tooling to parse

## Test Plan
- `shellcheck scripts/*.sh`
- `yamllint .github/workflows/*.yml`
- `shellcheck .github/actions/review-codex-run/run-in-container.sh`
- `./scripts/check-doc-links.sh`
- `./scripts/run-required-checks.sh ci-workflows`

Generated with Codex