### PR TITLE
perf(heartbeat): trim bootstrap via lightContext + isolatedSession

### DIFF
--- a/docs/heartbeat-checks.md
+++ b/docs/heartbeat-checks.md
@@ -12,7 +12,11 @@
   OPS_ALERT_TARGET="$(bash -lc 'SCRIPT_DIR=$(cd "$(dirname scripts/check-reminders.sh)" && pwd); source "$SCRIPT_DIR/load-env.sh" OPS_ALERT_SIGNAL_NUMBER?; if [ -z "${OPS_ALERT_SIGNAL_NUMBER:-}" ]; then echo "missing OPS_ALERT_SIGNAL_NUMBER" >&2; exit 1; fi; printf "%s\n" "$OPS_ALERT_SIGNAL_NUMBER"')"
   ```
 - File = reminder handoff written by `scripts/check-reminders.sh`
-- If `HANDOFF_FILE` exists at heartbeat time: treat as undelivered. Read + validate (must be JSON with `reminders` array; each entry needs string `page_id`, non-empty string `title`, `status` exactly `sent` or `missed`; any other shape/status = malformed → leave file, send ops alert via `message` tool (`action: send`, `channel: signal`, `target: "$OPS_ALERT_TARGET"`) describing the malformed handoff, skip delivery/`complete-reminder`/delete). For each valid reminder: send via OpenClaw `message` tool (`action: send`, `channel: signal`), run `scripts/notion-cli.sh complete-reminder PAGE_ID sent|missed`, delete handoff file.
+- If `HANDOFF_FILE` exists at heartbeat time: treat as undelivered. Read + validate (must be JSON with `reminders` array; each entry needs string `page_id`, non-empty string `title`, `status` exactly `sent` or `missed`; any other shape/status = malformed → leave file, send ops alert via `message` tool (`action: send`, `channel: signal`, `target: "$OPS_ALERT_TARGET"`) describing the malformed handoff, skip delivery/`complete-reminder`/delete). For each valid reminder:
+  - `status: sent` = approximate/on-time reminder. Use casual wording: `Hey, time to [task]`.
+  - `status: missed` = reminder already >15 min late. Say that delay happened without blame: `This was due a bit ago — [task]. Want to handle it now or reschedule?`
+  - Keep reminder copy shame-safe. No guilt, criticism, "you forgot", "you should have", or pressure framing. Treat delay as timing info, not user failure.
+  - Send via OpenClaw `message` tool (`action: send`, `channel: signal`), run `scripts/notion-cli.sh complete-reminder PAGE_ID sent|missed`, delete handoff file.
 - Hourly delivery backstop. Isolated `reminder-check` cron only writes handoff — no delivery. Delivery here (every 60 min) + opportunistically via AGENTS.md startup check.
 
 ### 2. Cron Job Health

--- a/docs/heartbeat-checks.md
+++ b/docs/heartbeat-checks.md
@@ -12,7 +12,11 @@
   OPS_ALERT_TARGET="$(bash -lc 'SCRIPT_DIR=$(cd "$(dirname scripts/check-reminders.sh)" && pwd); source "$SCRIPT_DIR/load-env.sh" OPS_ALERT_SIGNAL_NUMBER?; if [ -z "${OPS_ALERT_SIGNAL_NUMBER:-}" ]; then echo "missing OPS_ALERT_SIGNAL_NUMBER" >&2; exit 1; fi; printf "%s\n" "$OPS_ALERT_SIGNAL_NUMBER"')"
   ```
 - File = reminder handoff written by `scripts/check-reminders.sh`
