### PR TITLE
Switch the v2 review fixer to Claude Code via LiteLLM

### DIFF
--- a/.github/actions/review-claude-run/action.yml
+++ b/.github/actions/review-claude-run/action.yml
@@ -1,0 +1,208 @@
+---
+name: Run a Claude review prompt in the CI image
+description: >
+  Wraps Claude Code invocation for the v2 review pipeline fixer. Reads
+  the fixer prompt from a standalone markdown file at the given path —
+  the prompt is NEVER inlined into YAML, so editing a prompt is a
+  normal markdown diff with no escaping concerns.
+
+  Captures Claude output to <workspace>/.review-output/<role>-output.jsonl
+  and expects the inner prompt to write a structured JSON artifact at
+  <workspace>/.review-output/<role>-result.json (the caller is
+  responsible for validating that JSON against the expected schema).
+
+  This action spawns `docker run` directly against the CI image
+  (.github/ci/Dockerfile → ghcr.io/nickborgersprobably/hide-my-list-ci:latest),
+  bypassing @devcontainers/cli. The predecessor wrapped the deprecated
+  run-devcontainer composite action, which went through devcontainer-cli
+  and fought the self-hosted runner's shared-docker-socket topology in
+  assorted ways. All topology knobs live in this one action.
+
+  Forwards minimal env per agentic-pipeline-learnings §2.2 and uses
+  WORKFLOW_PAT as GH_TOKEN per §2.3.
+
+inputs:
+  role:
+    description: 'Role label used in artifact filenames (for example "fixer")'
+    required: true
+  prompt_path:
+    description: Repo-relative path to the standalone prompt markdown file (relative to workspace_folder)
+    required: true
+  image:
+    description: CI image tag (default ghcr.io/nickborgersprobably/hide-my-list-ci:latest)
+    required: false
+    default: ghcr.io/nickborgersprobably/hide-my-list-ci:latest
+  workspace_folder:
+    description: >
+      Workspace folder containing the PR checkout, relative to
+      $GITHUB_WORKSPACE. This is what the container sees as /workspace.
+    required: true
+  pr_number:
+    description: PR number being reviewed. Empty disables the PR metadata lookup.
+    required: false
+    default: ''
+  reviewed_sha:
+    description: Frozen reviewed SHA (40-char hex)
+    required: true
+  cycle:
+    description: Pipeline cycle number for this run
+    required: true
+  read_only:
+    description: Compatibility input with review-codex-run. The fixer passes "false".
+    required: false
+    default: 'false'
+  workflow_pat:
+    description: PAT used as GH_TOKEN inside the container (rule 2.3)
+    required: true
+  extra_env:
+    description: 'Additional KEY=VALUE pairs (newline-separated) to forward'
+    required: false
+    default: ''
+  pull:
+    description: When 'true' (default), docker pull the image before running
+    required: false
+    default: 'true'
+
+outputs:
+  output_artifact:
+    description: Host path to the captured Claude output JSONL
+    value: ${{ steps.paths.outputs.output_artifact }}
+  result_json:
+    description: Host path to the structured JSON artifact the prompt wrote
+    value: ${{ steps.paths.outputs.result_json }}
+
+runs:
+  using: composite
+  steps:
+    - name: Pre-create output directory in workspace
+      shell: bash
+      env:
+        WORKSPACE_FOLDER: ${{ inputs.workspace_folder }}
+      run: |
+        set -euo pipefail
+        OUTPUT_DIR="${GITHUB_WORKSPACE}/${WORKSPACE_FOLDER}/.review-output"
+        mkdir -p "$OUTPUT_DIR"
+        chmod 777 "$OUTPUT_DIR"
+
+    - name: Log in to GHCR
+      shell: bash
+      env:
+        GHCR_USERNAME: ${{ github.actor }}
+        GHCR_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
+
+    - name: Ensure CI image
+      if: inputs.pull == 'true'
+      shell: bash
+      run: scripts/ensure-ci-image.sh "${{ inputs.image }}"
+
+    - name: Fetch current PR metadata
+      id: pr-meta
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.workflow_pat }}
+        REPO: ${{ github.repository }}
+        PR_NUMBER: ${{ inputs.pr_number }}
+      run: |
+        set -euo pipefail
+
+        if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "0" ]; then
+          PR_TITLE=""
+          PR_BODY=""
+        else
+          PR_JSON=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")
+          PR_TITLE=$(echo "$PR_JSON" | jq -r '.title // ""')
+          PR_BODY=$(echo "$PR_JSON" | jq -r '.body // ""')
+        fi
+
+        echo "pr_title_b64=$(printf '%s' "$PR_TITLE" | base64 -w0)" >> "$GITHUB_OUTPUT"
+        echo "pr_body_b64=$(printf '%s' "$PR_BODY" | base64 -w0)" >> "$GITHUB_OUTPUT"
+
+    - name: Stage env file
+      id: stage-env
+      shell: bash
+      env:
+        ROLE: ${{ inputs.role }}
+        PROMPT_PATH: ${{ inputs.prompt_path }}
+        READ_ONLY: ${{ inputs.read_only }}
+        PR_NUMBER: ${{ inputs.pr_number }}
+        REVIEWED_SHA: ${{ inputs.reviewed_sha }}
+        CYCLE: ${{ inputs.cycle }}
+        WORKFLOW_PAT: ${{ inputs.workflow_pat }}
+        EXTRA_ENV: ${{ inputs.extra_env }}
+        REPO: ${{ github.repository }}
+        PR_TITLE_B64: ${{ steps.pr-meta.outputs.pr_title_b64 }}
+        PR_BODY_B64: ${{ steps.pr-meta.outputs.pr_body_b64 }}
+      run: |
+        set -euo pipefail
+        STAGING_DIR="${RUNNER_TEMP:-/tmp}/ci-agent"
+        mkdir -p "$STAGING_DIR"
+        ENV_FILE="$(mktemp "${STAGING_DIR}/env.XXXXXX")"
+        cat > "$ENV_FILE" <<EOF
+        ANTHROPIC_API_KEY=fake-key
+        ANTHROPIC_BASE_URL=https://llm.featherback-mermaid.ts.net/anthropic/
+        GH_TOKEN=${WORKFLOW_PAT}
+        REVIEW_ROLE=${ROLE}
+        REVIEW_PROMPT_PATH=${PROMPT_PATH}
+        REVIEW_READ_ONLY=${READ_ONLY}
+        PR_NUMBER=${PR_NUMBER}
+        REVIEWED_SHA=${REVIEWED_SHA}
+        REVIEW_CYCLE=${CYCLE}
+        OUTPUT_PATH=.review-output/${ROLE}-result.json
+        OUTPUT_LOG_PATH=.review-output/${ROLE}-output.jsonl
+        REPO=${REPO}
+        PR_TITLE_B64=${PR_TITLE_B64}
+        PR_BODY_B64=${PR_BODY_B64}
+        EOF
+        if [ -n "$EXTRA_ENV" ]; then
+          printf '%s\n' "$EXTRA_ENV" | grep -Ev '^\s*(#|$)' >> "$ENV_FILE" || true
+        fi
+        chmod 600 "$ENV_FILE"
+        echo "env_file=$ENV_FILE" >> "$GITHUB_OUTPUT"
+
+    - name: Run Claude prompt
+      shell: bash
+      env:
+        CI_AGENT_IMAGE: ${{ inputs.image }}
+        CI_AGENT_ENV_FILE: ${{ steps.stage-env.outputs.env_file }}
+        WORKSPACE_FOLDER: ${{ inputs.workspace_folder }}
+      run: |
+        set -euo pipefail
+
+        WORKSPACE_HOST="${GITHUB_WORKSPACE}/${WORKSPACE_FOLDER}"
+        CONTAINER_SCRIPT="${GITHUB_WORKSPACE}/.github/actions/review-claude-run/run-in-container.sh"
+
+        docker run --rm \
+          --network host \
+          --workdir /workspace \
+          -v "$WORKSPACE_HOST:/workspace" \
+          -v "$CONTAINER_SCRIPT:/run-in-container.sh:ro" \
+          --env-file "$CI_AGENT_ENV_FILE" \
+          -e GIT_CONFIG_COUNT=1 \
+          -e GIT_CONFIG_KEY_0=safe.directory \
+          -e GIT_CONFIG_VALUE_0=/workspace \
+          "$CI_AGENT_IMAGE" \
+          -lc '/run-in-container.sh'
+
+    - name: Clean up staged env file
+      if: always()
+      shell: bash
+      env:
+        CI_AGENT_ENV_FILE: ${{ steps.stage-env.outputs.env_file }}
+      run: rm -f "$CI_AGENT_ENV_FILE"
+
+    - name: Echo result paths
+      id: paths
+      shell: bash
+      env:
+        ROLE: ${{ inputs.role }}
+        WORKSPACE_FOLDER: ${{ inputs.workspace_folder }}
+      run: |
+        set -euo pipefail
+        BASE="${GITHUB_WORKSPACE}/${WORKSPACE_FOLDER}/.review-output"
+        {
+          echo "output_artifact=${BASE}/${ROLE}-output.jsonl"
+          echo "result_json=${BASE}/${ROLE}-result.json"
+        } >> "$GITHUB_OUTPUT"

