### PR TITLE
Loosen fixer to handle grouped multi-file fixes

### DIFF
--- a/.github/scripts/review/prompts/fixer.md
+++ b/.github/scripts/review/prompts/fixer.md
@@ -40,11 +40,12 @@ Reflects current PR state, not push-time state.
    All yes → apply. Otherwise → skip with reason.
 
    **Grouped** (multi-file, same conceptual fix):
-   - Every file in the group explicitly named by a reviewer?
+   - Every blocker in the group has non-null `file` and `line`? Any unanchored blocker in the group → remove it from grouped handling and skip it unless it later passes the single-file gate; if no anchored uniform subset remains, skip group with reason.
+   - Every file in the grouped subset explicitly named by a reviewer?
    - Each per-file change small + local (≤ ~30 lines per file)?
    - Total group diff ≤ ~100 lines?
-   - Same mechanical change pattern across all files (wording swap, add/remove line, etc.) — not different logic per file?
-   All yes → pick canonical wording, apply uniformly across all files. No per-file improvisation unless structure requires (e.g., inline JSON placeholder vs. prose paragraph). Otherwise → skip group with reason.
+   - Same mechanical change pattern across all files (wording swap, add/remove line, etc.) — not different logic per file? If one file breaks uniformity, split it out, reevaluate the remaining files as a grouped subset, and treat the split file as an individual blocker under the single-file gate.
+   All yes → pick canonical wording, apply uniformly across all files. No per-file improvisation unless structure requires (e.g., inline JSON placeholder vs. prose paragraph). Otherwise → skip only the blocker or subset that fails, with reason.
 5. Apply fixes in working tree. Run tests reviewers explicitly suggested. No formatters or linters.
 6. Leave changes unstaged. No `git add`, `git commit`, `git push`. Host step commits working tree + computes new SHA.
 7. Write result JSON. Set `new_sha` to `${REVIEWED_SHA}` — host commit step patches real post-commit SHA before judge reads.

--- a/.github/scripts/review/prompts/fixer.md
+++ b/.github/scripts/review/prompts/fixer.md
@@ -16,7 +16,7 @@ Reflects current PR state, not push-time state.
 
 1. **Apply only what reviewers asked for.** Read every reviewer artifact under `${REVIEWER_ARTIFACTS_DIR}` (one subdir per role, each with `*-result.json`). Per `blocking_issues[]` + high-confidence `fix_suggestions[]`: decide if fix safe. Apply what you can.
 2. **No new scope.** No unrelated refactors, features, improvements. Unrelated bugs → leave, future PR.
