### PR TITLE
ci: use runner.temp for host-side workflow output paths

### DIFF
--- a/.github/workflows/codex-diagnose-workflow-failure.yml
+++ b/.github/workflows/codex-diagnose-workflow-failure.yml
@@ -177,9 +177,13 @@ jobs:
                 | tee /output/diagnose-output.jsonl
             '
 
-          # Copy output back to /tmp/ on the runner for upload-artifact.
-          mkdir -p /tmp
-          cp "$OUTPUT_STAGING/diagnose-output.jsonl" /tmp/diagnose-output.jsonl 2>/dev/null || true
+          # Copy output back to runner.temp for upload-artifact. Using
+          # runner.temp (owned by the runner user, cleaned between runs)
+          # avoids host UID mismatch + accumulation issues on
+          # self-hosted runners. Mirrors the fix in
+          # NickBorgers/home-automation#1029.
+          mkdir -p "${RUNNER_TEMP}"
+          cp "$OUTPUT_STAGING/diagnose-output.jsonl" "${RUNNER_TEMP}/diagnose-output.jsonl" 2>/dev/null || true
           rm -rf "$OUTPUT_STAGING"
 
       - name: Upload diagnosis output
@@ -188,7 +192,7 @@ jobs:
         continue-on-error: true
         with:
           name: workflow-diagnosis-output
-          path: /tmp/diagnose-output.jsonl
+          path: ${{ runner.temp }}/diagnose-output.jsonl
           retention-days: 7
 
       - name: Notify agent webhook

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -230,8 +230,13 @@ jobs:
                 | tee /output/resolve-issue-conversation.jsonl
             '
 
-          mkdir -p /tmp
-          cp "$OUTPUT_STAGING/resolve-issue-conversation.jsonl" /tmp/resolve-issue-conversation.jsonl 2>/dev/null || true
+          # Copy output back to runner.temp for upload-artifact. Using
+          # runner.temp (owned by the runner user, cleaned between runs)
+          # avoids host UID mismatch + accumulation issues on
+          # self-hosted runners. Mirrors the fix in
+          # NickBorgers/home-automation#1029.
+          mkdir -p "${RUNNER_TEMP}"
+          cp "$OUTPUT_STAGING/resolve-issue-conversation.jsonl" "${RUNNER_TEMP}/resolve-issue-conversation.jsonl" 2>/dev/null || true
           rm -rf "$OUTPUT_STAGING"
 
       - name: Upload issue resolution conversation log
@@ -240,5 +245,5 @@ jobs:
         continue-on-error: true
         with:
           name: resolve-issue-conversation-log
-          path: /tmp/resolve-issue-conversation.jsonl
+          path: ${{ runner.temp }}/resolve-issue-conversation.jsonl
           retention-days: 7

--- a/.github/workflows/review-coverage-evaluator.yml
+++ b/.github/workflows/review-coverage-evaluator.yml
@@ -110,8 +110,13 @@ jobs:
                 | tee /output/coverage-evaluator-output.jsonl
             '
 
-          mkdir -p /tmp
-          cp "$OUTPUT_STAGING/coverage-evaluator-output.jsonl" /tmp/coverage-evaluator-output.jsonl 2>/dev/null || true
+          # Copy output back to runner.temp for upload-artifact. Using
+          # runner.temp (owned by the runner user, cleaned between runs)
+          # avoids host UID mismatch + accumulation issues on
+          # self-hosted runners. Mirrors the fix in
+          # NickBorgers/home-automation#1029.
+          mkdir -p "${RUNNER_TEMP}"
+          cp "$OUTPUT_STAGING/coverage-evaluator-output.jsonl" "${RUNNER_TEMP}/coverage-evaluator-output.jsonl" 2>/dev/null || true
           rm -rf "$OUTPUT_STAGING"
 
       - name: Upload evaluator output
@@ -120,5 +125,5 @@ jobs:
         continue-on-error: true
         with:
           name: coverage-evaluator-output
-          path: /tmp/coverage-evaluator-output.jsonl
+          path: ${{ runner.temp }}/coverage-evaluator-output.jsonl
           retention-days: 7

--- a/.github/workflows/review-finalize.yml
+++ b/.github/workflows/review-finalize.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Download verdict artifact
         uses: actions/download-artifact@v4
         with:
-          path: /tmp/verdict
+          path: ${{ runner.temp }}/verdict
           name: verdict-${{ inputs.post_fix_sha }}
 
       # Write the v1-compatible "All Required Agent Reviews" merge-gate
@@ -114,8 +114,8 @@ jobs:
             --repo "$REPO" 2>/dev/null || true
           gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label needs-human-review
 