--- a/.github/actions/review-claude-run/run-in-container.sh
+++ b/.github/actions/review-claude-run/run-in-container.sh
@@ -30,6 +30,7 @@ timeout 30m claude -p \
   --dangerously-skip-permissions \
   --permission-mode=bypassPermissions \
   --model claude-sonnet-4-6 \
+  --verbose \
   --output-format=stream-json \
   "$PROMPT_BODY" \
   < /dev/null 2>&1 \

--- a/.github/actions/review-claude-run/run-in-container.sh
+++ b/.github/actions/review-claude-run/run-in-container.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ ! -f "$REVIEW_PROMPT_PATH" ]; then
+  echo "::error::review-claude-run: prompt file not found at $REVIEW_PROMPT_PATH"
+  exit 1
+fi
+
+# Prepend caveman rules if available (optional — PRs branched
+# before caveman merged will not have the file).
+if [ -f .github/ci/caveman-rules.md ] && [ -f .github/ci/versions.env ]; then
+  # shellcheck disable=SC1091
+  source .github/ci/versions.env
+  if grep -Fq "v${CAVEMAN_VERSION}" .github/ci/caveman-rules.md; then
+    PROMPT_BODY=$(printf '%s\n\n%s' "$(cat .github/ci/caveman-rules.md)" "$(cat "$REVIEW_PROMPT_PATH")")
+  else
+    echo "::warning::review-claude-run: caveman version mismatch; skipping rules"
+    PROMPT_BODY=$(cat "$REVIEW_PROMPT_PATH")
+  fi
+else
+  PROMPT_BODY=$(cat "$REVIEW_PROMPT_PATH")
+fi
+
+mkdir -p "$(dirname "$OUTPUT_PATH")"
+
+# The prompt body instructs Claude to write its structured
+# result JSON to $OUTPUT_PATH. Keep stdout as stream-json so
+# the uploaded log stays machine-readable like the Codex path.
+timeout 30m claude -p \
+  --dangerously-skip-permissions \
+  --permission-mode=bypassPermissions \
+  --model claude-sonnet-4-6 \
+  --output-format=stream-json \
+  "$PROMPT_BODY" \
+  < /dev/null 2>&1 \
+  | tee "$OUTPUT_LOG_PATH"
+
+if [ ! -s "$OUTPUT_PATH" ]; then
+  echo "::error::review-claude-run: prompt did not produce $OUTPUT_PATH"
+  exit 1
+fi
+
+echo "review-claude-run: ${REVIEW_ROLE} produced $OUTPUT_PATH"

