### PR TITLE
Update cheap-tier cron specs to gemma4-small

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -111,7 +111,7 @@ Model assignments use a tier system defined in `setup/openclaw.json.template` un
 |------|------|---------|
 | `expensive` | Primary interactive agent | `claude-opus-4-6` |
 | `medium` | Heartbeat, fallback | `claude-sonnet-4-6` |
-| `cheap` | Isolated cron jobs | `claude-haiku-4-5` |
+| `cheap` | Isolated cron jobs | `gemma4-small` |
 
 To remap tiers to your available models:
 

--- a/setup/README.md
+++ b/setup/README.md
@@ -5,7 +5,7 @@
 - **OpenClaw** installed and configured (`openclaw setup`)
 - **Notion** database created with the schema from `docs/notion-schema.md`
 - **Signal** account configured if Signal will be one of the interactive messaging surfaces
-- **LiteLLM proxy** (or direct Anthropic API access) for model routing
+- **LiteLLM proxy** for the default model routing (`gemma4-small` cheap tier plus Anthropic-backed medium/expensive tiers)
 
 ## Quick Start
 
@@ -112,6 +112,8 @@ Model assignments use a tier system defined in `setup/openclaw.json.template` un
 | `expensive` | Primary interactive agent | `claude-opus-4-6` |
 | `medium` | Heartbeat, fallback | `claude-sonnet-4-6` |
 | `cheap` | Isolated cron jobs | `gemma4-small` |
+
+Default setup assumes LiteLLM fronts every configured model. If you want a direct Anthropic-only install, that is a custom setup: remap `modelTiers.cheap` to an Anthropic model you can access, then update the cron `model:` lines and agent defaults to match before first run.
 
 To remap tiers to your available models:
 

--- a/setup/cron/pull-main.md
+++ b/setup/cron/pull-main.md
@@ -10,7 +10,7 @@ CronCreate:
   durable: true
   name: "pull-main"
   sessionTarget: isolated
-  model: litellm/claude-haiku-4-5  # must match modelTiers.cheap
+  model: litellm/gemma4-small  # must match modelTiers.cheap
   payload:
     kind: agentTurn
   timeout-seconds: 60

--- a/setup/cron/reminder-check.md
+++ b/setup/cron/reminder-check.md
@@ -10,7 +10,7 @@ CronCreate:
   durable: true
   name: "reminder-check"
   sessionTarget: isolated
-  model: litellm/claude-haiku-4-5  # must match modelTiers.cheap
+  model: litellm/gemma4-small  # must match modelTiers.cheap
   payload:
     kind: agentTurn
   timeout-seconds: 60

--- a/setup/openclaw.json.template
+++ b/setup/openclaw.json.template
@@ -69,7 +69,7 @@
   "modelTiers": {
     "expensive": "claude-opus-4-6",
     "medium": "claude-sonnet-4-6",
-    "cheap": "claude-haiku-4-5"
+    "cheap": "gemma4-small"
   },
   "agents": {
     "defaults": {


### PR DESCRIPTION
Resolves #452

## Summary
- update `modelTiers.cheap` in `setup/openclaw.json.template` to `gemma4-small`
- update the canonical `reminder-check` and `pull-main` cron specs to use `litellm/gemma4-small`
- refresh the setup docs so the documented cheap-tier default matches the canonical config

## Test Plan
- `shellcheck scripts/*.sh`
- `yamllint .github/workflows/*.yml`
- `bash scripts/validate-model-refs.sh`
- verify markdown relative links in `docs/` and `setup/`

Generated with Codex