### PR TITLE
Sync OpenClaw cron runtime contract

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,7 +23,7 @@ flowchart TB
     subgraph Scheduling["OpenClaw Scheduling"]
         Heartbeat[Heartbeat<br/>every 60m]
         ReminderCron[Reminder Cron<br/>every 15m]
-        PullMainCron[Pull-Main Cron<br/>every 10m]
+        PullMainCron[Pull-Main Cron<br/>every 30m]
     end
 
     subgraph Messaging["Messaging Surfaces"]
@@ -237,7 +237,7 @@ sequenceDiagram
 6. Reminders >15 min past due flagged `missed`, still delivered with shame-safe note: `This was due a bit ago — [task]. Want to handle it now or reschedule?`
 7. Cron only fires when agent idle — won't interrupt mid-task. Better for ADHD focus.
 
-Both `reminder-check` and `pull-main` use `sessionTarget: isolated` with `model: litellm/claude-haiku-4-5` and `payload.kind: agentTurn`. Deliberate design: previous architecture ran both on `sessionTarget: main`, loaded full Opus context for routine script work, burned ~18M tokens per 6 hours. Isolated cron cuts per-run cost by orders of magnitude. Trade-off: delivery deferred to next user interaction or heartbeat; fully idle case = up to ~75 min delay (discovery and delivery on separate schedules). If reminder delivery fails after handoff file written: fail visibly, leave file, don't mark `sent` or `missed` until delivery succeeds.
+Both `reminder-check` and `pull-main` use `sessionTarget: isolated` with `model: litellm/claude-haiku-4-5` and `payload.kind: agentTurn`. Canonical timeout for both jobs is 300 seconds; `reminder-check` keeps its 15-minute cadence, while `pull-main` runs every 30 minutes to reduce maintenance-session queue pressure. Deliberate design: previous architecture ran both on `sessionTarget: main`, loaded full Opus context for routine script work, burned ~18M tokens per 6 hours. Isolated cron cuts per-run cost by orders of magnitude, but slower models can still take multiple minutes to chew through injected workspace context, so the longer timeout avoids guaranteed retry storms. Trade-off: delivery deferred to next user interaction or heartbeat; fully idle case = up to ~75 min delay (discovery and delivery on separate schedules). If reminder delivery fails after handoff file written: fail visibly, leave file, don't mark `sent` or `missed` until delivery succeeds.
 
 Deferred-delivery handoff = correctness constraint, not just implementation detail. OpenClaw has no post-announce delivery acknowledgment hook. Announce-only cron would mutate Notion before platform confirms delivery — cron crash or transport failure drops reminders permanently by moving them out of `pending` query set before delivery completes.
 
@@ -256,7 +256,7 @@ Deferred-delivery handoff = correctness constraint, not just implementation deta
 | CI/CD | GitHub Actions | Multi-agent review pipeline; GitHub-hosted gate jobs handle untrusted dispatch, self-hosted Codex reviewers inherit homelab proxy and VLAN restrictions |
 | Scripts | Bash + curl | Minimal dependencies, runs anywhere |
 | Scheduled Reminders | OpenClaw durable cron + check-reminders.sh | Isolated Haiku cron every 15 min writes `.reminder-signal`; heartbeat (60 min) + startup check deliver |
-| Workspace Sync | OpenClaw durable cron + pull-main.sh | Isolated cron every 10 min keeps workspace current, recovers dirty pulls |
+| Workspace Sync | OpenClaw durable cron + pull-main.sh | Isolated cron every 30 min keeps workspace current, recovers dirty pulls |
 | Image Generation | OpenAI gpt-image-1 | Unique AI images for reward novelty |
 | Video | ffmpeg | Weekly recap compilation |
 

--- a/docs/heartbeat-checks.md
+++ b/docs/heartbeat-checks.md
@@ -21,9 +21,9 @@ Verify durable cron jobs registered. Re-register any missing.
 | Job | Schedule | Action |
 |-----|----------|--------|
 | reminder-check | `*/15 * * * *` | Run `scripts/check-reminders.sh` (query-only; writes reminder handoff if reminders due) |
