### PR TITLE
Update cron docs and heartbeat references to gemma4

### DIFF
--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -30,7 +30,7 @@ Verify that durable cron jobs are registered. If any are missing, re-register th
 | reminder-check | `*/15 * * * *` | Run `scripts/check-reminders.sh` (query-only; writes the reminder handoff file if reminders due) |
 | pull-main | `*/10 * * * *` | Run `scripts/pull-main.sh`; the script handles dirty-pull recovery |
 
-To check: use CronList. If a job is missing (7-day auto-expiry), re-create it with CronCreate (durable: true) using the schedule, prompt, and options from `setup/cron/`. Both jobs run as isolated Haiku sessions with `sessionTarget: isolated`, `model: litellm/claude-haiku-4-5`, `payload.kind: agentTurn`, and `timeout-seconds: 60`. Cron jobs should never deliver directly to Signal or any other channel on their own. If any job had to be re-created, send an explicit ops alert to `OPS_ALERT_SIGNAL_NUMBER` naming the missing job(s).
+To check: use CronList. If a job is missing (7-day auto-expiry), re-create it with CronCreate (durable: true) using the schedule, prompt, and options from `setup/cron/`. Both jobs run as isolated sessions with `sessionTarget: isolated`, `model: litellm/gemma4`, `payload.kind: agentTurn`, and `timeout-seconds: 60`. Cron jobs should never deliver directly to Signal or any other channel on their own. If any job had to be re-created, send an explicit ops alert to `OPS_ALERT_SIGNAL_NUMBER` naming the missing job(s).
 
 ### 2b. Cron Spec Drift Check
 For each registered cron job (`reminder-check`, `pull-main`), compare the live job's effective registration against the canonical `CronCreate` spec in `setup/cron/<name>.md`.
@@ -43,7 +43,7 @@ At minimum, compare and correct these fields:
 - `schedule`
 - `prompt`
 - `sessionTarget` (canonical: `isolated` for both jobs)
-- `model` (canonical: `litellm/claude-haiku-4-5` for both jobs)
+- `model` (canonical: `litellm/gemma4` for both jobs)
 - direct-delivery routing field: live `to` if present (should not exist)
 - payload field: canonical `payload.kind`
 - `timeout-seconds`
@@ -51,8 +51,8 @@ At minimum, compare and correct these fields:
 If a stale `pipeline-monitor` cron is still registered, delete it with CronDelete — that job has been removed.
 
 If any field differs from the spec, patch the live job to match with CronUpdate. If CronUpdate cannot safely change an identity field such as `name` or `durable`, delete and re-create the job from the spec instead of leaving drift in place. Preserve the intended durable registration contract from the spec:
-- `reminder-check`: `name`, `durable`, `schedule`, `prompt`, `sessionTarget: isolated`, `model: litellm/claude-haiku-4-5`, no `to`, `payload.kind: agentTurn`, `timeout-seconds: 60`
-- `pull-main`: `name`, `durable`, `schedule`, `prompt`, `sessionTarget: isolated`, `model: litellm/claude-haiku-4-5`, no `to`, `payload.kind: agentTurn`, `timeout-seconds: 60`
+- `reminder-check`: `name`, `durable`, `schedule`, `prompt`, `sessionTarget: isolated`, `model: litellm/gemma4`, no `to`, `payload.kind: agentTurn`, `timeout-seconds: 60`
+- `pull-main`: `name`, `durable`, `schedule`, `prompt`, `sessionTarget: isolated`, `model: litellm/gemma4`, no `to`, `payload.kind: agentTurn`, `timeout-seconds: 60`
 
 If all jobs already match their specs, do not report anything. If any jobs were corrected, briefly note which ones were patched and what drift was fixed, and send that summary as an explicit ops alert to `OPS_ALERT_SIGNAL_NUMBER`. If drift could not be corrected safely, send an explicit ops alert describing the failure.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,8 +42,8 @@ flowchart TB
     Messaging <-->|OpenClaw routing| AI
     AI <-->|CRUD operations| Scripts
     Scripts <-->|REST API| Notion
