### PR TITLE
Fix Signal attachment delivery by provisioning media staging dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ When you create `~/.openclaw/openclaw.json`, set
 `USER.md` (for example, `America/Chicago`). Without it, relative dates like
 "tomorrow" are resolved against UTC.
 
+`setup/bootstrap.sh` also provisions OpenClaw's media staging directories under
+`~/.openclaw/media/outbound` with traversable permissions so Signal can read
+staged attachments such as reward images.
+
 See [setup/README.md](setup/README.md) for full setup instructions.
 
 ## Git hooks

--- a/docs/reward-system.md
+++ b/docs/reward-system.md
@@ -254,6 +254,9 @@ flowchart TD
 ```
 
 Output: writes PNG to `/tmp/reward-<timestamp>.png` and prints the path.
+OpenClaw then stages attachment delivery through `~/.openclaw/media/outbound/`,
+which must stay traversable (for example `0755`) so Signal can read the staged
+file.
 
 #### Theme Pools by Intensity
 

--- a/setup/README.md
+++ b/setup/README.md
@@ -55,6 +55,10 @@
    user, including the IANA TZ identifier in parentheses, such as
    `America/Chicago`.
 
+   Bootstrap also creates `~/.openclaw/media/` and
+   `~/.openclaw/media/outbound/` with `0755` permissions so OpenClaw-staged
+   attachments remain readable to Signal.
+
 5. Configure OpenClaw:
    ```bash
    # Copy and customize the config template
@@ -191,6 +195,11 @@ Manual regression playbook:
 - Verify `.env` contains `OPS_ALERT_SIGNAL_NUMBER` and that it points to the intended operator Signal recipient
 - Keep `heartbeat.target` unset or `"none"`; the supported delivery path is the explicit `message` call from `docs/heartbeat-checks.md` Check 1, not generic heartbeat reply routing
 - Confirm the Signal channel itself is configured and healthy in `openclaw.json`
+
+**Signal attachments fail with `Permission denied`:**
+- Re-run `bash setup/bootstrap.sh` to recreate or repair the OpenClaw media staging directories with the expected permissions.
+- If you need the repair immediately, run `chmod 755 ~/.openclaw/media ~/.openclaw/media/outbound`.
+- Verify both directories are traversable by the Signal process: `namei -om ~/.openclaw/media/outbound`.
 
 **Agent not responding:**
 - Check `openclaw status` for channel health

--- a/setup/bootstrap.sh
+++ b/setup/bootstrap.sh
@@ -102,6 +102,8 @@ fi
 
 mkdir -p "$ROOT_DIR/memory"
 mkdir -p "$ROOT_DIR/rewards"
+mkdir -p "$OPENCLAW_HOME/media/outbound"
+chmod 755 "$OPENCLAW_HOME/media" "$OPENCLAW_HOME/media/outbound"
 echo "Ensured runtime directories exist"
 echo ""
 


### PR DESCRIPTION
Resolves #471

## Summary
- update `setup/bootstrap.sh` to create `~/.openclaw/media/outbound` and enforce `0755` on both media staging directories
- document the media staging permission requirement in the main setup docs and reward-image delivery docs
- add a troubleshooting path for existing installs that are already failing with Signal `Permission denied`

## Test Plan
- run `shellcheck scripts/*.sh`
- run `shellcheck setup/bootstrap.sh`
- run `yamllint .github/workflows/*.yml`
- run `bash scripts/check-doc-links.sh`

Generated with Codex