-| pull-main | `*/10 * * * *` | Run `scripts/pull-main.sh`; script handles dirty-pull recovery |
+| pull-main | `*/30 * * * *` | Run `scripts/pull-main.sh`; script handles dirty-pull recovery |
 
-Check via CronList. Missing (7-day auto-expiry) → re-create with CronCreate (durable: true) using schedule, prompt, options from `setup/cron/`. Both jobs: `sessionTarget: isolated`, `model: litellm/claude-haiku-4-5`, `payload.kind: agentTurn`, `timeout-seconds: 60`. Cron jobs never deliver directly to Signal or other channels.
+Check via CronList. Missing (7-day auto-expiry) → re-create with CronCreate (durable: true) using schedule, prompt, options from `setup/cron/`. Both jobs: `sessionTarget: isolated`, `model: litellm/claude-haiku-4-5`, `payload.kind: agentTurn`, `timeout-seconds: 300`. Cron jobs never deliver directly to Signal or other channels.
 
 ### 2b. Cron Spec Drift Check
 For each registered cron job (`reminder-check`, `pull-main`), compare live registration against canonical `CronCreate` spec in `setup/cron/<name>.md`.
@@ -44,8 +44,8 @@ Compare + correct these fields:
 Stale `pipeline-monitor` cron still registered → delete with CronDelete (job removed).
 
 Field differs from spec → patch with CronUpdate. Identity field (`name`, `durable`) can't be safely changed → delete + re-create from spec. Intended contract:
-- `reminder-check`: `name`, `durable`, `schedule`, `prompt`, `sessionTarget: isolated`, `model: litellm/claude-haiku-4-5`, no `to`, `payload.kind: agentTurn`, `timeout-seconds: 60`
-- `pull-main`: `name`, `durable`, `schedule`, `prompt`, `sessionTarget: isolated`, `model: litellm/claude-haiku-4-5`, no `to`, `payload.kind: agentTurn`, `timeout-seconds: 60`
+- `reminder-check`: `name`, `durable`, `schedule`, `prompt`, `sessionTarget: isolated`, `model: litellm/claude-haiku-4-5`, no `to`, `payload.kind: agentTurn`, `timeout-seconds: 300`
+- `pull-main`: `name`, `durable`, `schedule: */30 * * * *`, `prompt`, `sessionTarget: isolated`, `model: litellm/claude-haiku-4-5`, no `to`, `payload.kind: agentTurn`, `timeout-seconds: 300`
 
 All match → report nothing. Any corrected → note which + what drift fixed.
 

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -74,7 +74,7 @@ OpenClaw provides `CronCreate` for recurring agent prompts. `durable: true` = jo
 | Job | Schedule | Replaces |
 |-----|----------|----------|
 | `reminder-check` | `*/15 * * * *` | `reminder-daemon.sh` (bash while-loop) |
-| `pull-main` | `*/10 * * * *` | Manual `git pull origin main` hygiene; cron drift correction now through heartbeat |
+| `pull-main` | `*/30 * * * *` | Manual `git pull origin main` hygiene; cron drift correction now through heartbeat |
 
 **Why better than daemons:**
 - No PID files, no silent death, no orphaned processes
@@ -84,7 +84,7 @@ OpenClaw provides `CronCreate` for recurring agent prompts. `durable: true` = jo
 
 **7-day expiry problem:** Recurring cron jobs auto-expire after 7 days. Heartbeat catches this, re-registers missing jobs. Also corrects spec drift from manual hotfixes or stale re-registration prompts by comparing live job against canonical `CronCreate` block and patching mismatched fields. Platform constraint worked around, not feature chosen.
 