-    ReminderCron -->|Isolated Haiku: query reminders| Scripts
-    PullMainCron -->|Isolated Haiku: pull workspace| Scripts
+    ReminderCron -->|Isolated Gemma: query reminders| Scripts
+    PullMainCron -->|Isolated Gemma: pull workspace| Scripts
     Heartbeat -->|Health checks + reminder delivery| AI
 ```
 
@@ -60,7 +60,7 @@ There is no standalone server. The OpenClaw agent *is* the application. It:
 6. **Celebrates completions** with immediate positive reinforcement
 7. **Delivers scheduled reminders** even when the chat is idle
 
-Interactive conversations are surface-agnostic. Durable cron jobs run as isolated Haiku sessions for cost efficiency — they execute scripts and write handoff files, but do not deliver user-facing messages. Reminder delivery reaches the user through the heartbeat (every 60 min) and the main-session startup check (AGENTS.md step 5, on every user interaction). Heartbeat-detected operational failures use a separate explicit Signal target from `.env` (`OPS_ALERT_SIGNAL_NUMBER`) so raw ops diagnostics do not land in the ADHD support thread. All cron jobs should stay silent when there is nothing actionable.
+Interactive conversations are surface-agnostic. Durable cron jobs run as isolated cron sessions for cost efficiency — they execute scripts and write handoff files, but do not deliver user-facing messages. Reminder delivery reaches the user through the heartbeat (every 60 min) and the main-session startup check (AGENTS.md step 5, on every user interaction). Heartbeat-detected operational failures use a separate explicit Signal target from `.env` (`OPS_ALERT_SIGNAL_NUMBER`) so raw ops diagnostics do not land in the ADHD support thread. All cron jobs should stay silent when there is nothing actionable.
 
 ## Component Architecture
 
@@ -199,7 +199,7 @@ The OpenClaw agent model is stateless between messages — there is no persisten
 
 ```mermaid
 sequenceDiagram
-    participant Cron as Isolated Haiku Cron<br/>(every 15 min)
+    participant Cron as Isolated Gemma Cron<br/>(every 15 min)
     participant Script as check-reminders.sh
     participant Notion as Notion API
     participant Signal as .reminder-signal
@@ -227,7 +227,7 @@ sequenceDiagram
 **How it works:**
 
 1. During task intake, the AI detects reminder-style language (e.g., "remind me at 6pm PT to call Sarah") and sets `is_reminder = true`, `remind_at` (full ISO 8601 with timezone), and `reminder_status = pending`.
-2. A durable cron job (`reminder-check`) runs every 15 minutes as an isolated Haiku session via OpenClaw's native scheduling.
+2. A durable cron job (`reminder-check`) runs every 15 minutes as an isolated cron session via OpenClaw's native scheduling.
 3. The cron job runs `scripts/check-reminders.sh` to query Notion for pending reminders where `remind_at <= now`.
 4. If due reminders are found, `check-reminders.sh` writes the reminder handoff file in the repo root (default filename: `.reminder-signal`, overridable via `REMINDER_SIGNAL_FILE` in `.env`). The isolated cron session then exits with `NO_REPLY` — it does not deliver reminders.
 5. Reminder delivery happens through two separate mechanisms:
@@ -237,7 +237,7 @@ sequenceDiagram
 6. Reminders more than 15 minutes past due are flagged as `missed` and still delivered with a shame-safe note such as: `This was due a bit ago — [task]. Want to handle it now or reschedule?`
 7. The cron job only fires when the agent is idle — it won't interrupt the user mid-task, which is better for ADHD focus.
 
-Both `reminder-check` and `pull-main` use `sessionTarget: isolated` with `model: litellm/claude-haiku-4-5` and `payload.kind: agentTurn`. This is a deliberate design choice: the previous architecture ran both on `sessionTarget: main`, which loaded the full Opus agent context for routine script work and burned ~18M tokens per 6 hours. Isolating cron jobs cuts per-run cost by orders of magnitude. The trade-off for reminders is that delivery is deferred to the next user interaction or heartbeat cycle; in the fully idle case, delivery can take up to about 75 minutes because discovery and delivery happen on separate schedules. If reminder delivery fails after the handoff file is written, the delivering session should fail visibly, leave the file in place, and avoid marking the reminder `sent` or `missed` until delivery actually succeeds.
+Both `reminder-check` and `pull-main` use `sessionTarget: isolated` with `model: litellm/gemma4` and `payload.kind: agentTurn`. This is a deliberate design choice: the previous architecture ran both on `sessionTarget: main`, which loaded the full Opus agent context for routine script work and burned ~18M tokens per 6 hours. Isolating cron jobs cuts per-run cost by orders of magnitude. The trade-off for reminders is that delivery is deferred to the next user interaction or heartbeat cycle; in the fully idle case, delivery can take up to about 75 minutes because discovery and delivery happen on separate schedules. If reminder delivery fails after the handoff file is written, the delivering session should fail visibly, leave the file in place, and avoid marking the reminder `sent` or `missed` until delivery actually succeeds.
 
 This deferred-delivery handoff is also a correctness constraint, not just an implementation detail. OpenClaw does not currently provide a post-announce delivery acknowledgment hook, so an announce-only cron flow would have to mutate Notion before the platform could confirm that the reminder was actually delivered. That would let a cron crash or transport failure drop reminders permanently by moving them out of the `pending` query set before delivery completed.
 
