### PR TITLE
Align cron specs and docs with gemma4

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,8 +42,8 @@ flowchart TB
     Messaging <-->|OpenClaw routing| AI
     AI <-->|CRUD operations| Scripts
     Scripts <-->|REST API| Notion
-    ReminderCron -->|Isolated Haiku: query reminders| Scripts
-    PullMainCron -->|Isolated Haiku: pull workspace| Scripts
+    ReminderCron -->|Isolated cron: query reminders| Scripts
+    PullMainCron -->|Isolated cron: pull workspace| Scripts
     Heartbeat -->|Health checks + reminder delivery| AI
 ```
 
@@ -60,7 +60,7 @@ No standalone server. OpenClaw agent *is* the application. It:
 6. **Celebrates completions** with immediate positive reinforcement
 7. **Delivers scheduled reminders** even when chat is idle
 
-Interactive conversations: surface-agnostic. Durable cron jobs: isolated Haiku sessions for cost efficiency — execute scripts, write handoff files, no user-facing messages. Reminder delivery via heartbeat (every 60 min) and main-session startup check (AGENTS.md step 5, on every user interaction). All cron jobs silent when nothing actionable.
+Interactive conversations: surface-agnostic. Durable cron jobs: isolated cron sessions for cost efficiency — execute scripts, write handoff files, no user-facing messages. Reminder delivery via heartbeat (every 60 min) and main-session startup check (AGENTS.md step 5, on every user interaction). All cron jobs silent when nothing actionable.
 
 ## Component Architecture
 
@@ -199,7 +199,7 @@ OpenClaw agent: stateless between messages — no persistent process checks cloc
 
 ```mermaid
 sequenceDiagram
-    participant Cron as Isolated Haiku Cron<br/>(every 15 min)
+    participant Cron as Isolated Cron<br/>(every 15 min)
     participant Script as check-reminders.sh
     participant Notion as Notion API
     participant Signal as .reminder-signal
@@ -227,7 +227,7 @@ sequenceDiagram
 **How it works:**
 
 1. At task intake, AI detects reminder language (e.g., "remind me at 6pm PT to call Sarah"), sets `is_reminder = true`, `remind_at` (full ISO 8601 with timezone), `reminder_status = pending`.
-2. Durable cron (`reminder-check`) runs every 15 min as isolated Haiku session via OpenClaw native scheduling.
+2. Durable cron (`reminder-check`) runs every 15 min as isolated cron session via OpenClaw native scheduling.
 3. Cron runs `scripts/check-reminders.sh` — queries Notion for pending reminders where `remind_at <= now`.
 4. Due reminders found → `check-reminders.sh` writes reminder handoff file in repo root (default: `.reminder-signal`, overridable via `REMINDER_SIGNAL_FILE` in `.env`). Isolated cron exits `NO_REPLY` — no reminder delivery.
 5. Delivery via two mechanisms:
@@ -237,7 +237,7 @@ sequenceDiagram
 6. Reminders >15 min past due flagged `missed`, still delivered with shame-safe note: `This was due a bit ago — [task]. Want to handle it now or reschedule?`
 7. Cron only fires when agent idle — won't interrupt mid-task. Better for ADHD focus.
 
-Both `reminder-check` and `pull-main` use `sessionTarget: isolated` with `model: litellm/claude-haiku-4-5` and `payload.kind: agentTurn`. Deliberate design: previous architecture ran both on `sessionTarget: main`, loaded full Opus context for routine script work, burned ~18M tokens per 6 hours. Isolated cron cuts per-run cost by orders of magnitude. Trade-off: delivery deferred to next user interaction or heartbeat; fully idle case = up to ~75 min delay (discovery and delivery on separate schedules). If reminder delivery fails after handoff file written: fail visibly, leave file, don't mark `sent` or `missed` until delivery succeeds.
+Both `reminder-check` and `pull-main` use `sessionTarget: isolated` with `model: litellm/gemma4` and `payload.kind: agentTurn`. Deliberate design: previous architecture ran both on `sessionTarget: main`, loaded full Opus context for routine script work, burned ~18M tokens per 6 hours. Isolated cron cuts per-run cost by orders of magnitude. Trade-off: delivery deferred to next user interaction or heartbeat; fully idle case = up to ~75 min delay (discovery and delivery on separate schedules). If reminder delivery fails after handoff file written: fail visibly, leave file, don't mark `sent` or `missed` until delivery succeeds.
 
 Deferred-delivery handoff = correctness constraint, not just implementation detail. OpenClaw has no post-announce delivery acknowledgment hook. Announce-only cron would mutate Notion before platform confirms delivery — cron crash or transport failure drops reminders permanently by moving them out of `pending` query set before delivery completes.
 
