### PR TITLE
fix(review): JSON skeleton for docs/prompt/psych reviewers

### DIFF
--- a/.github/scripts/review/prompts/docs.md
+++ b/.github/scripts/review/prompts/docs.md
@@ -31,7 +31,24 @@ Lens:
 
 ## Output contract
 
-Write verdict as JSON to `$OUTPUT_PATH` per `.github/scripts/review/schema/reviewer-v1.json`. Use `role: "docs"`. Each `blocking_issues[]` entry needs stable `id` (e.g. `"doc-001"`). Each high-confidence blocker → matching `fix_suggestions[]` entry — doc fix almost always `applicable: "manual"` unless literal rename.
+Write verdict as JSON to `$OUTPUT_PATH` conforming to `.github/scripts/review/schema/reviewer-v1.json`. Required:
+
+```json
+{
+  "schema_version": "1",
+  "role": "docs",
+  "reviewed_sha": "${REVIEWED_SHA}",
+  "cycle": ${REVIEW_CYCLE},
+  "decision": "approve | request_changes | comment | abstain",
+  "summary": "<one paragraph>",
+  "blocking_issues": [],
+  "non_blocking_notes": [],
+  "fix_suggestions": [],
+  "followup_issues": []
+}
+```
+
+Each `blocking_issues[]` entry needs stable `id` (e.g. `"doc-001"`). Each high-confidence blocker → matching `fix_suggestions[]` entry — doc fix almost always `applicable: "manual"` unless literal rename.
 
 `summary` ≤500 chars. Schema validator hard-fails longer — put detail in `blocking_issues[]` or `non_blocking_notes[]`.
 

--- a/.github/scripts/review/prompts/prompt.md
+++ b/.github/scripts/review/prompts/prompt.md
@@ -33,7 +33,24 @@ Diff touches no prompt or `.md` agent-spec file → set `decision: abstain` with
 
 ## Output contract
 
-Write verdict as JSON to `$OUTPUT_PATH` conforming to `.github/scripts/review/schema/reviewer-v1.json`. Use `role: "prompt"`. Each `blocking_issues[]` entry needs stable `id` (e.g. `"prm-001"`).
+Write verdict as JSON to `$OUTPUT_PATH` conforming to `.github/scripts/review/schema/reviewer-v1.json`. Required:
+
+```json
+{
+  "schema_version": "1",
+  "role": "prompt",
+  "reviewed_sha": "${REVIEWED_SHA}",
+  "cycle": ${REVIEW_CYCLE},
+  "decision": "approve | request_changes | comment | abstain",
+  "summary": "<one paragraph>",
+  "blocking_issues": [],
+  "non_blocking_notes": [],
+  "fix_suggestions": [],
+  "followup_issues": []
+}
+```
+
+Each `blocking_issues[]` entry needs stable `id` (e.g. `"prm-001"`).
 
 `summary` ≤500 chars. Schema validator hard-fails longer — put detail in `blocking_issues[]` or `non_blocking_notes[]`.
 

--- a/.github/scripts/review/prompts/psych.md
+++ b/.github/scripts/review/prompts/psych.md
@@ -36,7 +36,24 @@ Pure infra/CI diff, no user-facing change → set `decision: abstain`, one-line 
 
 ## Output contract
 
-Write verdict as JSON to `$OUTPUT_PATH` conforming to `.github/scripts/review/schema/reviewer-v1.json`. Use `role: "psych"`. Each `blocking_issues[]` entry needs stable `id` (e.g. `"psy-001"`).
+Write verdict as JSON to `$OUTPUT_PATH` conforming to `.github/scripts/review/schema/reviewer-v1.json`. Required:
+
+```json
+{
+  "schema_version": "1",
+  "role": "psych",
+  "reviewed_sha": "${REVIEWED_SHA}",
+  "cycle": ${REVIEW_CYCLE},
+  "decision": "approve | request_changes | comment | abstain",
+  "summary": "<one paragraph>",
+  "blocking_issues": [],
+  "non_blocking_notes": [],
+  "fix_suggestions": [],
+  "followup_issues": []
+}
+```
+
+Each `blocking_issues[]` entry needs stable `id` (e.g. `"psy-001"`).
 
 `summary` ≤500 chars. Schema validator hard-fails longer — put detail in `blocking_issues[]` or `non_blocking_notes[]`.
 


### PR DESCRIPTION
## Summary

- Three reviewer prompts (`docs.md`, `prompt.md`, `psych.md`) lacked the inline JSON output skeleton that `design.md` and `security.md` already had.
- Without the skeleton — specifically the `"reviewed_sha": "${REVIEWED_SHA}"` and `"cycle": ${REVIEW_CYCLE}` lines — the LLM had to construct the artifact freely and could pick the wrong SHA. On PR #477 the **prompt** reviewer wrote `5cbb7e1...` (main HEAD via `REVIEW_BASE_SHA`) while the other four wrote `bfa6275...` (`REVIEWED_SHA`).
- Judge (`aggregate.mjs:106`) fails closed on mixed `reviewed_sha` values → forced NO-GO + `needs-human-review`, even though no reviewer flagged a real issue.

This patch mirrors the `design.md` / `security.md` skeleton verbatim across the three remaining reviewers, per the DEV-AGENTS.md "Review prompt file architecture" sibling-files rule (identical wording across siblings unless structure forces variation).

## Test plan

- [ ] Reviewer matrix runs against this PR — five `reviewer-*` artifacts agree on `reviewed_sha`.
- [ ] Judge aggregates without the "spans multiple reviewed_sha values" reason.
- [ ] Pipeline reaches GO (or a real-issue NO-GO).
- [ ] After merge: re-trigger PR #477 (which has been stuck on this exact bug). It should now reach a real verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)