@@ -255,7 +255,7 @@ This deferred-delivery handoff is also a correctness constraint, not just an imp
 | Messaging | OpenClaw Surfaces | Interactive chat can be multi-channel (web, Signal, Telegram, Discord); reminder delivery via heartbeat + main-session startup check; heartbeat ops alerts use a separate Signal recipient |
 | CI/CD | GitHub Actions | Multi-agent review pipeline; GitHub-hosted gate jobs handle untrusted dispatch, while self-hosted Codex reviewers inherit the homelab proxy and VLAN restrictions |
 | Scripts | Bash + curl | Minimal dependencies, runs anywhere |
-| Scheduled Reminders | OpenClaw durable cron + check-reminders.sh | Isolated Haiku cron every 15 min writes `.reminder-signal`; heartbeat (60 min) + startup check deliver |
+| Scheduled Reminders | OpenClaw durable cron + check-reminders.sh | Isolated Gemma cron every 15 min writes `.reminder-signal`; heartbeat (60 min) + startup check deliver |
 | Workspace Sync | OpenClaw durable cron + pull-main.sh | Native cron every 10 min keeps the workspace current and recovers dirty pulls |
 | Image Generation | OpenAI gpt-image-1 | Unique AI images for reward novelty |
 | Video | ffmpeg | Weekly recap compilation |

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -85,7 +85,7 @@ OpenClaw provides `CronCreate` for scheduling recurring agent prompts. With `dur
 
 **The 7-day expiry problem:** Recurring cron jobs auto-expire after 7 days. The heartbeat catches this and re-registers the missing jobs. It also corrects spec drift caused by manual hotfixes or stale re-registration prompts by comparing the live job against the canonical `CronCreate` block and patching any mismatched registration fields. This is a platform constraint we work around rather than a feature we chose.
 
-**Current registration contract:** Both `reminder-check` and `pull-main` run as isolated Haiku sessions with `sessionTarget: isolated`, `model: litellm/claude-haiku-4-5`, `payload.kind: agentTurn`, and `timeout-seconds: 60`. This is a deliberate design choice that separates cheap query work from user-facing delivery. The previous architecture used `sessionTarget: main`, which loaded the full Opus agent context (~200k tokens) for routine script work. Moving to isolated Haiku cuts per-run cost by orders of magnitude. Reminder delivery is handled by the heartbeat (HEARTBEAT.md Check 1, every 60 min) and the main-session startup check (AGENTS.md step 5, on every user interaction). In the fully idle case, worst-case delivery latency is up to about 75 minutes: up to 15 minutes for `reminder-check` to write the handoff file, then up to another 60 minutes for heartbeat to deliver it if no user interaction happens first. The cron prompts end with `NO_REPLY` since they never produce user-facing output. Until OpenClaw exposes a post-delivery acknowledgment hook, this split flow is also the durability boundary that keeps failed reminder deliveries retryable.
+**Current registration contract:** Both `reminder-check` and `pull-main` run as isolated cron sessions with `sessionTarget: isolated`, `model: litellm/gemma4`, `payload.kind: agentTurn`, and `timeout-seconds: 60`. This is a deliberate design choice that separates cheap query work from user-facing delivery. The previous architecture used `sessionTarget: main`, which loaded the full Opus agent context (~200k tokens) for routine script work. Moving to isolated cron sessions on `litellm/gemma4` cuts per-run cost by orders of magnitude. Reminder delivery is handled by the heartbeat (HEARTBEAT.md Check 1, every 60 min) and the main-session startup check (AGENTS.md step 5, on every user interaction). In the fully idle case, worst-case delivery latency is up to about 75 minutes: up to 15 minutes for `reminder-check` to write the handoff file, then up to another 60 minutes for heartbeat to deliver it if no user interaction happens first. The cron prompts end with `NO_REPLY` since they never produce user-facing output. Until OpenClaw exposes a post-delivery acknowledgment hook, this split flow is also the durability boundary that keeps failed reminder deliveries retryable.
 
 These isolated cron sessions are intentionally narrow. They are script runners, not a substitute for the main agent or heartbeat control paths. The detailed ownership split is documented in [Agent Capabilities](agent-capabilities.md).
 
@@ -96,7 +96,7 @@ For production deployments, use these timings unless you have a clear reason to 
 | Mechanism | Recommended cadence | Why |
 |-----------|---------------------|-----|
 | Heartbeat | Every 60 minutes | Reminder-delivery backstop plus cron expiry, spec drift, and Notion/env health |
-| `reminder-check` | Every 15 minutes | Isolated Haiku query; writes `.reminder-signal` for heartbeat/startup delivery |
+| `reminder-check` | Every 15 minutes | Isolated Gemma query; writes `.reminder-signal` for heartbeat/startup delivery |
 | `pull-main` | Every 10 minutes | Cheap script-only sync path; keeps the workspace fresh |
 
 The core principle is simple: `reminder-check` controls when due reminders are discovered, while heartbeat is part of the idle-user delivery path. For routine reminders, 15-minute polling plus hourly heartbeat is the default production cost/latency tradeoff. This means exact-time delivery is not guaranteed in the current deferred-delivery architecture; fully idle worst-case delivery is about 75 minutes unless the user interacts sooner.
@@ -123,7 +123,7 @@ The primary deployed surface today is Signal. OpenClaw handles:
 - Acknowledgment reactions
 - Session scoping (per-channel-peer)
 
-**Our role:** Zero for transport mechanics. We write conversational responses; OpenClaw delivers them. Interactive conversations use the normal main-agent routing path. Cron jobs run as isolated Haiku sessions (query-only, no user delivery). Reminder delivery reaches the user through the heartbeat and the main-session startup check.
+**Our role:** Zero for transport mechanics. We write conversational responses; OpenClaw delivers them. Interactive conversations use the normal main-agent routing path. Cron jobs run as isolated cron sessions (query-only, no user delivery). Reminder delivery reaches the user through the heartbeat and the main-session startup check.
 
 ## Model Routing (LiteLLM Proxy)
 
@@ -145,7 +145,7 @@ OpenClaw supports multiple model providers. We route through a LiteLLM proxy on 
 
 - **Primary model:** Claude Opus 4.6 (conversations, task management)
 - **Heartbeat model:** Claude Sonnet 4.6 (routine checks, cheaper)
-- **Cron model:** Claude Haiku 4.5 (isolated cron jobs — reminder polling, workspace sync)
+- **Cron model:** Gemma 4 (isolated cron jobs — reminder polling, workspace sync)
 - **Fallback chain:** Opus → Sonnet → GPT-5.4
 
 **Our role:** We don't interact with model selection directly. The prompts in `docs/ai-prompts.md` are model-agnostic. OpenClaw picks the model based on the config.

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -136,7 +136,8 @@ OpenClaw supports multiple model providers. We route through a LiteLLM proxy on 
       "baseUrl": "https://llm.featherback-mermaid.ts.net/v1",
       "models": [
         { "id": "claude-opus-4-6", ... },
-        { "id": "claude-sonnet-4-6", ... }
+        { "id": "claude-sonnet-4-6", ... },
+        { "id": "gemma4", ... }
       ]
     }
   }

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -954,7 +954,7 @@ flowchart TD
 
 | Property | Normal Task | Reminder Task |
 |----------|-------------|---------------|
-| Selection | User requests → AI suggests | Isolated Haiku `reminder-check` writes the reminder handoff file; delivered by heartbeat (60 min) or main-session startup check (next user interaction) |
+| Selection | User requests → AI suggests | Isolated Gemma `reminder-check` writes the reminder handoff file; delivered by heartbeat (60 min) or main-session startup check (next user interaction) |
 | Lifecycle | Pending → In Progress → Completed | Pending → Completed (`Reminder Status` becomes `sent` or `missed`) |
 | Check-ins | Timer-based follow-ups | None (single delivery) |
 | Rejection | User can reject suggestion | N/A (delivered once) |

--- a/docs/user-interactions.md
+++ b/docs/user-interactions.md
@@ -756,7 +756,7 @@ Reminders are tasks with a specific wall-clock delivery time. Unlike check-ins (
 
 ```mermaid
 sequenceDiagram