@@ -255,7 +255,7 @@ Deferred-delivery handoff = correctness constraint, not just implementation deta
 | Messaging | OpenClaw Surfaces | Interactive chat multi-channel (web, Signal, Telegram, Discord); reminder delivery via heartbeat + main-session startup check |
 | CI/CD | GitHub Actions | Multi-agent review pipeline; GitHub-hosted gate jobs handle untrusted dispatch, self-hosted Codex reviewers inherit homelab proxy and VLAN restrictions |
 | Scripts | Bash + curl | Minimal dependencies, runs anywhere |
-| Scheduled Reminders | OpenClaw durable cron + check-reminders.sh | Isolated Haiku cron every 15 min writes `.reminder-signal`; heartbeat (60 min) + startup check deliver |
+| Scheduled Reminders | OpenClaw durable cron + check-reminders.sh | Isolated cron every 15 min writes `.reminder-signal`; heartbeat (60 min) + startup check deliver |
 | Workspace Sync | OpenClaw durable cron + pull-main.sh | Native cron every 10 min keeps workspace current, recovers dirty pulls |
 | Image Generation | OpenAI gpt-image-1 | Unique AI images for reward novelty |
 | Video | ffmpeg | Weekly recap compilation |

--- a/docs/heartbeat-checks.md
+++ b/docs/heartbeat-checks.md
@@ -19,7 +19,7 @@ Verify durable cron jobs registered. Re-register any missing.
 | reminder-check | `*/15 * * * *` | Run `scripts/check-reminders.sh` (query-only; writes reminder handoff if reminders due) |
 | pull-main | `*/10 * * * *` | Run `scripts/pull-main.sh`; script handles dirty-pull recovery |
 
-Check via CronList. Missing (7-day auto-expiry) → re-create with CronCreate (durable: true) using schedule, prompt, options from `setup/cron/`. Both jobs: `sessionTarget: isolated`, `model: litellm/claude-haiku-4-5`, `payload.kind: agentTurn`, `timeout-seconds: 60`. Cron jobs never deliver directly to Signal or other channels.
+Check via CronList. Missing (7-day auto-expiry) → re-create with CronCreate (durable: true) using schedule, prompt, options from `setup/cron/`. Both jobs: `sessionTarget: isolated`, `model: litellm/gemma4`, `payload.kind: agentTurn`, `timeout-seconds: 60`. Cron jobs never deliver directly to Signal or other channels.
 
 ### 2b. Cron Spec Drift Check
 For each registered cron job (`reminder-check`, `pull-main`), compare live registration against canonical `CronCreate` spec in `setup/cron/<name>.md`.
@@ -32,7 +32,7 @@ Compare + correct these fields:
 - `schedule`
 - `prompt`
 - `sessionTarget` (canonical: `isolated` both jobs)
-- `model` (canonical: `litellm/claude-haiku-4-5` both jobs)
+- `model` (canonical: `litellm/gemma4` both jobs)
 - direct-delivery routing: live `to` if present (should not exist)
 - payload: canonical `payload.kind`
 - `timeout-seconds`
@@ -40,8 +40,8 @@ Compare + correct these fields:
 Stale `pipeline-monitor` cron still registered → delete with CronDelete (job removed).
 
 Field differs from spec → patch with CronUpdate. Identity field (`name`, `durable`) can't be safely changed → delete + re-create from spec. Intended contract:
-- `reminder-check`: `name`, `durable`, `schedule`, `prompt`, `sessionTarget: isolated`, `model: litellm/claude-haiku-4-5`, no `to`, `payload.kind: agentTurn`, `timeout-seconds: 60`
-- `pull-main`: `name`, `durable`, `schedule`, `prompt`, `sessionTarget: isolated`, `model: litellm/claude-haiku-4-5`, no `to`, `payload.kind: agentTurn`, `timeout-seconds: 60`
+- `reminder-check`: `name`, `durable`, `schedule`, `prompt`, `sessionTarget: isolated`, `model: litellm/gemma4`, no `to`, `payload.kind: agentTurn`, `timeout-seconds: 60`
+- `pull-main`: `name`, `durable`, `schedule`, `prompt`, `sessionTarget: isolated`, `model: litellm/gemma4`, no `to`, `payload.kind: agentTurn`, `timeout-seconds: 60`
 
 All match → report nothing. Any corrected → note which + what drift fixed.
 

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -84,7 +84,7 @@ OpenClaw provides `CronCreate` for recurring agent prompts. `durable: true` = jo
 
 **7-day expiry problem:** Recurring cron jobs auto-expire after 7 days. Heartbeat catches this, re-registers missing jobs. Also corrects spec drift from manual hotfixes or stale re-registration prompts by comparing live job against canonical `CronCreate` block and patching mismatched fields. Platform constraint worked around, not feature chosen.
 
