### PR TITLE
Track config drift after template-changing pulls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ state.json
 .pr-signal
 .reminder-signal
 .pull-dirty
+.config-drift
 .pipeline-status
 .pipeline-last-state
 .pr-review-state.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@
    - Missed (>15 min late): note delay, no shame ("This was due a bit ago — [task]. Want to handle it now or reschedule?")
    - After delivery: run `scripts/notion-cli.sh complete-reminder PAGE_ID sent|missed` per item, then delete handoff file
    - If delivery fails: leave file for retry
+6. Check `.config-drift` flag (written by `scripts/pull-main.sh` only when `setup/openclaw.json.template` changed across a pull). Exists → read `agents.defaults.heartbeat` from template, `config.get` the same path from live config, `config.patch` if different, delete `.config-drift` on success. No user-facing note — this is background infrastructure hygiene, pre-authorized under Safety. `config.get`/`config.patch` fails: leave `.config-drift` in place, surface error, no silent retry. Template missing or parse fails: leave `.config-drift`, surface error. Scope narrow: only `agents.defaults.heartbeat` subtree syncs — deployment-local fields (gateway auth, channels, secrets) stay untouched.
 
 Then be ready. User might add task, ask what to do, say done, or chat.
 
@@ -114,7 +115,7 @@ Personalize prep using user preferences (beverage, comfort spot, rituals).
 - Don't show full task list. Core rule.
 - **NEVER touch firewall rules.** Critical security. No exceptions.
 - Don't exfiltrate data.
-- Ask before external actions. (Exception: reminder delivery to Signal pre-authorized — user consented at creation.)
+- Ask before external actions. (Exceptions: reminder delivery to Signal pre-authorized — user consented at creation. `config.patch` on `agents.defaults.heartbeat` for template-drift repair pre-authorized — narrow behavioral-defaults scope, no deployment secrets touched, gated on `.config-drift` flag from `pull-main`.)
 - `trash` > `rm`.
 
 ### Code & Prompt Changes (OpenClaw Agent Only)
@@ -127,7 +128,7 @@ Restrictions apply to **OpenClaw runtime agent** only — not Claude Code sessio
 - Infra & CI files outside restriction — but OpenClaw agent should still file issues; CI changes warrant review.
 - Restriction covers repo-managed content, not OpenClaw runtime features. Keep using OpenClaw heartbeat, durable cron, bootstrap loading, hooks, messaging as documented.
 - OpenClaw-owned runtime state (cron registrations, task records outside repo) not "managed content" under this rule.
-- Outside the self-contained dirty-pull recovery path in `scripts/pull-main.sh` (with `HEARTBEAT.md` only retrying stale `.pull-dirty` signals when recovery didn't complete), only files OpenClaw agent may write directly: `state.json`, `memory/`, `MEMORY.md`, `USER.md`, `.env`, repo-root reminder handoff file (default: `.reminder-signal`, overridable via `REMINDER_SIGNAL_FILE`), and temp `.reminder-signal-*.tmp` sibling in same dir for atomic replacement.
+- Outside the self-contained dirty-pull recovery path in `scripts/pull-main.sh` (with `HEARTBEAT.md` only retrying stale `.pull-dirty` signals when recovery didn't complete), only files OpenClaw agent may write directly: `state.json`, `memory/`, `MEMORY.md`, `USER.md`, `.env`, repo-root reminder handoff file (default: `.reminder-signal`, overridable via `REMINDER_SIGNAL_FILE`), temp `.reminder-signal-*.tmp` sibling in same dir for atomic replacement, and `.config-drift` (main agent deletes after successful config sync per step 6; `pull-main` writes it).
 
 ## Memory
 

--- a/scripts/pull-main.sh
+++ b/scripts/pull-main.sh
@@ -21,7 +21,38 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/load-github-auth.sh"
 
 SIGNAL_FILE="$ROOT_DIR/.pull-dirty"
+CONFIG_DRIFT_FILE="$ROOT_DIR/.config-drift"
+TEMPLATE_FILE="$ROOT_DIR/setup/openclaw.json.template"
 REPO="NickBorgersProbably/hide-my-list"
+
+# Hash the current on-disk template, or empty string if missing.
+template_hash() {
+    if [ -f "$TEMPLATE_FILE" ]; then
+        git hash-object "$TEMPLATE_FILE" 2>/dev/null || echo ""
+    else
+        echo ""
+    fi
+}
+
+# Write .config-drift flag if the template changed across a pull.
+# Writes AFTER git operations complete, so recovery-path `git clean -fd`
+# cannot delete an unconsumed flag — that was the blocker that closed PR #395.
+maybe_write_config_drift() {
+    local pre="$1" post="$2"
+    if [ -n "$post" ] && [ "$pre" != "$post" ]; then
+        DETECTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        PRE_SHA="$pre" \
+        POST_SHA="$post" \
+        python3 -c "
+import json, os
+print(json.dumps({
+    'detected_at': os.environ['DETECTED_AT'],
+    'pre_template_sha': os.environ['PRE_SHA'],
+    'post_template_sha': os.environ['POST_SHA'],
+}, indent=2))
+" > "$CONFIG_DRIFT_FILE" 2>/dev/null || true
+    fi
+}
 
 cd "$ROOT_DIR"
 
@@ -259,9 +290,15 @@ print(body)
 
     # Success — clean up
     rm -f "$SIGNAL_FILE"
+    maybe_write_config_drift "$PRE_TEMPLATE_HASH" "$(template_hash)"
 }
 
 # --- Flag parsing ---
+
+# Capture template hash before any git operation so both paths can detect
+# whether the pull changed setup/openclaw.json.template.
+PRE_TEMPLATE_HASH="$(template_hash)"
+export PRE_TEMPLATE_HASH
 
 if [ "${1:-}" = "--recover-only" ]; then
     recover_dirty_pull
@@ -286,6 +323,7 @@ pull_output=$(git pull origin main 2>&1) && pull_exit=0 || pull_exit=$?
 if [ "$pull_exit" -eq 0 ]; then
     # Clean pull — remove any stale signal from a prior run
     rm -f "$SIGNAL_FILE"
+    maybe_write_config_drift "$PRE_TEMPLATE_HASH" "$(template_hash)"
     exit 0
 fi
 


### PR DESCRIPTION
Resolves #465

## Summary
- write a `.config-drift` flag after `scripts/pull-main.sh` finishes a pull that changed `setup/openclaw.json.template`
- keep the flag write outside git cleanup paths so dirty-pull recovery does not delete it before the main agent can repair `agents.defaults.heartbeat`
- document the main-agent startup repair step and ignore `.config-drift` in git

## Test Plan
- `shellcheck scripts/*.sh`
- `yamllint .github/workflows/*.yml`
- repo-local markdown link check across `*.md` files, excluding template placeholders like `${RUN_URL}`

Generated with Codex