### PR TITLE
chore: update AI CLI pins

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -38,8 +38,8 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
     && rm -rf /var/lib/apt/lists/*
 
 # Pin AI CLI versions so Dockerfile, post-create script, and updater workflow stay in sync
-ARG CLAUDE_CODE_VERSION=2.1.104
-ARG CODEX_CLI_VERSION=0.120.0
+ARG CLAUDE_CODE_VERSION=2.1.114
+ARG CODEX_CLI_VERSION=0.121.0
 
 # Install Node.js LTS (needed for Claude Code plugins and Mermaid validation)
 ARG NODE_VERSION=20

--- a/.github/ci/versions.env
+++ b/.github/ci/versions.env
@@ -3,8 +3,8 @@
 # Keep in sync with `.devcontainer/Dockerfile` via its own ARG lines
 # (or remove the devcontainer dependency on pins once it stops pulling
 # from GHCR for local-dev speedups).
-CLAUDE_CODE_VERSION=2.1.104
-CODEX_CLI_VERSION=0.120.0
+CLAUDE_CODE_VERSION=2.1.114
+CODEX_CLI_VERSION=0.121.0
 ACTIONLINT_VERSION=1.7.7
 NODE_MAJOR=20
 # Canonical CI-only caveman rules in `.github/ci/caveman-rules.md`


### PR DESCRIPTION
Automated weekly update of the pinned AI CLI versions.

Updated in `.github/ci/versions.env` as the CI pin source and
mirrored into `.devcontainer/Dockerfile`'s ARG defaults for
the devcontainer image build.

- **Claude Code:** 2.1.104 → 2.1.114
- **Codex:** 0.120.0 → 0.121.0

🤖 Generated automatically by the `update-ai-clis` workflow.