-    participant Cron as Isolated Haiku Cron
+    participant Cron as Isolated Gemma Cron
     participant Scr as check-reminders.sh
     participant Notion as Notion API
     participant Signal as .reminder-signal
@@ -781,7 +781,7 @@ sequenceDiagram
     end
 ```
 
-The `reminder-check` cron runs as an isolated Haiku session — it is query-only and does not deliver reminders. Delivery happens through two paths: the main-session startup check (AGENTS.md step 5, on every user interaction) and the heartbeat (HEARTBEAT.md Check 1, every 60 min). Both delivery paths first validate that the handoff is JSON with a `reminders` array where each entry is an object with string `page_id`, non-empty string `title`, and `status` exactly `sent` or `missed`. Any other shape or status makes the handoff malformed, so the file stays in place and nothing is delivered, completed, or deleted. If delivery fails after validation, the handoff file is left in place for retry.
+The `reminder-check` cron runs as an isolated cron session on `litellm/gemma4` — it is query-only and does not deliver reminders. Delivery happens through two paths: the main-session startup check (AGENTS.md step 5, on every user interaction) and the heartbeat (HEARTBEAT.md Check 1, every 60 min). Both delivery paths first validate that the handoff is JSON with a `reminders` array where each entry is an object with string `page_id`, non-empty string `title`, and `status` exactly `sent` or `missed`. Any other shape or status makes the handoff malformed, so the file stays in place and nothing is delivered, completed, or deleted. If delivery fails after validation, the handoff file is left in place for retry.
 
 ### Reminder Delivery Messages
 

--- a/setup/README.md
+++ b/setup/README.md
@@ -99,7 +99,7 @@ The agent uses OpenClaw's durable cron system instead of bash daemons:
 | pull-main | Every 10 min | Pull `origin/main` and recover from dirty tracked-file states |
 | heartbeat (built-in) | Every 60 min | System health, cron re-registration, cron drift correction, stranded reminder delivery, ops alerts to the separate operator Signal recipient |
 
-Cron jobs auto-expire after 7 days. The heartbeat re-registers missing jobs automatically and patches live cron jobs back to the `setup/cron/` specs if they drift. Both jobs run as isolated Haiku sessions (`sessionTarget: isolated`, `model: litellm/claude-haiku-4-5`, `payload.kind: agentTurn`).
+Cron jobs auto-expire after 7 days. The heartbeat re-registers missing jobs automatically and patches live cron jobs back to the `setup/cron/` specs if they drift. Both jobs run as isolated cron sessions (`sessionTarget: isolated`, `model: litellm/gemma4`, `payload.kind: agentTurn`).
 
 Production recommendation: keep `reminder-check` at 15-minute cadence and heartbeat hourly as the default production cost/latency tradeoff for routine or low-stakes reminders. In the fully idle case, reminder delivery can take up to about 75 minutes under this deferred-delivery design, so exact-time reminders are not guaranteed unless the architecture changes.
 

--- a/setup/cron/pull-main.md
+++ b/setup/cron/pull-main.md
@@ -10,13 +10,13 @@ CronCreate:
   durable: true
   name: "pull-main"
   sessionTarget: isolated
-  model: litellm/claude-haiku-4-5
+  model: litellm/gemma4
   payload:
     kind: agentTurn
   timeout-seconds: 60
 ```
 