-**Current registration contract:** Both `reminder-check` and `pull-main` run as isolated Haiku sessions with `sessionTarget: isolated`, `model: litellm/claude-haiku-4-5`, `payload.kind: agentTurn`, `timeout-seconds: 60`. Deliberate: separates cheap query work from user-facing delivery. Previous architecture used `sessionTarget: main` — loaded full Opus context (~200k tokens) for routine script work. Isolated Haiku cuts per-run cost by orders of magnitude. Reminder delivery handled by heartbeat (Check 1 in `docs/heartbeat-checks.md`, every 60 min) and main-session startup check (AGENTS.md step 5, every user interaction). Fully idle worst-case delivery latency: ~75 min — up to 15 min for `reminder-check` to write handoff, then up to 60 min for heartbeat if no user interaction first. Cron prompts end with `NO_REPLY` — never produce user-facing output. Until OpenClaw exposes post-delivery acknowledgment hook, this split flow = durability boundary keeping failed deliveries retryable.
+**Current registration contract:** Both `reminder-check` and `pull-main` run as isolated cron sessions with `sessionTarget: isolated`, `model: litellm/gemma4`, `payload.kind: agentTurn`, `timeout-seconds: 60`. Deliberate: separates cheap query work from user-facing delivery. Previous architecture used `sessionTarget: main` — loaded full Opus context (~200k tokens) for routine script work. Isolated cron cuts per-run cost by orders of magnitude. Reminder delivery handled by heartbeat (Check 1 in `docs/heartbeat-checks.md`, every 60 min) and main-session startup check (AGENTS.md step 5, every user interaction). Fully idle worst-case delivery latency: ~75 min — up to 15 min for `reminder-check` to write handoff, then up to 60 min for heartbeat if no user interaction first. Cron prompts end with `NO_REPLY` — never produce user-facing output. Until OpenClaw exposes post-delivery acknowledgment hook, this split flow = durability boundary keeping failed deliveries retryable.
 
 Isolated cron sessions intentionally narrow. Script runners, not substitute for main agent or heartbeat control paths. Detailed ownership split in [Agent Capabilities](agent-capabilities.md).
 
@@ -95,7 +95,7 @@ For production, use these timings unless clear reason to pay for tighter polling
 | Mechanism | Recommended cadence | Why |
 |-----------|---------------------|-----|
 | Heartbeat | Every 60 minutes | Reminder-delivery backstop plus cron expiry, spec drift, and Notion/env health |
-| `reminder-check` | Every 15 minutes | Isolated Haiku query; writes `.reminder-signal` for heartbeat/startup delivery |
+| `reminder-check` | Every 15 minutes | Isolated cron query; writes `.reminder-signal` for heartbeat/startup delivery |
 | `pull-main` | Every 10 minutes | Cheap script-only sync path; keeps workspace fresh |
 
 Core principle: `reminder-check` controls when due reminders discovered; heartbeat part of idle-user delivery path. 15-min polling + hourly heartbeat = default production cost/latency tradeoff. Exact-time delivery not guaranteed in current deferred-delivery architecture; fully idle worst-case ~75 min unless user interacts sooner.
@@ -122,7 +122,7 @@ Primary deployed surface: Signal. OpenClaw handles:
 - Acknowledgment reactions
 - Session scoping (per-channel-peer)
 
-**Our role:** Zero for transport mechanics. We write conversational responses; OpenClaw delivers them. Interactive conversations use normal main-agent routing. Cron jobs = isolated Haiku sessions (query-only, no user delivery). Reminder delivery reaches user through heartbeat and main-session startup check.
+**Our role:** Zero for transport mechanics. We write conversational responses; OpenClaw delivers them. Interactive conversations use normal main-agent routing. Cron jobs = isolated cron sessions (query-only, no user delivery). Reminder delivery reaches user through heartbeat and main-session startup check.
 
 ## Model Routing (LiteLLM Proxy)
 