-          REASONS=$(jq -r '.reasons[]? // empty' /tmp/verdict/verdict-${{ inputs.post_fix_sha }}.json | sed 's/^/- /')
-          BLOCKERS=$(jq -r '.unaddressed_blocker_ids[]? // empty' /tmp/verdict/verdict-${{ inputs.post_fix_sha }}.json | sed 's/^/- /')
+          REASONS=$(jq -r '.reasons[]? // empty' "${RUNNER_TEMP}/verdict/verdict-${{ inputs.post_fix_sha }}.json" | sed 's/^/- /')
+          BLOCKERS=$(jq -r '.unaddressed_blocker_ids[]? // empty' "${RUNNER_TEMP}/verdict/verdict-${{ inputs.post_fix_sha }}.json" | sed 's/^/- /')
 
           BODY_FILE=$(mktemp)
           {
@@ -167,7 +167,7 @@ jobs:
             --repo "$REPO" 2>/dev/null || true
           gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label agent-reviews-passed
 
-          REASONS=$(jq -r '.reasons[]? // empty' /tmp/verdict/verdict-${{ inputs.post_fix_sha }}.json | sed 's/^/- /')
+          REASONS=$(jq -r '.reasons[]? // empty' "${RUNNER_TEMP}/verdict/verdict-${{ inputs.post_fix_sha }}.json" | sed 's/^/- /')
 
           # Post a single Merge Decision comment so humans can see the
           # verdict at a glance. Uses the same `<!-- codex-merge-decision -->`

--- a/.github/workflows/review-judge.yml
+++ b/.github/workflows/review-judge.yml
@@ -63,21 +63,21 @@ jobs:
       - name: Download all reviewer artifacts
         uses: actions/download-artifact@v4
         with:
-          path: /tmp/reviewer-artifacts
+          path: ${{ runner.temp }}/reviewer-artifacts
           pattern: reviewer-*-${{ inputs.reviewed_sha }}
 
       - name: Download fix-result artifact
         uses: actions/download-artifact@v4
         with:
-          path: /tmp/fix-result
+          path: ${{ runner.temp }}/fix-result
           name: fix-result-${{ inputs.reviewed_sha }}
 
       - name: Aggregate verdict
         id: aggregate
         env:
-          REVIEWER_DIR: /tmp/reviewer-artifacts
-          FIX_RESULT_PATH: /tmp/fix-result/fixer-result.json
-          VERDICT_OUTPUT_PATH: /tmp/verdict-${{ inputs.post_fix_sha }}.json
+          REVIEWER_DIR: ${{ runner.temp }}/reviewer-artifacts
+          FIX_RESULT_PATH: ${{ runner.temp }}/fix-result/fixer-result.json
+          VERDICT_OUTPUT_PATH: ${{ runner.temp }}/verdict-${{ inputs.post_fix_sha }}.json
         run: node .github/scripts/review/judge.mjs
 
       - name: Write verdict commit status
@@ -96,4 +96,4 @@ jobs:
         continue-on-error: true
         with:
           name: verdict-${{ inputs.post_fix_sha }}
-          path: /tmp/verdict-${{ inputs.post_fix_sha }}.json
+          path: ${{ runner.temp }}/verdict-${{ inputs.post_fix_sha }}.json


### PR DESCRIPTION
## Summary

Ports the runner.temp pattern from [`NickBorgers/home-automation#1029`](https://github.com/NickBorgers/home-automation/pull/1029), adapted for hide-my-list's actual workflow pattern.

## What's actually wrong (in this repo)

hide-my-list's CI agent workflows run the AI inside a Docker container that writes output to a container-side `/output/<name>.jsonl`. After the container exits, the workflow **on the host runner** does:

```yaml
cp "$OUTPUT_STAGING/<name>.jsonl" /tmp/<name>.jsonl
…
- uses: actions/upload-artifact@v4
  with:
    path: /tmp/<name>.jsonl
```

The bug is host-side, not container-side. On a self-hosted runner:

1. **File accumulation** — `/tmp/<name>.jsonl` persists across runs. Outputs pile up indefinitely; one run can read another's stale output if any reader doesn't clean up first.
2. **UID / ownership confusion** — files left at `/tmp/X` by a previous run can be owned by a different UID (e.g. a container user from a prior run that wrote there before this fix landed). Subsequent `cp`, `mkdir`, or `actions/upload-artifact` reads can fail or pick up the wrong content.
3. **Path collision between concurrent jobs** — two jobs on the same self-hosted runner using the same `/tmp/<name>.jsonl` race for the file.

## The fix

Move every **host-side** path that was hardcoded `/tmp/<name>` to `${{ runner.temp }}/<name>` (or `$RUNNER_TEMP/<name>` in shell). GitHub cleans `runner.temp` between runs (solves accumulation) and the runner user owns it (solves UID confusion + collision). **Container-side `/output/<name>` paths inside `docker run --mount` and the in-container `tee /output/...` calls are unchanged** — only the host side moves.

This mirrors home-automation#1029's pattern; the surface differs because hide-my-list's failure mode is host-side `cp` / `download-artifact` / `upload-artifact` / host-side `jq` reads, not the host-side `tee | pipefail` failure that home-automation hit.

## Files touched

- `.github/workflows/codex.yml` (host-side `cp` + `upload-artifact` for `resolve-issue-conversation.jsonl`)
- `.github/workflows/codex-diagnose-workflow-failure.yml`
- `.github/workflows/review-coverage-evaluator.yml`
- `.github/workflows/review-finalize.yml` (v2 pipeline — host-side `/tmp/verdict`)
- `.github/workflows/review-judge.yml` (v2 pipeline — host-side `/tmp/reviewer-artifacts`, `/tmp/fix-result`, `/tmp/verdict-*.json`)

## Skipped: `codex-code-review.yml`

The v1 review pipeline workflow has many `/tmp/*-output.jsonl` instances. **Skipped intentionally** — that file is being deleted by PR #477 (`chore: remove v1 review pipeline`). Patching it here would be wasted work.

## Test plan
- [x] `bash scripts/run-required-checks.sh ci-workflows` (actionlint + workflow-ref validators)
- [ ] After merge: trigger a v2 review on a test PR — confirm the steps complete without the host-side `/tmp` accumulation, and that `${{ runner.temp }}` directories get cleaned between runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)