### PR TITLE
refactor: extract container script from review-codex-run action

### DIFF
--- a/.github/actions/review-codex-run/action.yml
+++ b/.github/actions/review-codex-run/action.yml
@@ -214,48 +214,7 @@ runs:
           -e GIT_CONFIG_KEY_0=safe.directory \
           -e GIT_CONFIG_VALUE_0=/workspace \
           "$CI_AGENT_IMAGE" \
-          -lc '
-            set -euo pipefail
-
-            source .devcontainer/configure-codex.sh
-
-            if [ ! -f "$REVIEW_PROMPT_PATH" ]; then
-              echo "::error::review-codex-run: prompt file not found at $REVIEW_PROMPT_PATH"
-              exit 1
-            fi
-            # Prepend caveman rules if available (optional — PRs branched
-            # before caveman merged will not have the file).
-            if [ -f .github/ci/caveman-rules.md ] && [ -f .github/ci/versions.env ]; then
-              source .github/ci/versions.env
-              if grep -Fq "v${CAVEMAN_VERSION}" .github/ci/caveman-rules.md; then
-                PROMPT_BODY=$(printf '%s\n\n%s' "$(cat .github/ci/caveman-rules.md)" "$(cat "$REVIEW_PROMPT_PATH")")
-              else
-                echo "::warning::review-codex-run: caveman version mismatch — skipping rules"
-                PROMPT_BODY=$(cat "$REVIEW_PROMPT_PATH")
-              fi
-            else
-              PROMPT_BODY=$(cat "$REVIEW_PROMPT_PATH")
-            fi
-
-            mkdir -p "$(dirname "$OUTPUT_PATH")"
-
-            # The prompt body instructs Codex to write its structured
-            # result JSON to $OUTPUT_PATH and conform to the schema in
-            # .github/scripts/review/schema/.
-            timeout 30m codex exec \
-              --json \
-              --dangerously-bypass-approvals-and-sandbox \
-              "$PROMPT_BODY" \
-              < /dev/null 2>&1 \
-              | tee "$OUTPUT_LOG_PATH"
-
-            if [ ! -s "$OUTPUT_PATH" ]; then
-              echo "::error::review-codex-run: prompt did not produce $OUTPUT_PATH"
-              exit 1
-            fi
-
-            echo "review-codex-run: ${REVIEW_ROLE} produced $OUTPUT_PATH"
-          '
+          -lc '.github/actions/review-codex-run/run-in-container.sh'
 
     - name: Clean up staged env file
       if: always()

--- a/.github/actions/review-codex-run/run-in-container.sh
+++ b/.github/actions/review-codex-run/run-in-container.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck disable=SC1091
+source .devcontainer/configure-codex.sh
+
+if [ ! -f "$REVIEW_PROMPT_PATH" ]; then
+  echo "::error::review-codex-run: prompt file not found at $REVIEW_PROMPT_PATH"
+  exit 1
+fi
+
+# Prepend caveman rules if available (optional — PRs branched
+# before caveman merged will not have the file).
+if [ -f .github/ci/caveman-rules.md ] && [ -f .github/ci/versions.env ]; then
+  # shellcheck disable=SC1091
+  source .github/ci/versions.env
+  if grep -Fq "v${CAVEMAN_VERSION}" .github/ci/caveman-rules.md; then
+    PROMPT_BODY=$(printf '%s\n\n%s' "$(cat .github/ci/caveman-rules.md)" "$(cat "$REVIEW_PROMPT_PATH")")
+  else
+    echo "::warning::review-codex-run: caveman version mismatch — skipping rules"
+    PROMPT_BODY=$(cat "$REVIEW_PROMPT_PATH")
+  fi
+else
+  PROMPT_BODY=$(cat "$REVIEW_PROMPT_PATH")
+fi
+
+mkdir -p "$(dirname "$OUTPUT_PATH")"
+
+# The prompt body instructs Codex to write its structured
+# result JSON to $OUTPUT_PATH and conform to the schema in
+# .github/scripts/review/schema/.
+timeout 30m codex exec \
+  --json \
+  --dangerously-bypass-approvals-and-sandbox \
+  "$PROMPT_BODY" \
+  < /dev/null 2>&1 \
+  | tee "$OUTPUT_LOG_PATH"
+
+if [ ! -s "$OUTPUT_PATH" ]; then
+  echo "::error::review-codex-run: prompt did not produce $OUTPUT_PATH"
+  exit 1
+fi
+
+echo "review-codex-run: ${REVIEW_ROLE} produced $OUTPUT_PATH"


### PR DESCRIPTION
Closes #424

## Summary

- Extract the inline `-lc '...'` shell payload from `review-codex-run/action.yml` into `.github/actions/review-codex-run/run-in-container.sh`
- Action now calls: `"$CI_AGENT_IMAGE" -lc '.github/actions/review-codex-run/run-in-container.sh'`
- Behavior fully preserved: caveman rules prepend, version check, prompt-not-found guard, output-not-produced guard

## Why

The long inline single-quoted block prevents actionlint from parsing the action metadata. It also created a trap where apostrophes in comments (e.g. `won't`) silently terminated the single-quoted string, causing bash syntax errors at runtime. A standalone script avoids both problems.

## Test plan

- [ ] Review pipeline runs cleanly on this PR
- [ ] Reviewers produce output (caveman logic preserved in extracted script)

🤖 Generated with [Claude Code](https://claude.com/claude-code)