@@ -144,7 +144,7 @@ OpenClaw supports multiple model providers. We route through LiteLLM proxy on Ta
 
 - **Primary model:** Claude Opus 4.6 (conversations, task management)
 - **Heartbeat model:** Claude Sonnet 4.6 (routine checks, cheaper)
-- **Cron model:** Claude Haiku 4.5 (isolated cron — reminder polling, workspace sync)
+- **Cron model:** Gemma 4 (isolated cron — reminder polling, workspace sync)
 - **Fallback chain:** Opus → Sonnet → GPT-5.4
 
 **Our role:** No direct interaction with model selection. Prompts in `docs/ai-prompts.md` model-agnostic. OpenClaw picks model from config.

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -946,7 +946,7 @@ flowchart TD
 
 | Property | Normal Task | Reminder Task |
 |----------|-------------|---------------|
-| Selection | User requests → AI suggests | Isolated Haiku `reminder-check` writes reminder handoff file; delivered by heartbeat (60 min) or main-session startup check (next user interaction) |
+| Selection | User requests → AI suggests | Isolated `reminder-check` writes reminder handoff file; delivered by heartbeat (60 min) or main-session startup check (next user interaction) |
 | Lifecycle | Pending → In Progress → Completed | Pending → Completed (`Reminder Status` becomes `sent` or `missed`) |
 | Check-ins | Timer-based follow-ups | None (single delivery) |
 | Rejection | User can reject suggestion | N/A (delivered once) |