-- If `HANDOFF_FILE` exists at heartbeat time: treat as undelivered. Read + validate (must be JSON with `reminders` array; each entry needs string `page_id`, non-empty string `title`, `status` exactly `sent` or `missed`; any other shape/status = malformed → leave file, send ops alert via `message` tool (`action: send`, `channel: signal`, `target: "$OPS_ALERT_TARGET"`) describing the malformed handoff, skip delivery/`complete-reminder`/delete). For each valid reminder: send via OpenClaw `message` tool (`action: send`, `channel: signal`), run `scripts/notion-cli.sh complete-reminder PAGE_ID sent|missed`, delete handoff file.
+- If `HANDOFF_FILE` exists at heartbeat time: treat as undelivered. Read + validate (must be JSON with `reminders` array; each entry needs string `page_id`, non-empty string `title`, `status` exactly `sent` or `missed`; any other shape/status = malformed → leave file, send ops alert via `message` tool (`action: send`, `channel: signal`, `target: "$OPS_ALERT_TARGET"`) describing the malformed handoff, skip delivery/`complete-reminder`/delete). For each valid reminder:
+  - `status: sent` = approximate/on-time reminder. Casual wording: `Hey, time to [task]`.
+  - `status: missed` = reminder already >15 min late. Note delay without blame: `This was due a bit ago — [task]. Want to handle it now or reschedule?`
+  - Shame-safe: no guilt, criticism, "you forgot", "you should have", or pressure framing. Treat delay as timing info, not user failure. Required here because heartbeat runs with `lightContext: true` → no AGENTS.md in bootstrap, so this file is the only place the tone contract lives for heartbeat-delivered reminders.
+  - Send via OpenClaw `message` tool (`action: send`, `channel: signal`), run `scripts/notion-cli.sh complete-reminder PAGE_ID sent|missed`, delete handoff file.
 - Hourly delivery backstop. Isolated `reminder-check` cron only writes handoff — no delivery. Delivery here (every 60 min) + opportunistically via AGENTS.md startup check.
 
 ### 2. Cron Job Health

