### PR TITLE
Document envelopeTimezone as required setup step

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ cp ~/.openclaw/workspace/.env.template ~/.openclaw/workspace/.env
 cd ~/.openclaw/workspace && bash setup/bootstrap.sh
 ```
 
+When you create `~/.openclaw/openclaw.json`, set
+`agents.defaults.envelopeTimezone` to the same IANA timezone identifier used in
+`USER.md` (for example, `America/Chicago`). Without it, relative dates like
+"tomorrow" are resolved against UTC.
+
 See [setup/README.md](setup/README.md) for full setup instructions.
 
 ## Git hooks

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -28,6 +28,22 @@ OpenClaw loads via `bootstrap-extra-files` hook automatically. No special config
 
 **What we don't use:** `BOOT.md` (one-time gateway startup script). Could auto-register cron jobs, but heartbeat handles re-registration and `setup/bootstrap.sh` handles initial setup.
 
+## Envelope Timezone
+
+OpenClaw also reads `agents.defaults.envelopeTimezone` from `openclaw.json`.
+For hide-my-list, set that field during first setup to the same IANA timezone
+identifier stored in `USER.md` (for example, `America/Chicago`).
+
+Why it matters: OpenClaw injects a `Current time:` line into each prompt. If
+`envelopeTimezone` is unset, that line stays UTC-only, and the agent can reason
+about relative dates like "tomorrow" against the wrong calendar day for users
+outside UTC.
+
+Canonical setup path:
+- Put the user's timezone in `USER.md`
+- Copy that same TZ identifier into `setup/openclaw.json.template` when creating
+  `~/.openclaw/openclaw.json`
+
 ## Heartbeat
 
 OpenClaw heartbeat = built-in periodic trigger configured in `openclaw.json`:

--- a/setup/README.md
+++ b/setup/README.md
@@ -51,12 +51,34 @@
    bash setup/bootstrap.sh
    ```
 
+   Before continuing, make sure `USER.md` has the correct timezone line for the
+   user, including the IANA TZ identifier in parentheses, such as
+   `America/Chicago`.
+
 5. Configure OpenClaw:
    ```bash
    # Copy and customize the config template
    cp setup/openclaw.json.template ~/.openclaw/openclaw.json
    # Edit ~/.openclaw/openclaw.json — replace all {{PLACEHOLDER}} values
    ```
+
+   `agents.defaults.envelopeTimezone` is a required first-setup field. Set it to
+   the same IANA timezone identifier from `USER.md`.
+
+   Example:
+   ```json
+   {
+     "agents": {
+       "defaults": {
+         "envelopeTimezone": "America/Chicago"
+       }
+     }
+   }
+   ```
+
+   Without `envelopeTimezone`, OpenClaw injects `Current time:` in UTC, so the
+   agent can misread relative dates like "tomorrow" when the user's local date
+   differs from UTC.
 
 6. Start the gateway:
    ```bash
@@ -171,6 +193,13 @@ Manual regression playbook:
 **Agent not responding:**
 - Check `openclaw status` for channel health
 - Check gateway logs: `openclaw logs`
+
+**Relative dates land on the wrong day:**
+- Confirm `USER.md` has the correct IANA timezone identifier in the `Timezone`
+  line
+- Confirm `~/.openclaw/openclaw.json` sets `agents.defaults.envelopeTimezone` to
+  that same identifier
+- Restart the gateway after changing `openclaw.json`
 
 **Cron jobs disappeared:**
 - They auto-expire after 7 days. The next heartbeat (every 60 min) will re-register them.

--- a/setup/bootstrap.sh
+++ b/setup/bootstrap.sh
@@ -93,6 +93,11 @@ else
     echo "MEMORY.md already exists, skipping"
 fi
 
+USER_TZ_IDENTIFIER=""
+if [ -f "$ROOT_DIR/USER.md" ]; then
+    USER_TZ_IDENTIFIER="$(sed -n 's/^- \*\*Timezone:\*\* .* (\([^()]*\))$/\1/p' "$ROOT_DIR/USER.md" | head -n 1)"
+fi
+
 # --- Directories ---
 
 mkdir -p "$ROOT_DIR/memory"
@@ -123,6 +128,13 @@ if [ -f "$OPENCLAW_HOME/openclaw.json" ]; then
 else
     echo "NOTE: openclaw.json template is at setup/openclaw.json.template"
     echo "Copy it to $OPENCLAW_HOME/openclaw.json and fill in the {{PLACEHOLDER}} values."
+    echo "IMPORTANT: set agents.defaults.envelopeTimezone to the TZ identifier from USER.md."
+    if [ -n "$USER_TZ_IDENTIFIER" ]; then
+        echo "  Use: \"$USER_TZ_IDENTIFIER\""
+    else
+        echo "  Example: \"America/Chicago\""
+    fi
+    echo "  Without it, OpenClaw injects Current time in UTC and relative dates like \"tomorrow\" can land on the wrong day."
 fi
 echo ""
 

--- a/setup/openclaw.json.template
+++ b/setup/openclaw.json.template
@@ -80,6 +80,7 @@
         ]
       },
       "workspace": "{{OPENCLAW_HOME}}/workspace",
+      "envelopeTimezone": "{{TZ_IDENTIFIER}}",
       "compaction": {
         "mode": "safeguard"
       },


### PR DESCRIPTION
Resolves #455

## Summary
- add `agents.defaults.envelopeTimezone` to the canonical `setup/openclaw.json.template`
- document the first-setup requirement in `setup/README.md`, `docs/openclaw-integration.md`, and `README.md`
- surface the same requirement in `setup/bootstrap.sh` so operators copy the timezone identifier from `USER.md`

## Test Plan
- bash scripts/check-doc-links.sh
- shellcheck scripts/*.sh
- yamllint .github/workflows/*.yml

Generated with Codex