--- a/docs/user-interactions.md
+++ b/docs/user-interactions.md
@@ -744,7 +744,7 @@ Reminders = tasks with specific wall-clock delivery time. Unlike check-ins (acti
 
 ```mermaid
 sequenceDiagram
-    participant Cron as Isolated Haiku Cron
+    participant Cron as Isolated Cron
     participant Scr as check-reminders.sh
     participant Notion as Notion API
     participant Signal as .reminder-signal
@@ -769,7 +769,7 @@ sequenceDiagram
     end
 ```
 
-`reminder-check` cron runs as isolated Haiku session — query-only, no delivery. Delivery via two paths: main-session startup check (AGENTS.md step 5, on every user interaction) and heartbeat (Check 1 in `docs/heartbeat-checks.md`, every 60 min). Both validate handoff is JSON with `reminders` array where each entry has string `page_id`, non-empty string `title`, `status` exactly `sent` or `missed`. Wrong shape or status = malformed, file stays, nothing delivered/completed/deleted. Delivery failure = file stays for retry.
+`reminder-check` cron runs as isolated cron session — query-only, no delivery. Delivery via two paths: main-session startup check (AGENTS.md step 5, on every user interaction) and heartbeat (Check 1 in `docs/heartbeat-checks.md`, every 60 min). Both validate handoff is JSON with `reminders` array where each entry has string `page_id`, non-empty string `title`, `status` exactly `sent` or `missed`. Wrong shape or status = malformed, file stays, nothing delivered/completed/deleted. Delivery failure = file stays for retry.
 
 ### Reminder Delivery Messages
 

--- a/setup/README.md
+++ b/setup/README.md
@@ -112,6 +112,25 @@ git pull origin main
 
 The agent reads docs on every interaction, so changes take effect immediately. No restart needed unless `openclaw.json` changed.
 
+### Upgrading from Haiku-based cron config
+
+If your `~/.openclaw/openclaw.json` was deployed before this change, it still defines `claude-haiku-4-5` as the cron model and does not include a `gemma4` entry. The heartbeat drift check will try to re-register `reminder-check` and `pull-main` with `litellm/gemma4` — if that model is not in your live config, cron re-registration fails and reminders and workspace sync stop working.
+
+Before the next heartbeat runs, add this entry to the `models` array in `~/.openclaw/openclaw.json`:
+
+```json
+{
+  "id": "gemma4",
+  "name": "Gemma 4",
+  "reasoning": false,
+  "input": ["text"],
+  "contextWindow": 200000,
+  "maxTokens": 4096
+}
+```
+
+After editing `openclaw.json`, restart the agent for the new model to be available.
+
 ## Contributor Hooks
 
 Install hooks in every worktree before committing:

--- a/setup/cron/pull-main.md
+++ b/setup/cron/pull-main.md
@@ -10,13 +10,13 @@ CronCreate:
   durable: true
   name: "pull-main"
   sessionTarget: isolated
-  model: litellm/claude-haiku-4-5
+  model: litellm/gemma4
   payload:
     kind: agentTurn
   timeout-seconds: 60
 ```
 
-Isolated Haiku maintenance session. Executes `scripts/pull-main.sh`, stays silent (`NO_REPLY`). Cron spec re-application after pulls handled by heartbeat drift correction (`docs/heartbeat-checks.md` Check 2b), not this job — isolated session can't reliably call CronList/CronUpdate.
+Isolated cron maintenance session. Executes `scripts/pull-main.sh`, stays silent (`NO_REPLY`). Cron spec re-application after pulls handled by heartbeat drift correction (`docs/heartbeat-checks.md` Check 2b), not this job — isolated session can't reliably call CronList/CronUpdate.
 
 ## Prompt
 

--- a/setup/cron/reminder-check.md
+++ b/setup/cron/reminder-check.md
@@ -10,13 +10,13 @@ CronCreate:
   durable: true
   name: "reminder-check"
   sessionTarget: isolated
-  model: litellm/claude-haiku-4-5
+  model: litellm/gemma4
   payload:
     kind: agentTurn
   timeout-seconds: 60
 ```
 
-Isolated Haiku session. Query-only: runs check script, writes handoff file (default: `.reminder-signal`, overridable via `REMINDER_SIGNAL_FILE` in `.env`) if reminders due, exits. Does not deliver.
+Isolated cron session. Query-only: runs check script, writes handoff file (default: `.reminder-signal`, overridable via `REMINDER_SIGNAL_FILE` in `.env`) if reminders due, exits. Does not deliver.
 
 **Reminder delivery** — two mechanisms:
 1. **AGENTS.md step 5** (opportunistic): main session checks handoff file on every user interaction.
@@ -24,7 +24,7 @@ Isolated Haiku session. Query-only: runs check script, writes handoff file (defa
 
 Both paths validate before sending: must be JSON with `reminders` array, each entry has string `page_id`, non-empty string `title`, `status` exactly `sent` or `missed`. Malformed → leave file, no delivery, no `complete-reminder` call, no delete. Valid → send each via OpenClaw `message` tool (`action: send`, `channel: signal`), then call `scripts/notion-cli.sh complete-reminder PAGE_ID sent|missed` to atomically set Notion `Status → Completed`, `Reminder Status → sent|missed`, `Completed At`.
 
-Deliberate design: old arch used `sessionTarget: main`, loaded full Opus context (~200k tokens) for a job that 95% finds nothing. Isolated Haiku cuts cost by orders of magnitude. Trade-off: idle worst-case latency ~75 min (15 min cron + 60 min heartbeat). In practice most reminders still deliver on next user interaction. Practical difference small — cron only fires when REPL idle anyway.
+Deliberate design: old arch used `sessionTarget: main`, loaded full Opus context (~200k tokens) for a job that 95% finds nothing. Isolated cron with `litellm/gemma4` cuts cost by orders of magnitude. Trade-off: idle worst-case latency ~75 min (15 min cron + 60 min heartbeat). In practice most reminders still deliver on next user interaction. Practical difference small — cron only fires when REPL idle anyway.
 
 Handoff file = durability boundary. OpenClaw lacks post-announce delivery ack hook, so announce-only flow can't safely call `complete-reminder` before delivery without risking loss on crash. Job stays query-only until hook exists.
 

--- a/setup/openclaw.json.template
+++ b/setup/openclaw.json.template
@@ -45,14 +45,6 @@
             "input": ["text"],
             "contextWindow": 200000,
             "maxTokens": 4096
-          },
-          {
-            "id": "claude-haiku-4-5",
-            "name": "Claude Haiku 4.5",
-            "reasoning": false,
-            "input": ["text"],
-            "contextWindow": 200000,
-            "maxTokens": 4096
           }
         ]
       }


### PR DESCRIPTION
Resolves #432

## Summary
- update the canonical cron specs in setup/cron/ from litellm/claude-haiku-4-5 to litellm/gemma4
- align HEARTBEAT and the related architecture/setup docs with the same cron registration contract
- replace stale "Haiku" wording with model-neutral "isolated cron" wording where the model name was not the important detail

## Test Plan
- run shellcheck scripts/*.sh
- run yamllint .github/workflows/*.yml
- run scripts/check-doc-links.sh

Generated with Codex