-**Current registration contract:** Both `reminder-check` and `pull-main` run as isolated Haiku sessions with `sessionTarget: isolated`, `model: litellm/claude-haiku-4-5`, `payload.kind: agentTurn`, `timeout-seconds: 60`. Deliberate: separates cheap query work from user-facing delivery. Previous architecture used `sessionTarget: main` — loaded full Opus context (~200k tokens) for routine script work. Isolated Haiku cuts per-run cost by orders of magnitude. Reminder delivery handled by heartbeat (Check 1 in `docs/heartbeat-checks.md`, every 60 min) and main-session startup check (AGENTS.md step 5, every user interaction). Fully idle worst-case delivery latency: ~75 min — up to 15 min for `reminder-check` to write handoff, then up to 60 min for heartbeat if no user interaction first. Cron prompts end with `NO_REPLY` — never produce user-facing output. Until OpenClaw exposes post-delivery acknowledgment hook, this split flow = durability boundary keeping failed deliveries retryable.
+**Current registration contract:** Both `reminder-check` and `pull-main` run as isolated Haiku sessions with `sessionTarget: isolated`, `model: litellm/claude-haiku-4-5`, `payload.kind: agentTurn`, `timeout-seconds: 300`. `reminder-check` stays on `*/15`; `pull-main` runs on `*/30` to cut maintenance-session queue pressure without materially changing workspace freshness. Deliberate: separates cheap query work from user-facing delivery. Previous architecture used `sessionTarget: main` — loaded full Opus context (~200k tokens) for routine script work. Isolated Haiku cuts per-run cost by orders of magnitude, but larger workspace injections can still take multiple minutes on slower models, so the 5-minute timeout avoids retry pileups. Reminder delivery handled by heartbeat (Check 1 in `docs/heartbeat-checks.md`, every 60 min) and main-session startup check (AGENTS.md step 5, every user interaction). Fully idle worst-case delivery latency: ~75 min — up to 15 min for `reminder-check` to write handoff, then up to 60 min for heartbeat if no user interaction first. Cron prompts end with `NO_REPLY` — never produce user-facing output. Until OpenClaw exposes post-delivery acknowledgment hook, this split flow = durability boundary keeping failed deliveries retryable.
 
 Isolated cron sessions intentionally narrow. Script runners, not substitute for main agent or heartbeat control paths. Detailed ownership split in [Agent Capabilities](agent-capabilities.md).
 
@@ -96,7 +96,7 @@ For production, use these timings unless clear reason to pay for tighter polling
 |-----------|---------------------|-----|
 | Heartbeat | Every 60 minutes | Reminder-delivery backstop plus cron expiry, spec drift, and Notion/env health |
 | `reminder-check` | Every 15 minutes | Isolated Haiku query; writes `.reminder-signal` for heartbeat/startup delivery |
-| `pull-main` | Every 10 minutes | Cheap script-only sync path; keeps workspace fresh |
+| `pull-main` | Every 30 minutes | Cheap script-only sync path; keeps workspace fresh without unnecessary maintenance churn |
 
 Core principle: `reminder-check` controls when due reminders discovered; heartbeat part of idle-user delivery path. 15-min polling + hourly heartbeat = default production cost/latency tradeoff. Exact-time delivery not guaranteed in current deferred-delivery architecture; fully idle worst-case ~75 min unless user interacts sooner.
 

--- a/setup/README.md
+++ b/setup/README.md
@@ -96,10 +96,10 @@ The agent uses OpenClaw's durable cron system instead of bash daemons:
 | Job | Schedule | Purpose |
 |-----|----------|---------|
 | reminder-check | Every 15 min | Poll Notion for due reminders, write the reminder handoff file (delivery via heartbeat/startup check) |
-| pull-main | Every 10 min | Pull `origin/main` and recover from dirty tracked-file states |
+| pull-main | Every 30 min | Pull `origin/main` and recover from dirty tracked-file states |
 | heartbeat (built-in) | Every 60 min | System health, cron re-registration, cron drift correction, stranded reminder delivery, ops alerts to the separate operator Signal recipient |
 
-Cron jobs auto-expire after 7 days. The heartbeat re-registers missing jobs automatically and patches live cron jobs back to the `setup/cron/` specs if they drift. Both jobs run as isolated cron sessions (`sessionTarget: isolated`, `model: litellm/claude-haiku-4-5`, `payload.kind: agentTurn`).
+Cron jobs auto-expire after 7 days. The heartbeat re-registers missing jobs automatically and patches live cron jobs back to the `setup/cron/` specs if they drift. Both jobs run as isolated cron sessions (`sessionTarget: isolated`, `model: litellm/claude-haiku-4-5`, `payload.kind: agentTurn`, `timeout-seconds: 300`).
 
 Production recommendation: keep `reminder-check` at 15-minute cadence and heartbeat hourly as the default production cost/latency tradeoff for routine or low-stakes reminders. In the fully idle case, reminder delivery can take up to about 75 minutes under this deferred-delivery design, so exact-time reminders are not guaranteed unless the architecture changes.
 