-2a. **Cross-file consistency.** Same fix across files = uniform wording + structure. No per-file paraphrasing.
+2a. **Cross-file consistency.** Same fix across files = uniform wording + structure. No per-file paraphrasing. Grouped multi-file fixes must apply the same pattern to every file. If one file in the group needs different logic, split it out as individual and skip if it doesn't pass the single-file gate.
 3. **Deterministic CI fixes NOT your job.** Lint/format/typecheck/test repair = upstream CI. Lint failure found → abort + report.
 4. **Do NOT touch `.git/`.** No `git add`, `git commit`, `git push`, `git config`, `git rebase`, or any git-write command. Pipeline commits + pushes after exit — host runner owns `.git/`. Git-write inside container fails ("cannot update the ref 'HEAD'") — `.git/` bind-mounted under different UID, forcing commit corrupts `.git/config` for runner cleanup (see PR #409).
 5. **Read-only git fine.** `git diff`, `git log`, `git status`, `git show`, `git ls-files` all work. Container entrypoint sets `safe.directory=/workspace` — no need to add. Use freely.
@@ -29,12 +29,22 @@ Reflects current PR state, not push-time state.
    find "${REVIEWER_ARTIFACTS_DIR}" -name '*-result.json'
    ```
 2. No reviewer result files, or artifact unparseable → no edits. Write no-op fix result to `$OUTPUT_PATH` and stop.
-3. Per blocker (`role/id` pair), read `message`, `patch_hint` (from `fix_suggestions[]` if present), `file`/`line`. If `file` null, `line` null, or blocker doesn't bound change to one named file + one small local edit → skip with reason. Otherwise:
+3. **Scan + group.** Read ALL blockers from ALL reviewer artifacts first. Group blockers that share one conceptual fix — same root cause, same type of change needed across files (e.g., multiple reviewers flagging "docs say X but code says Y" in different files). Ungrouped blockers stay individual.
+4. **Safety gate.** Per group or individual blocker:
+
+   **Individual** (single file):
+   - `file` and `line` not null?
    - Safe from description alone?
    - Touches only reviewer-named file?
    - Small + local (≤ ~50 lines)?
    All yes → apply. Otherwise → skip with reason.
-4. **Group related blockers.** Scan all blockers first. Same conceptual change across files → group, pick canonical wording, apply identically. No per-file improvisation unless structure requires (e.g., inline JSON placeholder vs. prose paragraph).
+
+   **Grouped** (multi-file, same conceptual fix):
+   - Every file in the group explicitly named by a reviewer?
+   - Each per-file change small + local (≤ ~30 lines per file)?
+   - Total group diff ≤ ~100 lines?
+   - Same mechanical change pattern across all files (wording swap, add/remove line, etc.) — not different logic per file?
+   All yes → pick canonical wording, apply uniformly across all files. No per-file improvisation unless structure requires (e.g., inline JSON placeholder vs. prose paragraph). Otherwise → skip group with reason.
 5. Apply fixes in working tree. Run tests reviewers explicitly suggested. No formatters or linters.
 6. Leave changes unstaged. No `git add`, `git commit`, `git push`. Host step commits working tree + computes new SHA.
 7. Write result JSON. Set `new_sha` to `${REVIEWED_SHA}` — host commit step patches real post-commit SHA before judge reads.
@@ -48,9 +58,9 @@ Write fix-result JSON to `$OUTPUT_PATH`, conforming to `.github/scripts/review/s
   "schema_version": "1",
   "input_sha": "${REVIEWED_SHA}",
   "new_sha": "${REVIEWED_SHA}",
-  "addressed": ["security/sec-001", "docs/doc-003"],
+  "addressed": ["security/sec-001", "docs/doc-001", "docs/doc-003", "prompt/prm-001"],
   "skipped": [
-    { "id": "design/d-002", "reason": "fix touches three files; out of fixer scope" }
+    { "id": "design/d-002", "reason": "fix requires architectural redesign beyond fixer scope" }
   ]
 }
 ```

--- a/scripts/validate-model-refs.sh
+++ b/scripts/validate-model-refs.sh
@@ -196,6 +196,7 @@ check_contract_window \
   'never need updating when models change' \
   "customization section"
 
+# shellcheck disable=SC2016  # backticks are literal grep anchors, not command substitution
 check_contract_window \
   "docs/architecture.md" \
   'Both `reminder-check` and `pull-main` use `sessionTarget: isolated`' \


### PR DESCRIPTION
## Summary
- Reorders fixer procedure: scan + group ALL blockers first, then apply safety gates (previously, single-file gate in step 3 filtered out multi-file issues before grouping in step 4 could run)
- Adds grouped multi-file safety gate: all files reviewer-named, ≤30 lines/file, ≤100 lines total, same mechanical pattern
- Individual single-file fixes keep original gate (≤50 lines)
- Strengthens constraint 2a with grouped-fix contract

Motivated by PR #447 where 4 reviewers independently flagged the same conceptual issue across 5 files — fixer addressed 0/6 blockers despite the fix being a uniform wording swap.

## Test plan
- [ ] Review fixer.md prompt for clarity and unambiguous decision logic
- [ ] Mental simulation: PR #447 scenario (6 blockers, 5 files, uniform wording swap) → fixer should now group and apply
- [ ] Mental simulation: blocker requiring different logic per file → fixer should skip group
- [ ] Next PR that triggers the review pipeline will exercise the new fixer behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)