-This job runs as an isolated Haiku maintenance session. It executes `scripts/pull-main.sh` and stays silent (`NO_REPLY`). Cron spec re-application after pulls is handled by the heartbeat drift correction (HEARTBEAT.md Check 2b), not by this job — an isolated session cannot reliably call CronList/CronUpdate.
+This job runs as an isolated cron maintenance session on `litellm/gemma4`. It executes `scripts/pull-main.sh` and stays silent (`NO_REPLY`). Cron spec re-application after pulls is handled by the heartbeat drift correction (HEARTBEAT.md Check 2b), not by this job — an isolated session cannot reliably call CronList/CronUpdate.
 
 ## Prompt
 

--- a/setup/cron/reminder-check.md
+++ b/setup/cron/reminder-check.md
@@ -10,13 +10,13 @@ CronCreate:
   durable: true
   name: "reminder-check"
   sessionTarget: isolated
-  model: litellm/claude-haiku-4-5
+  model: litellm/gemma4
   payload:
     kind: agentTurn
   timeout-seconds: 60
 ```
 
-This job runs as an isolated Haiku session. It is query-only: it runs the check script, which writes the reminder handoff file (default filename: `.reminder-signal`, overridable via `REMINDER_SIGNAL_FILE` in `.env`) if any reminders are due, and then exits. It does not deliver reminders to the user.
+This job runs as an isolated cron session on `litellm/gemma4`. It is query-only: it runs the check script, which writes the reminder handoff file (default filename: `.reminder-signal`, overridable via `REMINDER_SIGNAL_FILE` in `.env`) if any reminders are due, and then exits. It does not deliver reminders to the user.
 
 **Reminder delivery** is handled separately by two mechanisms:
 1. **AGENTS.md step 5** (opportunistic): every time the user interacts, the main session checks for the handoff file and delivers immediately.
@@ -24,7 +24,7 @@ This job runs as an isolated Haiku session. It is query-only: it runs the check 
 
 Both delivery paths validate the handoff file before sending anything: it must be JSON with a `reminders` array where each entry is an object with string `page_id`, non-empty string `title`, and `status` exactly `sent` or `missed`. Any other shape or status makes the handoff malformed, so the delivering session leaves the file in place, does not deliver any entries, does not call `complete-reminder`, and does not delete the handoff file. For a valid handoff, the delivering session sends each reminder to Signal using the OpenClaw `message` tool (`action: send`, `channel: signal`), then calls `scripts/notion-cli.sh complete-reminder PAGE_ID sent|missed` to atomically set Notion `Status` to `Completed`, `Reminder Status` to `sent` or `missed`, and `Completed At`.
 
-This separation is a deliberate design choice. The previous architecture ran reminder-check on `sessionTarget: main`, which loaded the full Opus agent context (~200k tokens) for a job that 95% of the time just runs a script and finds nothing. Moving to isolated Haiku cuts per-run cost by orders of magnitude. The trade-off is that fully idle worst-case delivery latency is now up to about 75 minutes: up to 15 minutes for this cron to write the handoff file, then up to another 60 minutes for heartbeat to deliver it if the user does not interact first. In practice, many reminders still deliver on the next user interaction. The current system already can't interrupt mid-conversation (cron only fires when the REPL is idle), so the practical difference is small.
+This separation is a deliberate design choice. The previous architecture ran reminder-check on `sessionTarget: main`, which loaded the full Opus agent context (~200k tokens) for a job that 95% of the time just runs a script and finds nothing. Moving to isolated cron sessions on `litellm/gemma4` cuts per-run cost by orders of magnitude. The trade-off is that fully idle worst-case delivery latency is now up to about 75 minutes: up to 15 minutes for this cron to write the handoff file, then up to another 60 minutes for heartbeat to deliver it if the user does not interact first. In practice, many reminders still deliver on the next user interaction. The current system already can't interrupt mid-conversation (cron only fires when the REPL is idle), so the practical difference is small.
 
 The handoff file is also the current durability boundary. OpenClaw does not currently provide a post-announce delivery acknowledgment hook, so an announce-only cron flow cannot safely call `complete-reminder` before delivery without risking permanent reminder loss if the turn crashes after the Notion PATCH but before user-facing delivery completes. Until that hook exists, this job stays query-only.
 

--- a/setup/openclaw.json.template
+++ b/setup/openclaw.json.template
@@ -39,6 +39,14 @@
             "maxTokens": 8192
           },
           {
+            "id": "gemma4",
+            "name": "Gemma 4",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 200000,
+            "maxTokens": 4096
+          },
+          {
             "id": "claude-haiku-4-5",
             "name": "Claude Haiku 4.5",
             "reasoning": false,


### PR DESCRIPTION
Resolves #431

## Summary
- update HEARTBEAT.md cron health and drift-check references from `litellm/claude-haiku-4-5` to `litellm/gemma4`
- replace stale "isolated Haiku" wording in the heartbeat docs with Gemma-neutral or Gemma-specific cron wording
- align the related cron spec and architecture docs so the published cron contract stays internally consistent

## Test Plan
- run `shellcheck scripts/*.sh`
- run `yamllint .github/workflows/*.yml`
- grep the touched docs for stale `claude-haiku-4-5` cron references
- verify local markdown links in the touched docs resolve

Generated with Codex