--- a/docs/heartbeat-checks.md
+++ b/docs/heartbeat-checks.md
@@ -12,11 +12,7 @@
   OPS_ALERT_TARGET="$(bash -lc 'SCRIPT_DIR=$(cd "$(dirname scripts/check-reminders.sh)" && pwd); source "$SCRIPT_DIR/load-env.sh" OPS_ALERT_SIGNAL_NUMBER?; if [ -z "${OPS_ALERT_SIGNAL_NUMBER:-}" ]; then echo "missing OPS_ALERT_SIGNAL_NUMBER" >&2; exit 1; fi; printf "%s\n" "$OPS_ALERT_SIGNAL_NUMBER"')"
   ```
 - File = reminder handoff written by `scripts/check-reminders.sh`
-- If `HANDOFF_FILE` exists at heartbeat time: treat as undelivered. Read + validate (must be JSON with `reminders` array; each entry needs string `page_id`, non-empty string `title`, `status` exactly `sent` or `missed`; any other shape/status = malformed → leave file, send ops alert via `message` tool (`action: send`, `channel: signal`, `target: "$OPS_ALERT_TARGET"`) describing the malformed handoff, skip delivery/`complete-reminder`/delete). For each valid reminder:
-  - `status: sent` = approximate/on-time reminder. Use casual wording: `Hey, time to [task]`.
-  - `status: missed` = reminder already >15 min late. Say that delay happened without blame: `This was due a bit ago — [task]. Want to handle it now or reschedule?`
-  - Keep reminder copy shame-safe. No guilt, criticism, "you forgot", "you should have", or pressure framing. Treat delay as timing info, not user failure.
-  - Send via OpenClaw `message` tool (`action: send`, `channel: signal`), run `scripts/notion-cli.sh complete-reminder PAGE_ID sent|missed`, delete handoff file.
+- If `HANDOFF_FILE` exists at heartbeat time: treat as undelivered. Read + validate (must be JSON with `reminders` array; each entry needs string `page_id`, non-empty string `title`, `status` exactly `sent` or `missed`; any other shape/status = malformed → leave file, send ops alert via `message` tool (`action: send`, `channel: signal`, `target: "$OPS_ALERT_TARGET"`) describing the malformed handoff, skip delivery/`complete-reminder`/delete). For each valid reminder: send via OpenClaw `message` tool (`action: send`, `channel: signal`), run `scripts/notion-cli.sh complete-reminder PAGE_ID sent|missed`, delete handoff file.
 - Hourly delivery backstop. Isolated `reminder-check` cron only writes handoff — no delivery. Delivery here (every 60 min) + opportunistically via AGENTS.md startup check.
 
 ### 2. Cron Job Health

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -51,11 +51,15 @@ OpenClaw heartbeat = built-in periodic trigger configured in `openclaw.json`:
 ```json
 "heartbeat": {
   "every": "60m",
-  "model": "litellm/<cheap-tier model>"
+  "model": "litellm/<cheap-tier model>",
+  "lightContext": true,
+  "isolatedSession": true
 }
 ```
 
-Every 60 min, OpenClaw creates short agent session, reads `HEARTBEAT.md`, executes checks. Uses the cheap-tier model from `setup/openclaw.json.template` (`agents.defaults.heartbeat.model`, which must match `modelTiers.cheap`) for routine operational tasks — heartbeat checks are scripted health checks that don't need reasoning. Reminder delivery not via `heartbeat.target`; Check 1 sends reminders explicitly with OpenClaw `message` tool (`action: send`, `channel: signal`). `target` field only controls where generic non-`HEARTBEAT_OK` output routes; without it, defaults to `"none"`, silently discarded ([openclaw/openclaw#29215](https://github.com/openclaw/openclaw/issues/29215)).
+Every 60 min, OpenClaw creates short agent session, reads `HEARTBEAT.md`, executes checks. Uses the cheap-tier model from `setup/openclaw.json.template` (`agents.defaults.heartbeat.model`, which must match `modelTiers.cheap`) for routine operational tasks — heartbeat checks are scripted health checks that don't need reasoning.
+
+`lightContext: true` filters bootstrap to only `HEARTBEAT.md` (no AGENTS.md, SOUL.md, IDENTITY.md, TOOLS.md, USER.md, MEMORY.md). Heartbeat reads `docs/heartbeat-checks.md` on demand through its file tools, so the full spec is still available — it just doesn't sit in bootstrap for every run. `isolatedSession: true` skips replaying prior conversation transcripts into the heartbeat's context. Together they cut heartbeat per-run token cost substantially without changing what checks the heartbeat performs. Reminder delivery not via `heartbeat.target`; Check 1 sends reminders explicitly with OpenClaw `message` tool (`action: send`, `channel: signal`). `target` field only controls where generic non-`HEARTBEAT_OK` output routes; without it, defaults to `"none"`, silently discarded ([openclaw/openclaw#29215](https://github.com/openclaw/openclaw/issues/29215)).
 
 **Our usage:** Two roles:
 1. **Reminder-delivery backstop:** Isolated `reminder-check` cron only writes `.reminder-signal` — no user delivery. Heartbeat Check 1 reads stranded signal files, validates, delivers to Signal via `message` tool every 60 min. (AGENTS.md startup check provides faster opportunistic delivery when user active.)

--- a/scripts/validate-model-refs.sh
+++ b/scripts/validate-model-refs.sh
@@ -135,6 +135,18 @@ if [[ "$heartbeat_model" != "litellm/$tier_cheap" ]]; then
   tier_errors+=("agents.defaults.heartbeat.model = $heartbeat_model, expected litellm/$tier_cheap (cheap tier)")
 fi
 
+# Check agents.defaults.heartbeat.{lightContext,isolatedSession} = true.
+# Extract the heartbeat block (inclusive of closing brace) so we only match
+# inside it — prevents a stray lightContext elsewhere in the template from
+# silencing this check.
+heartbeat_block="$(awk '/"heartbeat":[[:space:]]*\{/,/^[[:space:]]*\}/' "$TEMPLATE")"
+if ! grep -qE '"lightContext"[[:space:]]*:[[:space:]]*true' <<<"$heartbeat_block"; then
+  tier_errors+=("agents.defaults.heartbeat.lightContext must be true (strips bootstrap to HEARTBEAT.md only)")
+fi
+if ! grep -qE '"isolatedSession"[[:space:]]*:[[:space:]]*true' <<<"$heartbeat_block"; then
+  tier_errors+=("agents.defaults.heartbeat.isolatedSession must be true (skips transcript replay)")
+fi
+
 # --- Invariant 3: cron-tier agreement -----------------------------------
 
 canonical_cron_sources=(

--- a/setup/README.md
+++ b/setup/README.md
@@ -208,8 +208,9 @@ Manual regression playbook:
 - Or manually re-register per the definitions in `setup/cron/`
 
 **Heartbeat still loads full bootstrap after pulling the latest template:**
-- `setup/openclaw.json.template` sets `agents.defaults.heartbeat.lightContext` and `agents.defaults.heartbeat.isolatedSession` to `true`, but these fields don't auto-apply to an already-deployed `~/.openclaw/openclaw.json` — the template change only affects *new* installs.
-- To apply on a live instance, edit `~/.openclaw/openclaw.json` and add the two fields under `agents.defaults.heartbeat`:
+- `scripts/pull-main.sh` writes `.config-drift` when `setup/openclaw.json.template` changes. On the next main-agent startup/interaction, `AGENTS.md` step 6 reads the template's `agents.defaults.heartbeat` subtree and patches that subtree into the live `~/.openclaw/openclaw.json`.
+- Verify the repair ran: `.config-drift` should be gone after the next main-agent session, and the live `agents.defaults.heartbeat` block should include `lightContext: true` and `isolatedSession: true`.
+- If you need the change before another main-agent session runs, or `.config-drift` remains because config repair failed, edit `~/.openclaw/openclaw.json` manually and add the two fields under `agents.defaults.heartbeat`:
   ```json
   "heartbeat": {
     "every": "60m",

--- a/setup/README.md
+++ b/setup/README.md
@@ -214,11 +214,11 @@ Manual regression playbook:
   ```json
   "heartbeat": {
     "every": "60m",
-    "model": "litellm/gemma4-small",
     "lightContext": true,
     "isolatedSession": true
   }
   ```
+- Keep the existing heartbeat `model` unchanged. Only add the two new fields unless you intentionally also need to realign heartbeat with your instance's current cheap-tier model.
 - Then restart the gateway: `openclaw gateway`.
 - Verify: the next heartbeat run's context should only contain `HEARTBEAT.md` from bootstrap (not AGENTS.md, SOUL.md, etc.) — inspect the gateway logs or attach a debugger to confirm.
 

--- a/setup/README.md
+++ b/setup/README.md
@@ -207,6 +207,20 @@ Manual regression playbook:
 - They auto-expire after 7 days. The next heartbeat (every 60 min) will re-register them.
 - Or manually re-register per the definitions in `setup/cron/`
 
+**Heartbeat still loads full bootstrap after pulling the latest template:**
+- `setup/openclaw.json.template` sets `agents.defaults.heartbeat.lightContext` and `agents.defaults.heartbeat.isolatedSession` to `true`, but these fields don't auto-apply to an already-deployed `~/.openclaw/openclaw.json` — the template change only affects *new* installs.
+- To apply on a live instance, edit `~/.openclaw/openclaw.json` and add the two fields under `agents.defaults.heartbeat`:
+  ```json
+  "heartbeat": {
+    "every": "60m",
+    "model": "litellm/gemma4-small",
+    "lightContext": true,
+    "isolatedSession": true
+  }
+  ```
+- Then restart the gateway: `openclaw gateway`.
+- Verify: the next heartbeat run's context should only contain `HEARTBEAT.md` from bootstrap (not AGENTS.md, SOUL.md, etc.) — inspect the gateway logs or attach a debugger to confirm.
+
 **Git pull conflicts:**
 - Agent-edited files (MEMORY.md, memory/*.md) are gitignored so won't conflict
 - If HEARTBEAT.md or AGENTS.md conflict, the repo version is authoritative

--- a/setup/cron/heartbeat-check.md
+++ b/setup/cron/heartbeat-check.md
@@ -7,7 +7,9 @@ Heartbeat = built-in OpenClaw feature, not a cron job. Configured in `openclaw.j
 ```json
 "heartbeat": {
   "every": "60m",
-  "model": "litellm/gemma4-small"  // must match modelTiers.cheap
+  "model": "litellm/gemma4-small",  // must match modelTiers.cheap
+  "lightContext": true,              // bootstrap = HEARTBEAT.md only
+  "isolatedSession": true            // skip prior conversation transcript
 }
 ```
 
@@ -24,7 +26,7 @@ Every 60 min, OpenClaw runs agent with `HEARTBEAT.md` as context. Agent performs
 5. Verify environment intact
 6. Pull main if flagged
 
-Uses cheap-tier model — routine operational checks don't need reasoning. Heartbeat also processes stranded handoff files; hourly cadence is part of production reminder-latency tradeoff.
+Uses cheap-tier model — routine operational checks don't need reasoning. `lightContext: true` strips the main-session bootstrap (AGENTS.md, SOUL.md, etc.) from heartbeat context — heartbeat reads `docs/heartbeat-checks.md` on demand instead. `isolatedSession: true` skips replaying prior transcripts. Together they reduce heartbeat per-run context cost without changing behavior. Heartbeat also processes stranded handoff files; hourly cadence is part of production reminder-latency tradeoff.
 
 ## Notes
 

--- a/setup/openclaw.json.template
+++ b/setup/openclaw.json.template
@@ -86,7 +86,9 @@
       },
       "heartbeat": {
         "every": "60m",
-        "model": "litellm/gemma4-small"
+        "model": "litellm/gemma4-small",
+        "lightContext": true,
+        "isolatedSession": true
       },
       "maxConcurrent": 4,
       "subagents": {


### PR DESCRIPTION
## Summary

Every 60 minutes the heartbeat session spins up to run a fixed 5-step check list (stranded reminders, cron drift, Notion ping, env check, dirty-pull recovery). It doesn't need AGENTS.md's intent detection, SOUL.md's personality, USER.md, IDENTITY.md, or TOOLS.md — yet today it loads all of them via the default `bootstrap-extra-files` hook. Two OpenClaw config knobs cut that:

- **`agents.defaults.heartbeat.lightContext: true`** — bootstrap filter keeps only `HEARTBEAT.md`. Heartbeat still reads `docs/heartbeat-checks.md` on demand through its file tools, so the full check list is available without sitting in bootstrap every run.
- **`agents.defaults.heartbeat.isolatedSession: true`** — skip replaying prior conversation transcript, similar to what `sessionTarget: isolated` does for crons.

Verified in OpenClaw source:
- `src/config/types.agent-defaults.ts:353-363` — both fields documented on the heartbeat config type
- `src/agents/bootstrap-files.ts:175-179` — implements the filter: `contextMode === "lightweight"` + `runKind === "heartbeat"` → `files.filter(f => f.name === "HEARTBEAT.md")`
- `src/infra/heartbeat-runner.ts:1023` — passes the `bootstrapContextMode: "lightweight"` through when `lightContext === true`

## Changes

- `setup/openclaw.json.template`: add the two fields to `agents.defaults.heartbeat`
- `setup/cron/heartbeat-check.md` + `docs/openclaw-integration.md`: update canonical heartbeat config block and narrative to document the new fields
- `setup/README.md`: new Troubleshooting entry for the one-time operator sync needed on deployed instances (template changes don't auto-propagate to live `openclaw.json`)
- `scripts/validate-model-refs.sh`: enforce both fields in the template's heartbeat block so future edits can't silently drop them (negative-test verified)
- `docs/agent-capabilities.md` + `setup/cron/heartbeat-check.md` notes line: add `payload.lightContext` to the cron-contract listings (parity fix; same blocker PR #467 hit on cycle 1 — pre-applied here so this PR doesn't eat the same one)

## Deployment

`openclaw.json` lives outside the repo, so template changes don't auto-apply to already-deployed instances. `setup/README.md` now has a dedicated Troubleshooting entry with the exact manual edit + restart steps. When PR #464 (the auto-drift-repair path) eventually lands, this manual step becomes obsolete for future template changes.

## Context window context

This is PR B of a three-PR context-window cleanup plan. PR A (#467) handled the two isolated crons via `payload.lightContext`. PR C (AGENTS.md stub + `docs/ai-prompts.md` split) still to come; all three are independent of each other and of #464.

## Test plan
- [x] `bash scripts/validate-model-refs.sh` — passes; negative test verified (removing either field triggers a clear error)
- [x] `bash scripts/check-doc-links.sh`
- [x] `bash scripts/validate-spec-catalog.sh`
- [ ] After merge + operator sync: confirm the next heartbeat cycle loads only HEARTBEAT.md from bootstrap (inspect gateway logs) and still executes all 5 checks correctly
- [ ] Verify the operator-sync Troubleshooting note works end-to-end: edit a test instance's live `~/.openclaw/openclaw.json`, restart, observe the trim

🤖 Generated with [Claude Code](https://claude.com/claude-code)