--- a/.github/ci/README.md
+++ b/.github/ci/README.md
@@ -22,7 +22,7 @@ through the shared socket" bugs.
 |---|---|
 | `Dockerfile` | Image recipe. `ubuntu:24.04` base, UID-1000 `ci` user, pinned Claude Code / Codex / actionlint / Node major. Installs shellcheck, yamllint, gh, Mermaid npm globals, envsubst. |
 | `versions.env` | Single source of truth for CLI version pins. Consumed by `.github/workflows/ci-image.yml` as `--build-arg`s. |
-| `caveman-rules.md` | Canonical CI-only caveman prompt contract. `review-codex-run` prepends it to review prompts and validates its pinned source version against `CAVEMAN_VERSION`. |
+| `caveman-rules.md` | Canonical CI-only caveman prompt contract. `review-codex-run` and `review-claude-run` prepend it to review prompts and validate its pinned source version against `CAVEMAN_VERSION`. |
 | `README.md` | This file. |
 
 ## Relationship to `.devcontainer/`

--- a/.github/ci/README.md
+++ b/.github/ci/README.md
@@ -40,9 +40,13 @@ through the shared socket" bugs.
 
 ## How workflows consume the image
 
-Review pipeline v2 uses `./.github/actions/review-codex-run` which
-shells out to `docker run` against the CI image. The other agent
-workflows (`codex`, `codex-diagnose-workflow-failure`,
+Review pipeline v2 uses two direct-`docker run` composite actions
+against the CI image:
+
+- `./.github/actions/review-codex-run` for the read-only reviewers
+- `./.github/actions/review-claude-run` for the single-writer fixer
+
+The other agent workflows (`codex`, `codex-diagnose-workflow-failure`,
 `review-coverage-evaluator`) invoke `docker run` inline.
 
 All of them call `scripts/ensure-ci-image.sh` before launch. The helper
@@ -69,6 +73,10 @@ home-automation refactor:
 - **Always `--network host`** so the nested container inherits the
   runner's Tailscale connection to LiteLLM at
   `https://llm.featherback-mermaid.ts.net/v1`.
+- **Claude-over-LiteLLM uses the Anthropic-compatible path**.
+  `review-claude-run` forwards `ANTHROPIC_BASE_URL=https://llm.featherback-mermaid.ts.net/anthropic/`
+  and `ANTHROPIC_API_KEY=fake-key`; reviewer jobs keep using the
+  OpenAI-compatible path via `.devcontainer/configure-codex.sh`.
 
 ## Issue Resolution Agent issue-resolution entry points
 

--- a/.github/ci/caveman-rules.md
+++ b/.github/ci/caveman-rules.md
@@ -1,6 +1,6 @@
 <!-- Canonical CI-only caveman rules.
      Derived from JuliusBrussee/caveman v1.5.1 full mode.
-     review-codex-run validates this header against CAVEMAN_VERSION in .github/ci/versions.env. -->
+     review-codex-run and review-claude-run validate this header against CAVEMAN_VERSION in .github/ci/versions.env. -->
 
 # CI Caveman Rules
 

--- a/.github/ci/versions.env
+++ b/.github/ci/versions.env
@@ -9,6 +9,6 @@ ACTIONLINT_VERSION=1.7.7
 NODE_MAJOR=20
 # Canonical CI-only caveman rules in `.github/ci/caveman-rules.md`
 # are derived from JuliusBrussee/caveman full mode at this version.
-# `review-codex-run` validates the file header against this pin before
-# prepending those rules to review prompts.
+# `review-codex-run` and `review-claude-run` validate the file header
+# against this pin before prepending those rules to review prompts.
 CAVEMAN_VERSION=1.5.1

--- a/.github/scripts/review/prompts/fixer-claude-smoke.md
+++ b/.github/scripts/review/prompts/fixer-claude-smoke.md
@@ -1,0 +1,31 @@
+You = Claude Code CI smoke test for the review fixer migration.
+
+Goal: prove the CI container can use Claude Code against the LiteLLM
+Anthropic endpoint, read the same reviewer-artifact directory the real
+fixer uses, write a file into the bind-mounted workspace, and emit a
+structured result JSON to `$OUTPUT_PATH`.
+
+## Requirements
+
+1. Read every `*-result.json` under `${REVIEWER_ARTIFACTS_DIR}`.
+2. Parse the first blocker id and summary you find.
+3. Write exactly one line to `${SMOKE_TARGET_PATH}` in this format:
+   `claude-smoke:<id>:<summary>`
+4. Write JSON to `$OUTPUT_PATH` with this shape:
+
+```json
+{
+  "auth_ok": true,
+  "artifact_files": ["relative/path.json"],
+  "first_blocker_id": "docs/doc-001",
+  "first_blocker_summary": "example",
+  "workspace_write_path": ".review-output/claude-smoke-target.txt",
+  "workspace_write_ok": true
+}
+```
+
+## Constraints
+
+- No `git add`, `git commit`, `git push`, or any other git-write command.
+- Keep changes inside `.review-output/`.
+- Stop once the target file and `$OUTPUT_PATH` exist.

--- a/.github/scripts/review/prompts/fixer-claude-smoke.md
+++ b/.github/scripts/review/prompts/fixer-claude-smoke.md
@@ -8,9 +8,9 @@ structured result JSON to `$OUTPUT_PATH`.
 ## Requirements
 
 1. Read every `*-result.json` under `${REVIEWER_ARTIFACTS_DIR}`.
-2. Parse the first blocker id and summary you find.
+2. Parse the first blocker id and message you find.
 3. Write exactly one line to `${SMOKE_TARGET_PATH}` in this format:
-   `claude-smoke:<id>:<summary>`
+   `claude-smoke:<id>:<message>`
 4. Write JSON to `$OUTPUT_PATH` with this shape:
 
 ```json
@@ -18,7 +18,7 @@ structured result JSON to `$OUTPUT_PATH`.
   "auth_ok": true,
   "artifact_files": ["relative/path.json"],
   "first_blocker_id": "docs/doc-001",
-  "first_blocker_summary": "example",
+  "first_blocker_message": "example",
   "workspace_write_path": ".review-output/claude-smoke-target.txt",
   "workspace_write_ok": true
 }

--- a/.github/workflows/review-fixer-claude-smoke.yml
+++ b/.github/workflows/review-fixer-claude-smoke.yml
@@ -1,0 +1,87 @@
+---
+name: Review pipeline v2 — Claude fixer smoke test
+
+on:
+  workflow_dispatch:
+    inputs:
+      image:
+        description: CI image tag to test
+        required: false
+        default: ghcr.io/nickborgersprobably/hide-my-list-ci:latest
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  smoke:
+    name: Claude fixer smoke
+    runs-on: self-hosted
+    steps:
+      - name: Checkout current ref
+        uses: actions/checkout@v4
+
+      - name: Create directories for CI mounts
+        run: mkdir -p ~/.config/gh ~/.claude ~/.codex
+
+      - name: Seed sample reviewer artifacts
+        run: |
+          set -euo pipefail
+          mkdir -p .review-output/reviewer-artifacts/docs
+          cat > .review-output/reviewer-artifacts/docs/docs-result.json <<'JSON'
+          {
+            "blocking_issues": [
+              {
+                "id": "docs/doc-001",
+                "summary": "replace stale docs path",
+                "file": "docs/architecture.md",
+                "line": 1
+              }
+            ]
+          }
+          JSON
+
+      - name: Run Claude smoke prompt
+        id: run
+        uses: ./.github/actions/review-claude-run
+        with:
+          role: fixer-smoke
+          prompt_path: .github/scripts/review/prompts/fixer-claude-smoke.md
+          image: ${{ inputs.image }}
+          workspace_folder: .
+          pr_number: ''
+          reviewed_sha: ${{ github.sha }}
+          cycle: smoke
+          read_only: 'false'
+          workflow_pat: ${{ secrets.WORKFLOW_PAT }}
+          extra_env: |
+            REVIEWER_ARTIFACTS_DIR=.review-output/reviewer-artifacts
+            SMOKE_TARGET_PATH=.review-output/claude-smoke-target.txt
+
+      - name: Verify smoke results
+        env:
+          RESULT_JSON: ${{ steps.run.outputs.result_json }}
+          OUTPUT_LOG: ${{ steps.run.outputs.output_artifact }}
+        run: |
+          set -euo pipefail
+          jq -e '
+            .auth_ok == true
+            and .workspace_write_ok == true
+            and .first_blocker_id == "docs/doc-001"
+            and .first_blocker_summary == "replace stale docs path"
+            and .workspace_write_path == ".review-output/claude-smoke-target.txt"
+            and (.artifact_files | length) >= 1
+          ' "$RESULT_JSON" >/dev/null
+          test -s "$OUTPUT_LOG"
+          grep -Fxq 'claude-smoke:docs/doc-001:replace stale docs path' .review-output/claude-smoke-target.txt
+
+      - name: Upload smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: review-fixer-claude-smoke-${{ github.run_id }}
+          path: |
+            .review-output/fixer-smoke-result.json
+            .review-output/fixer-smoke-output.jsonl
+            .review-output/claude-smoke-target.txt
+            .review-output/reviewer-artifacts

--- a/.github/workflows/review-fixer-claude-smoke.yml
+++ b/.github/workflows/review-fixer-claude-smoke.yml
@@ -1,13 +1,41 @@
 ---
 name: Review pipeline v2 — Claude fixer smoke test
 
+# Pre-merge smoke for the Claude fixer container path. Auto-runs on
+# any PR that touches files governing the runtime contract that the
+# v2 fixer depends on, so a broken Claude auth / flag / env-forwarding
+# / workspace-write regression surfaces here instead of in the next
+# real review cycle (rule 2.9).
+#
+# Same-repo only — workflow runs on `self-hosted` and forwards
+# `WORKFLOW_PAT`, so fork PRs must not execute it. Mirrors the guard
+# pattern in `.github/workflows/pr-tests.yml`.
+
 on:
+  pull_request:
+    branches:
+      - main
+      - master
+      - '**'
+    paths:
+      - '.github/actions/review-claude-run/**'
+      - '.github/workflows/review-fixer.yml'
+      - '.github/workflows/review-fixer-claude-smoke.yml'
+      - '.github/scripts/review/prompts/fixer.md'
+      - '.github/scripts/review/prompts/fixer-claude-smoke.md'
+      - '.github/ci/Dockerfile'
+      - '.github/ci/versions.env'
+      - '.github/ci/caveman-rules.md'
   workflow_dispatch:
     inputs:
       image:
         description: CI image tag to test
         required: false
         default: ghcr.io/nickborgersprobably/hide-my-list-ci:latest
+
+concurrency:
+  group: review-fixer-claude-smoke-${{ github.event.pull_request.head.ref || github.ref_name }}-${{ github.event.pull_request.head.sha || github.sha }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -17,6 +45,7 @@ jobs:
   smoke:
     name: Claude fixer smoke
     runs-on: self-hosted
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout current ref
         uses: actions/checkout@v4
@@ -33,7 +62,7 @@ jobs:
             "blocking_issues": [
               {
                 "id": "docs/doc-001",
-                "summary": "replace stale docs path",
+                "message": "replace stale docs path",
                 "file": "docs/architecture.md",
                 "line": 1
               }
@@ -47,7 +76,7 @@ jobs:
         with:
           role: fixer-smoke
           prompt_path: .github/scripts/review/prompts/fixer-claude-smoke.md
-          image: ${{ inputs.image }}
+          image: ${{ inputs.image || 'ghcr.io/nickborgersprobably/hide-my-list-ci:latest' }}
           workspace_folder: .
           pr_number: ''
           reviewed_sha: ${{ github.sha }}
@@ -68,7 +97,7 @@ jobs:
             .auth_ok == true
             and .workspace_write_ok == true
             and .first_blocker_id == "docs/doc-001"
-            and .first_blocker_summary == "replace stale docs path"
+            and .first_blocker_message == "replace stale docs path"
             and .workspace_write_path == ".review-output/claude-smoke-target.txt"
             and (.artifact_files | length) >= 1
           ' "$RESULT_JSON" >/dev/null

--- a/.github/workflows/review-fixer.yml
+++ b/.github/workflows/review-fixer.yml
@@ -108,9 +108,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run agentic fixer in devcontainer
+      - name: Run Claude fixer in CI image
         id: run
-        uses: ./.github/actions/review-codex-run
+        uses: ./.github/actions/review-claude-run
         with:
           role: fixer
           prompt_path: .github/scripts/review/prompts/fixer.md
@@ -152,8 +152,8 @@ jobs:
       # artifact so the downstream push step reads a consistent SHA.
 
       - name: Reset workspace ownership after container run
-        # The Codex fixer may run `sudo chown 1000:1000 /workspace`
-        # (the container's UID) to ensure it has write access. Because
+        # The fixer may run `sudo chown 1000:1000 /workspace` (the
+        # container's UID) to ensure it has write access. Because
         # /workspace is bind-mounted from pr-head/ on the host, this
         # changes pr-head/'s owner to UID 1000 on the host. Git then
         # refuses to operate from pr-head/ as the runner (UID 1001),

--- a/DEV-AGENTS.md
+++ b/DEV-AGENTS.md
@@ -41,7 +41,10 @@ Support dev pipeline. Not OpenClaw prompt. Edit directly via PRs — any contrib
 
 - `.github/workflows/` — GitHub Actions workflow definitions
 - `.github/actions/` — Composite actions used by workflows
-- `.github/ci/caveman-rules.md` — Canonical CI-only caveman prompt contract prepended by `review-codex-run`
+- `.github/actions/review-claude-run/` — Direct-`docker run` composite invoking Claude Code against the LiteLLM Anthropic endpoint; v2 pipeline single-writer fixer
+- `.github/scripts/review/prompts/fixer-claude-smoke.md` — Prompt for the Claude fixer auth/IO smoke test
+- `.github/workflows/review-fixer-claude-smoke.yml` — Pre-merge smoke test exercising the Claude fixer container path on PRs touching that path
+- `.github/ci/caveman-rules.md` — Canonical CI-only caveman prompt contract prepended by `review-codex-run` and `review-claude-run`
 - `docs/agentic-pipeline-learnings.md` — Prescriptive review/CI pipeline contract + guardrail doc
 - `scripts/create-deduped-workflow-failure-issue.sh` — Creates/reuses canonical deduplicated GH Actions failure issue for diagnosis workflow
 - `scripts/check-doc-links.sh` — Internal doc link validator for local hooks + CI doc checks
@@ -71,7 +74,7 @@ Treat OpenClaw prompt + spec file edits with care — change live app behavior. 
 
 ## Review Pipeline
 
-PRs reviewed by multi-agent Codex pipeline. Roles same in both versions; orchestration differs.
+PRs reviewed by multi-agent review pipeline (Codex reviewers + Claude fixer in v2). Roles same in both versions; orchestration differs.
 
 **Reviewer roles** (both versions):
 1. Design Review — validates intent + design quality; runs docs-as-spec consistency check on spec-critical changes

--- a/docs/agentic-pipeline-learnings.md
+++ b/docs/agentic-pipeline-learnings.md
@@ -97,10 +97,10 @@ Why **not** just lower `MAX` to `1`: `cap-exhausted` hard-codes `verdict='NO-GO'
 **Why:** Docker silently fails when bind-mount source path doesn't exist. Any workflow mounting host config dirs into devcontainer should `mkdir -p` those paths first. Current Codex review pipeline does this for `~/.config/gh`, `~/.claude`, `~/.codex`; future workflows adding same mounts need same guard.
 **Evidence:** #77, #78
 
-### 2.2 Don't make CI reviewer containers depend on forwarded Anthropic/OAuth credentials
-**Why:** Stable pattern = run review jobs through baked container config, pass only minimal runtime env needed. Today's Codex reviewer jobs forward `OPENAI_API_KEY=fake-key` and `GH_TOKEN=${WORKFLOW_PAT}`; they do not rely on `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` passthrough.
-**Before:** Earlier iterations tried to forward LLM auth env vars directly, failed in confusing ways when container runtime forwarding differed from expectations.
-**Evidence:** #90, #100
+### 2.2 Pass only the active tool's minimal auth env into CI containers
+**Why:** Stable pattern = run review jobs through baked container config, pass only the runtime env the selected CLI actually reads. Current split: Codex reviewer jobs forward `OPENAI_API_KEY=fake-key` and `GH_TOKEN=${WORKFLOW_PAT}`; Claude fixer jobs forward `ANTHROPIC_API_KEY=fake-key`, `ANTHROPIC_BASE_URL=https://llm.featherback-mermaid.ts.net/anthropic/`, and `GH_TOKEN=${WORKFLOW_PAT}`. Neither path should depend on OAuth/keychain passthrough.
+**Before:** Earlier iterations tried to forward unused or mismatched LLM auth env vars directly, failed in confusing ways when container runtime forwarding differed from expectations.
+**Evidence:** #90, #100, #475
 
 ### 2.3 Use `WORKFLOW_PAT` as `GH_TOKEN` for `gh` inside devcontainers
 **Why:** `github.token` doesn't authenticate `gh pr comment` from inside `devcontainers/ci@v0.3` container on self-hosted runners.

--- a/docs/agentic-pipeline-learnings.md
+++ b/docs/agentic-pipeline-learnings.md
@@ -115,9 +115,11 @@ Why **not** just lower `MAX` to `1`: `cap-exhausted` hard-codes `verdict='NO-GO'
 **Why:** BuildKit's default attestations can produce OCI manifest lists without valid platform metadata, breaking `docker push`. If current image-push path needs `BUILDX_NO_DEFAULT_ATTESTATIONS=1`, set it explicitly in workflow code rather than docs only.
 **Evidence:** #133
 
-### 2.6 Use the custom `run-devcontainer` action for run steps; reserve `devcontainers/ci@v0.3` for build-and-push only
-**Why:** `devcontainers/ci@v0.3` hit post-step cleanup crash on self-hosted runners. Repo avoids this by building/pushing with `devcontainers/ci@v0.3`, then running commands through `.github/actions/run-devcontainer/action.yml`, which uses `@devcontainers/cli up/exec` directly.
-**Evidence:** #179
+### 2.6 Run steps go through purpose-built composites against the right base image
+**Why:** `devcontainers/ci@v0.3` hit post-step cleanup crash on self-hosted runners. Two stable patterns:
+- **Non-review workflows** — build/push with `devcontainers/ci@v0.3`, then run via `.github/actions/run-devcontainer/action.yml` (uses `@devcontainers/cli up/exec` directly).
+- **Review pipeline v2** — direct-`docker run` against the dedicated CI image (`.github/ci/Dockerfile`) via `.github/actions/review-codex-run` (read-only reviewers) and `.github/actions/review-claude-run` (single-writer fixer). The CI image is purpose-built for agent jobs and avoids the devcontainer's shared-socket fragility.
+**Evidence:** #179, #475
 
 ### 2.7 Bake the Codex CLI into the Dockerfile; route models via LiteLLM with explicit `CODEX_MODEL`
 **Why:** Runtime CLI downloads stalled on slow networks; missing model defaults caused fallback to mismatched models. Downgrading three of six review stages to `gpt-5-mini` cut review cost ~45% with no measurable quality loss.


### PR DESCRIPTION
Resolves #475

## Summary
- add a dedicated `review-claude-run` composite action that invokes Claude Code against the LiteLLM Anthropic endpoint and preserves the fixer prompt contract/output layout
- switch `.github/workflows/review-fixer.yml` from the Codex runner to the Claude runner while keeping the host-side commit/push flow intact
- add a manual smoke-test workflow plus prompt for validating Claude auth, reviewer-artifact reads, workspace writes, and output capture; update CI docs/pipeline learnings to document the split reviewer/fixer toolchain

## Test Plan
- `shellcheck scripts/*.sh`
- `shellcheck .github/actions/review-claude-run/run-in-container.sh`
- `yamllint .github/workflows/*.yml`
- `yamllint .github/actions/review-claude-run/action.yml`
- `bash scripts/check-doc-links.sh`
- `actionlint .github/workflows/review-fixer.yml .github/workflows/review-fixer-claude-smoke.yml`
- `bash scripts/validate-workflow-refs.sh`
- local smoke run of `.github/actions/review-claude-run/run-in-container.sh` with `ANTHROPIC_BASE_URL=https://llm.featherback-mermaid.ts.net/anthropic/`, seeded reviewer artifacts, and assertions on `.review-output/fixer-smoke-result.json` plus `.review-output/claude-smoke-target.txt`

Generated with Codex