--- a/setup/cron/pull-main.md
+++ b/setup/cron/pull-main.md
@@ -6,14 +6,14 @@ Keeps workspace synced with origin/main. Script-driven for Git hygiene: `scripts
 
 ```
 CronCreate:
-  schedule: "*/10 * * * *"
+  schedule: "*/30 * * * *"
   durable: true
   name: "pull-main"
   sessionTarget: isolated
   model: litellm/claude-haiku-4-5
   payload:
     kind: agentTurn
-  timeout-seconds: 60
+  timeout-seconds: 300
 ```
 
 Isolated Haiku maintenance session. Executes `scripts/pull-main.sh`, stays silent (`NO_REPLY`). Cron spec re-application after pulls handled by heartbeat drift correction (`docs/heartbeat-checks.md` Check 2b), not this job — isolated session can't reliably call CronList/CronUpdate.
@@ -44,4 +44,6 @@ If `HEAD` advanced during this invocation, reply with ONLY: NO_REPLY.
 - If `gh` auth missing, falls back to `GITHUB_PAT` from `.env` via `GH_TOKEN`. If neither available, leaves `.pull-dirty` for HEARTBEAT backstop (section 5) to retry via `scripts/pull-main.sh --recover-only` after auth restored. Until then, heartbeat preserves signal + surfaces problem for operator.
 - Cron jobs auto-expire after 7 days. Heartbeat (`docs/heartbeat-checks.md` Checks 2/2b) re-registers missing jobs + patches drift.
 - Post-pull cron spec re-application handled by heartbeat within next 60-minute cycle. Delay acceptable — cron spec changes rare, not user-facing.
+- 30-minute cadence trims queue pressure without materially changing repo freshness for this workspace.
+- 5-minute timeout leaves enough room for slower isolated sessions to finish instead of stacking retries.
 - GitHub issue preserves local changes for PR-based review before incorporation. Enforces design principle: structural/prompt changes go through external review.

--- a/setup/cron/reminder-check.md
+++ b/setup/cron/reminder-check.md
@@ -13,7 +13,7 @@ CronCreate:
   model: litellm/claude-haiku-4-5
   payload:
     kind: agentTurn
-  timeout-seconds: 60
+  timeout-seconds: 300
 ```
 
 Isolated Haiku session. Query-only: runs check script, writes handoff file (default: `.reminder-signal`, overridable via `REMINDER_SIGNAL_FILE` in `.env`) if reminders due, exits. Does not deliver.
@@ -39,5 +39,6 @@ Reply with ONLY: NO_REPLY
 
 - Cron auto-expires after 7 days. Heartbeat (`docs/heartbeat-checks.md` Checks 2/2b) re-registers if missing, patches if drifted.
 - 15-min polling = recommended cost/latency balance. Affects discovery only; idle delivery still depends on heartbeat or next interaction.
+- 5-minute timeout leaves enough room for slower full-workspace isolated sessions instead of forcing guaranteed retries on larger contexts.
 - Cron fires only when REPL idle. Mid-conversation → script waits. Better for ADHD — no mid-task interrupts.
 - `check-reminders.sh` queries Notion, writes `.reminder-signal`. Delivery not this job's responsibility.


### PR DESCRIPTION
Resolves #442

## Summary
- raise the canonical isolated cron timeout from 60 seconds to 300 seconds for both `reminder-check` and `pull-main`
- slow `pull-main` from every 10 minutes to every 30 minutes in the tracked cron specs and runtime docs
- sync heartbeat drift-check and setup/architecture docs with the current OpenClaw runtime contract, including stale `pipeline-monitor` cleanup coverage

## Test Plan
- shellcheck scripts/*.sh
- yamllint .github/workflows/*.yml
- bash scripts/check-doc-links.sh

Generated with Codex