### PR TITLE
Move heartbeat model to cheap tier (gemma4-small)

### DIFF
--- a/docs/agent-capabilities.md
+++ b/docs/agent-capabilities.md
@@ -56,7 +56,7 @@ Tool availability does not override `AGENTS.md` safety policy. External actions 
 
 ## Heartbeat Session
 
-Short built-in OpenClaw session configured in `openclaw.json`, driven by `HEARTBEAT.md` (bootstrap stub that delegates to `docs/heartbeat-checks.md`). Runs every 60 minutes with lighter model than main agent.
+Short built-in OpenClaw session configured in `openclaw.json`, driven by `HEARTBEAT.md` (bootstrap stub that delegates to `docs/heartbeat-checks.md`). Runs every 60 minutes with cheap-tier model (`modelTiers.cheap`).
 
 ### Confirmed tool contract
 

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -51,11 +51,11 @@ OpenClaw heartbeat = built-in periodic trigger configured in `openclaw.json`:
 ```json
 "heartbeat": {
   "every": "60m",
-  "model": "litellm/<medium-tier model>"
+  "model": "litellm/<cheap-tier model>"
 }
 ```
 
-Every 60 min, OpenClaw creates short agent session, reads `HEARTBEAT.md`, executes checks. Uses the lighter medium-tier model from `setup/openclaw.json.template` (`agents.defaults.heartbeat.model`, which must match `modelTiers.medium`) for routine operational tasks. Reminder delivery not via `heartbeat.target`; Check 1 sends reminders explicitly with OpenClaw `message` tool (`action: send`, `channel: signal`). `target` field only controls where generic non-`HEARTBEAT_OK` output routes; without it, defaults to `"none"`, silently discarded ([openclaw/openclaw#29215](https://github.com/openclaw/openclaw/issues/29215)).
+Every 60 min, OpenClaw creates short agent session, reads `HEARTBEAT.md`, executes checks. Uses the cheap-tier model from `setup/openclaw.json.template` (`agents.defaults.heartbeat.model`, which must match `modelTiers.cheap`) for routine operational tasks — heartbeat checks are scripted health checks that don't need reasoning. Reminder delivery not via `heartbeat.target`; Check 1 sends reminders explicitly with OpenClaw `message` tool (`action: send`, `channel: signal`). `target` field only controls where generic non-`HEARTBEAT_OK` output routes; without it, defaults to `"none"`, silently discarded ([openclaw/openclaw#29215](https://github.com/openclaw/openclaw/issues/29215)).
 
 **Our usage:** Two roles:
 1. **Reminder-delivery backstop:** Isolated `reminder-check` cron only writes `.reminder-signal` — no user delivery. Heartbeat Check 1 reads stranded signal files, validates, delivers to Signal via `message` tool every 60 min. (AGENTS.md startup check provides faster opportunistic delivery when user active.)
@@ -159,10 +159,10 @@ OpenClaw supports multiple model providers. We route through LiteLLM proxy on Ta
 }
 ```
 
-Canonical model list and tier mappings live in `setup/openclaw.json.template` (see `modelTiers`). `scripts/validate-model-refs.sh` enforces that every `litellm/<id>` reference in classifier-listed spec files resolves against that list, that tier mappings are consistent with agent config (including `agents.defaults.heartbeat.model` matching `modelTiers.medium`), and that cron specs plus sibling docs stay aligned with the cheap tier contract.
+Canonical model list and tier mappings live in `setup/openclaw.json.template` (see `modelTiers`). `scripts/validate-model-refs.sh` enforces that every `litellm/<id>` reference in classifier-listed spec files resolves against that list, that tier mappings are consistent with agent config (including `agents.defaults.heartbeat.model` matching `modelTiers.cheap`), and that cron specs plus sibling docs stay aligned with the cheap tier contract.
 
 - **Primary model (expensive tier):** Whatever `modelTiers.expensive` maps to for conversations and task management
-- **Heartbeat model (medium tier):** Whatever `modelTiers.medium` maps to for routine checks and fallback
+- **Heartbeat model (cheap tier):** Whatever `modelTiers.cheap` maps to for routine health checks
 - **Cron model (cheap tier):** Whatever `modelTiers.cheap` maps to for isolated cron work such as reminder polling and workspace sync
 - **Codex CLI model:** GPT-5.4, configured separately in `.codex/config.toml` via `.devcontainer/configure-codex.sh`; not served through the OpenClaw models array above.
 

--- a/scripts/validate-model-refs.sh
+++ b/scripts/validate-model-refs.sh
@@ -6,7 +6,7 @@
 #      file registered by review-classify's is_spec_md() must resolve in
 #      setup/openclaw.json.template's models array.
 #   2) Tier-config consistency: modelTiers in the template must match
-#      agents.defaults (expensive=primary, medium=heartbeat+fallback).
+#      agents.defaults (expensive=primary, medium=fallback, cheap=heartbeat).
 #   3) Cron-tier agreement: cron spec files must use the cheap-tier model
 #      from modelTiers, and sibling docs' cron-contract sections must point
 #      back to the canonical setup/cron specs instead of drifting.
@@ -129,10 +129,10 @@ elif [[ "$fallback_model" != "litellm/$tier_medium" ]]; then
   tier_errors+=("agents.defaults.model.fallbacks[0] = $fallback_model, expected litellm/$tier_medium (medium tier)")
 fi
 
-# Check agents.defaults.heartbeat.model matches medium tier
+# Check agents.defaults.heartbeat.model matches cheap tier
 heartbeat_model="$(grep -oE '"model":[[:space:]]*"litellm/[^"]+"' "$TEMPLATE" | tail -1 | grep -oE 'litellm/[^"]+')"
-if [[ "$heartbeat_model" != "litellm/$tier_medium" ]]; then
-  tier_errors+=("agents.defaults.heartbeat.model = $heartbeat_model, expected litellm/$tier_medium (medium tier)")
+if [[ "$heartbeat_model" != "litellm/$tier_cheap" ]]; then
+  tier_errors+=("agents.defaults.heartbeat.model = $heartbeat_model, expected litellm/$tier_cheap (cheap tier)")
 fi
 
 # --- Invariant 3: cron-tier agreement -----------------------------------

--- a/setup/README.md
+++ b/setup/README.md
@@ -132,8 +132,8 @@ Model assignments use a tier system defined in `setup/openclaw.json.template` un
 | Tier | Role | Default |
 |------|------|---------|
 | `expensive` | Primary interactive agent | `claude-opus-4-6` |
-| `medium` | Heartbeat, fallback | `claude-sonnet-4-6` |
-| `cheap` | Isolated cron jobs | `gemma4-small` |
+| `medium` | Fallback | `claude-sonnet-4-6` |
+| `cheap` | Heartbeat, isolated cron jobs | `gemma4-small` |
 
 Default setup assumes LiteLLM fronts every configured model. If you want a direct Anthropic-only install, that is a custom setup: remap `modelTiers.cheap` to an Anthropic model you can access, then update the cron `model:` lines and agent defaults to match before first run.
 
@@ -141,7 +141,7 @@ To remap tiers to your available models:
 
 1. Add your models to the `models[]` array in `setup/openclaw.json.template`
 2. Edit `modelTiers` values to point at your model IDs
-3. Update `agents.defaults` in the same file to match: `model.primary` = `litellm/<expensive>`, `model.fallbacks` = `[litellm/<medium>]`, `heartbeat.model` = `litellm/<medium>`
+3. Update `agents.defaults` in the same file to match: `model.primary` = `litellm/<expensive>`, `model.fallbacks` = `[litellm/<medium>]`, `heartbeat.model` = `litellm/<cheap>`
 4. Update `model:` lines in `setup/cron/reminder-check.md` and `setup/cron/pull-main.md` to `litellm/<cheap>`
 5. Run `bash scripts/validate-model-refs.sh` — catches drift between tiers, agent config, cron specs, and documented defaults
 

--- a/setup/cron/heartbeat-check.md
+++ b/setup/cron/heartbeat-check.md
@@ -7,7 +7,7 @@ Heartbeat = built-in OpenClaw feature, not a cron job. Configured in `openclaw.j
 ```json
 "heartbeat": {
   "every": "60m",
-  "model": "litellm/claude-sonnet-4-6"  // must match modelTiers.medium
+  "model": "litellm/gemma4-small"  // must match modelTiers.cheap
 }
 ```
 
@@ -24,7 +24,7 @@ Every 60 min, OpenClaw runs agent with `HEARTBEAT.md` as context. Agent performs
 5. Verify environment intact
 6. Pull main if flagged
 
-Uses medium-tier model — routine operational checks. Heartbeat also processes stranded handoff files; hourly cadence is part of production reminder-latency tradeoff.
+Uses cheap-tier model — routine operational checks don't need reasoning. Heartbeat also processes stranded handoff files; hourly cadence is part of production reminder-latency tradeoff.
 
 ## Notes
 

--- a/setup/openclaw.json.template
+++ b/setup/openclaw.json.template
@@ -86,7 +86,7 @@
       },
       "heartbeat": {
         "every": "60m",
-        "model": "litellm/claude-sonnet-4-6"
+        "model": "litellm/gemma4-small"
       },
       "maxConcurrent": 4,
       "subagents": {


### PR DESCRIPTION
## Summary
- Heartbeat was running `claude-sonnet-4-6` (medium tier) every 60 minutes for scripted health checks (file existence, cron registration, Notion pings) — no reasoning needed
- Changed `agents.defaults.heartbeat.model` to `litellm/gemma4-small` (cheap tier), matching what cron jobs already use
- Updated validation script, config template, and 4 docs to reflect the new tier assignment

## Operator action required
Update your live `~/.openclaw/openclaw.json` heartbeat model to `litellm/gemma4-small` and restart OpenClaw. The repo docs alone don't change the running instance config.

## Test plan
- [x] `scripts/validate-model-refs.sh` passes (tier-config consistency, cron-tier agreement, template membership)
- [x] `scripts/run-required-checks.sh ci-docs` passes (links, model refs, spec catalog, Mermaid)
- [x] `scripts/run-required-checks.sh ci-scripts` passes (shellcheck, permissions)
- [ ] Review pipeline validates cross-doc consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)