### PR TITLE
ci(review-pipeline-v2): inherit verdict on merge-from-main, finalize without judge artifact

### DIFF
--- a/.github/actions/review-state/action.yml
+++ b/.github/actions/review-state/action.yml
@@ -53,6 +53,9 @@ outputs:
   cycle:
     description: 'Highest prior cycle observed in the commit chain (read-cycle)'
     value: ${{ steps.run.outputs.cycle }}
+  cycle_sha:
+    description: 'SHA where the highest prior cycle was observed (read-cycle); empty when cycle=0'
+    value: ${{ steps.run.outputs.cycle_sha }}
   state:
     description: 'Current state of the requested context (read-status)'
     value: ${{ steps.run.outputs.state }}
@@ -96,6 +99,7 @@ runs:
             MAX_DEPTH=50
             CURRENT="$SHA"
             HIGHEST=0
+            HIGHEST_SHA=""
             for _ in $(seq 1 "$MAX_DEPTH"); do
               if [ "$CURRENT" = "$BASE_SHA" ] || [ -z "$CURRENT" ]; then
                 break
@@ -105,13 +109,17 @@ runs:
                 2>/dev/null || echo "")
               if [[ "$VALUE" =~ ^[0-9]+$ ]] && [ "$VALUE" -gt "$HIGHEST" ]; then
                 HIGHEST="$VALUE"
+                HIGHEST_SHA="$CURRENT"
               fi
               # Step to first parent.
               PARENT=$(gh api "repos/${REPO}/commits/${CURRENT}" \
                 --jq '.parents[0].sha // empty' 2>/dev/null || echo "")
               CURRENT="$PARENT"
             done
-            echo "cycle=$HIGHEST" >> "$GITHUB_OUTPUT"
+            {
+              echo "cycle=$HIGHEST"
+              echo "cycle_sha=$HIGHEST_SHA"
+            } >> "$GITHUB_OUTPUT"
             ;;
 
           write-status)

--- a/.github/workflows/review-finalize.yml
+++ b/.github/workflows/review-finalize.yml
@@ -8,7 +8,7 @@ name: Review pipeline v2 — finalize
 # coverage workflow, not here.
 #
 # On NO-GO: stamps review/cycle-N, applies the `needs-human-review`
-# label, and posts ONE sticky comment summarizing unaddressed blockers.
+# label, and posts a Merge Decision comment summarizing unaddressed blockers.
 # Never closes the PR. Never creates an issue. (User decision: avoid
 # the lessons-learned-issue → new PR → NO-GO infinite loop class.)
 
@@ -77,6 +77,16 @@ jobs:
           context: review/cycle
           state: success
           description: ${{ inputs.cycle }}
+          github_token: ${{ secrets.WORKFLOW_PAT }}
+
+      - name: Stamp review/verdict on post-fix SHA
+        uses: ./.github/actions/review-state
+        with:
+          op: write-status
+          sha: ${{ inputs.post_fix_sha }}
+          context: review/verdict
+          state: ${{ inputs.verdict == 'GO' && 'success' || 'failure' }}
+          description: ${{ inputs.verdict }}
           github_token: ${{ secrets.WORKFLOW_PAT }}
 
       - name: Download verdict artifact

--- a/.github/workflows/review-finalize.yml
+++ b/.github/workflows/review-finalize.yml
@@ -27,6 +27,25 @@ on:
       verdict:
         type: string
         required: true
+      skip_verdict_artifact:
+        # Set by gather paths that bypass the judge and therefore have
+        # no verdict-${sha} artifact to read. Currently set by the
+        # cap-exhausted job and the inherit-on-merge-from-main job.
+        # When true, the finalize job skips the artifact download and
+        # seeds REASONS/BLOCKERS inline so labels and the merge-gate
+        # status still transition to a coherent state on HEAD.
+        type: boolean
+        required: false
+        default: false
+      synthesized_reason_text:
+        # When skip_verdict_artifact=true, this string is used in
+        # place of the verdict-artifact reasons. Empty falls back to
+        # a "cycle cap exceeded after cycle N" default. Pass a
+        # non-empty value from the inherit-on-merge-from-main path
+        # to surface the inherit semantics in the sticky comment.
+        type: string
+        required: false
+        default: ''
     secrets:
       WORKFLOW_PAT:
         required: true
@@ -61,6 +80,7 @@ jobs:
           github_token: ${{ secrets.WORKFLOW_PAT }}
 
       - name: Download verdict artifact
+        if: inputs.skip_verdict_artifact != true
         uses: actions/download-artifact@v4
         with:
           path: ${{ runner.temp }}/verdict
@@ -101,6 +121,9 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ inputs.pr_number }}
           POST_FIX_SHA: ${{ inputs.post_fix_sha }}
+          SKIP_ARTIFACT: ${{ inputs.skip_verdict_artifact }}
+          SYNTH_REASON: ${{ inputs.synthesized_reason_text }}
+          INPUT_CYCLE: ${{ inputs.cycle }}
         run: |
           set -euo pipefail
 
@@ -114,8 +137,20 @@ jobs:
             --repo "$REPO" 2>/dev/null || true
           gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label needs-human-review
 
-          REASONS=$(jq -r '.reasons[]? // empty' "${RUNNER_TEMP}/verdict/verdict-${{ inputs.post_fix_sha }}.json" | sed 's/^/- /')
-          BLOCKERS=$(jq -r '.unaddressed_blocker_ids[]? // empty' "${RUNNER_TEMP}/verdict/verdict-${{ inputs.post_fix_sha }}.json" | sed 's/^/- /')
+          if [ "$SKIP_ARTIFACT" = "true" ]; then
+            # Judge never ran for this finalize call (cap-exhausted or
+            # inherit path), so there is no verdict-${sha}.json.
+            # Synthesize the reason inline.
+            if [ -n "$SYNTH_REASON" ]; then
+              REASONS="- ${SYNTH_REASON}"
+            else
+              REASONS="- cycle cap exceeded after cycle ${INPUT_CYCLE}"
+            fi
+            BLOCKERS=""
+          else
+            REASONS=$(jq -r '.reasons[]? // empty' "${RUNNER_TEMP}/verdict/verdict-${POST_FIX_SHA}.json" | sed 's/^/- /')
+            BLOCKERS=$(jq -r '.unaddressed_blocker_ids[]? // empty' "${RUNNER_TEMP}/verdict/verdict-${POST_FIX_SHA}.json" | sed 's/^/- /')
+          fi
 
           BODY_FILE=$(mktemp)
           {
@@ -152,6 +187,8 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ inputs.pr_number }}
           POST_FIX_SHA: ${{ inputs.post_fix_sha }}
+          SKIP_ARTIFACT: ${{ inputs.skip_verdict_artifact }}
+          SYNTH_REASON: ${{ inputs.synthesized_reason_text }}
         run: |
           set -euo pipefail
 
@@ -167,7 +204,17 @@ jobs:
             --repo "$REPO" 2>/dev/null || true
           gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label agent-reviews-passed
 
-          REASONS=$(jq -r '.reasons[]? // empty' "${RUNNER_TEMP}/verdict/verdict-${{ inputs.post_fix_sha }}.json" | sed 's/^/- /')
+          if [ "$SKIP_ARTIFACT" = "true" ]; then
+            # Inherit-on-merge-from-main path with prior GO. Use the
+            # synthesized reason text as the rationale.
+            if [ -n "$SYNTH_REASON" ]; then
+              REASONS="- ${SYNTH_REASON}"
+            else
+              REASONS=""
+            fi
+          else
+            REASONS=$(jq -r '.reasons[]? // empty' "${RUNNER_TEMP}/verdict/verdict-${POST_FIX_SHA}.json" | sed 's/^/- /')
+          fi
 
           # Post a single Merge Decision comment so humans can see the
           # verdict at a glance. Marker is `<!-- codex-merge-decision -->`

--- a/.github/workflows/review-pipeline.yml
+++ b/.github/workflows/review-pipeline.yml
@@ -58,6 +58,9 @@ jobs:
       roles_json: ${{ steps.classify.outputs.roles_json }}
       cycle: ${{ steps.cycle.outputs.cycle }}
       capped: ${{ steps.cap.outputs.capped }}
+      inherited: ${{ steps.delta.outputs.inherited }}
+      prior_cycle_sha: ${{ steps.cycle-read.outputs.cycle_sha }}
+      prior_verdict: ${{ steps.prior-verdict.outputs.description }}
     steps:
       - name: Checkout reviewed SHA
         uses: actions/checkout@v4
@@ -74,20 +77,73 @@ jobs:
           base_sha: ${{ inputs.base_sha }}
           github_token: ${{ secrets.WORKFLOW_PAT }}
 
-      - name: Compute next cycle and cap check
-        id: cycle
+      # A "cycle" represents new PR content needing review, not branch-HEAD
+      # churn. A merge-from-main (HEAD = merge(prev-PR, main-tip)) absorbs
+      # main into the branch but adds zero new PR content; consuming a
+      # cycle on it can push a PR with prior cycle 2 GO over the cap and
+      # leave it terminally NO-GO. Detect this case and inherit the prior
+      # verdict instead of running reviewers/fixer/judge again.
+      # See docs/agentic-pipeline-learnings.md §1.14.
+      - name: Detect merge-from-main no-content-delta
+        id: delta
         env:
           PRIOR: ${{ steps.cycle-read.outputs.cycle }}
         run: |
           set -euo pipefail
-          NEXT=$(( PRIOR + 1 ))
-          echo "cycle=$NEXT" >> "$GITHUB_OUTPUT"
-          echo "review-pipeline-v2: prior cycle=$PRIOR next=$NEXT"
+          if [ "${PRIOR:-0}" -lt 1 ]; then
+            echo "inherited=false" >> "$GITHUB_OUTPUT"
+            echo "review-pipeline-v2: no prior cycle to inherit from"
+            exit 0
+          fi
+          PARENT_TOKENS=$(git rev-list --parents -n 1 HEAD | wc -w)
+          # rev-list --parents emits "<HEAD> <p1> [<p2> ...]"; <3 tokens
+          # means HEAD has 0 or 1 parents (not a merge commit).
+          if [ "$PARENT_TOKENS" -lt 3 ]; then
+            echo "inherited=false" >> "$GITHUB_OUTPUT"
+            echo "review-pipeline-v2: HEAD is not a merge commit"
+            exit 0
+          fi
+          SECOND=$(git rev-parse HEAD^2)
+          git fetch origin main --depth=50 --quiet
+          if git merge-base --is-ancestor "$SECOND" origin/main; then
+            echo "inherited=true" >> "$GITHUB_OUTPUT"
+            echo "review-pipeline-v2: HEAD is merge-from-main (second parent ${SECOND} is on origin/main); inheriting prior cycle ${PRIOR}"
+          else
+            echo "inherited=false" >> "$GITHUB_OUTPUT"
+            echo "review-pipeline-v2: HEAD is a merge commit but second parent ${SECOND} is NOT on origin/main"
+          fi
+
+      - name: Read prior verdict from cycle SHA
+        id: prior-verdict
+        if: steps.delta.outputs.inherited == 'true'
+        uses: ./.github/actions/review-state
+        with:
+          op: read-status
+          sha: ${{ steps.cycle-read.outputs.cycle_sha }}
+          context: review/verdict
+          github_token: ${{ secrets.WORKFLOW_PAT }}
+
+      - name: Compute next cycle and cap check
+        id: cycle
+        env:
+          PRIOR: ${{ steps.cycle-read.outputs.cycle }}
+          INHERITED: ${{ steps.delta.outputs.inherited }}
+        run: |
+          set -euo pipefail
+          if [ "$INHERITED" = "true" ]; then
+            echo "cycle=$PRIOR" >> "$GITHUB_OUTPUT"
+            echo "review-pipeline-v2: inheriting cycle=$PRIOR (no PR content delta)"
+          else
+            NEXT=$(( PRIOR + 1 ))
+            echo "cycle=$NEXT" >> "$GITHUB_OUTPUT"
+            echo "review-pipeline-v2: prior cycle=$PRIOR next=$NEXT"
+          fi
 
       - name: Cap check
         id: cap
         env:
           NEXT: ${{ steps.cycle.outputs.cycle }}
+          INHERITED: ${{ steps.delta.outputs.inherited }}
           # NO-GO retries only: MAX bounds the number of cycles the
           # fixer gets on a PR whose cycle 1 did not converge. GO
           # cycles are short-circuited in review-entry.yml after
@@ -96,7 +152,11 @@ jobs:
           MAX: '2'
         run: |
           set -euo pipefail
-          if [ "$NEXT" -gt "$MAX" ]; then
+          # An inherited cycle does not consume a fresh cycle slot, so
+          # the cap never fires on the inherit path — see §1.14.
+          if [ "$INHERITED" = "true" ]; then
+            echo "capped=false" >> "$GITHUB_OUTPUT"
+          elif [ "$NEXT" -gt "$MAX" ]; then
             echo "capped=true" >> "$GITHUB_OUTPUT"
           else
             echo "capped=false" >> "$GITHUB_OUTPUT"
@@ -104,14 +164,14 @@ jobs:
 
       - name: Classify diff into reviewer roles
         id: classify
-        if: steps.cap.outputs.capped != 'true'
+        if: steps.cap.outputs.capped != 'true' && steps.delta.outputs.inherited != 'true'
         uses: ./.github/actions/review-classify
         with:
           base_ref: ${{ inputs.base_sha }}
           head_sha: ${{ inputs.reviewed_sha }}
 
       - name: Stamp gather status
-        if: steps.cap.outputs.capped != 'true'
+        if: steps.cap.outputs.capped != 'true' && steps.delta.outputs.inherited != 'true'
         uses: ./.github/actions/review-state
         with:
           op: write-status
@@ -119,6 +179,17 @@ jobs:
           context: review/gather
           state: success
           description: 'cycle=${{ steps.cycle.outputs.cycle }} roles=${{ steps.classify.outputs.roles_json }}'
+          github_token: ${{ secrets.WORKFLOW_PAT }}
+
+      - name: Stamp gather status (inherit path)
+        if: steps.delta.outputs.inherited == 'true'
+        uses: ./.github/actions/review-state
+        with:
+          op: write-status
+          sha: ${{ inputs.reviewed_sha }}
+          context: review/gather
+          state: success
+          description: 'cycle=${{ steps.cycle.outputs.cycle }} inherited from ${{ steps.cycle-read.outputs.cycle_sha }}'
           github_token: ${{ secrets.WORKFLOW_PAT }}
 
   cap-exhausted:
@@ -131,6 +202,26 @@ jobs:
       post_fix_sha: ${{ inputs.reviewed_sha }}
       cycle: ${{ needs.gather.outputs.cycle }}
       verdict: 'NO-GO'
+      skip_verdict_artifact: true
+    secrets:
+      WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}
+
+  # Inherit-on-merge-from-main path: HEAD is a clean merge from main
+  # with no PR-side content delta, so we re-stamp the prior verdict on
+  # HEAD without rerunning reviewers/fixer/judge. See §1.14 in
+  # docs/agentic-pipeline-learnings.md.
+  inherit:
+    name: Inherit prior verdict (merge-from-main)
+    needs: gather
+    if: needs.gather.outputs.inherited == 'true'
+    uses: ./.github/workflows/review-finalize.yml
+    with:
+      pr_number: ${{ inputs.pr_number }}
+      post_fix_sha: ${{ inputs.reviewed_sha }}
+      cycle: ${{ needs.gather.outputs.cycle }}
+      verdict: ${{ needs.gather.outputs.prior_verdict }}
+      skip_verdict_artifact: true
+      synthesized_reason_text: 'inherited from prior cycle ${{ needs.gather.outputs.cycle }} (HEAD is merge-from-main with no PR content delta)'
     secrets:
       WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}
 
@@ -164,6 +255,7 @@ jobs:
     needs: gather
     if: |
       needs.gather.outputs.capped != 'true' &&
+      needs.gather.outputs.inherited != 'true' &&
       contains(fromJSON(needs.gather.outputs.roles_json), 'design')
     uses: ./.github/workflows/review-reviewer.yml
     with:
@@ -183,6 +275,7 @@ jobs:
     needs: gather
     if: |
       needs.gather.outputs.capped != 'true' &&
+      needs.gather.outputs.inherited != 'true' &&
       contains(fromJSON(needs.gather.outputs.roles_json), 'security')
     uses: ./.github/workflows/review-reviewer.yml
     with:
@@ -202,6 +295,7 @@ jobs:
     needs: gather
     if: |
       needs.gather.outputs.capped != 'true' &&
+      needs.gather.outputs.inherited != 'true' &&
       contains(fromJSON(needs.gather.outputs.roles_json), 'psych')
     uses: ./.github/workflows/review-reviewer.yml
     with:
@@ -221,6 +315,7 @@ jobs:
     needs: gather
     if: |
       needs.gather.outputs.capped != 'true' &&
+      needs.gather.outputs.inherited != 'true' &&
       contains(fromJSON(needs.gather.outputs.roles_json), 'docs')
     uses: ./.github/workflows/review-reviewer.yml
     with:
@@ -240,6 +335,7 @@ jobs:
     needs: gather
     if: |
       needs.gather.outputs.capped != 'true' &&
+      needs.gather.outputs.inherited != 'true' &&
       contains(fromJSON(needs.gather.outputs.roles_json), 'prompt')
     uses: ./.github/workflows/review-reviewer.yml
     with:
@@ -265,6 +361,7 @@ jobs:
     if: |
       always() &&
       needs.gather.outputs.capped != 'true' &&
+      needs.gather.outputs.inherited != 'true' &&
       needs.gather.result == 'success' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
@@ -285,6 +382,7 @@ jobs:
     if: |
       always() &&
       needs.gather.outputs.capped != 'true' &&
+      needs.gather.outputs.inherited != 'true' &&
       needs.gather.result == 'success' &&
       needs.fix.result == 'success' &&
       !contains(needs.*.result, 'failure') &&
@@ -304,6 +402,7 @@ jobs:
     if: |
       always() &&
       needs.gather.outputs.capped != 'true' &&
+      needs.gather.outputs.inherited != 'true' &&
       needs.gather.result == 'success' &&
       needs.judge.result == 'success'
     uses: ./.github/workflows/review-finalize.yml
@@ -330,6 +429,7 @@ jobs:
     needs:
       - gather
       - cap-exhausted
+      - inherit
       - review-design
       - review-security
       - review-psych

--- a/docs/agentic-pipeline-learnings.md
+++ b/docs/agentic-pipeline-learnings.md
@@ -87,6 +87,22 @@ Why **not** just lower `MAX` to `1`: `cap-exhausted` hard-codes `verdict='NO-GO'
 **Before:** PR #397 posted three full Merge Decisions and ~15 reviewer comments for single docs-only PR already GO at cycle 1.
 **Evidence:** #397
 
+### 1.14 A cycle represents new PR content, not branch-HEAD churn
+**Why:** Cycle counter walks first-parents in `review-state` `read-cycle` (`.github/actions/review-state/action.yml`) and increments on each new HEAD SHA. But a `git merge main` into a PR branch creates a new HEAD that adds zero new PR-side content — it only absorbs main. Counting that as a fresh cycle pushes a PR with `cycle=2 GO` over `MAX=2` and into `cap-exhausted`, which invalidates the prior verdict. See §1.14 invariant: a cycle is consumed only when there is new PR content to review.
+
+Detection lives in `review-pipeline.yml` `gather` job: HEAD has 2+ parents AND `HEAD^2` is reachable from `origin/main` ⇒ inherit. The `inherit` job re-stamps the prior verdict on the new HEAD via `review-finalize.yml` with `skip_verdict_artifact: true` and a `synthesized_reason_text` indicating the inherit. Reviewers/fixer/judge are skipped via additional `inherited != 'true'` guards alongside the existing `capped != 'true'` guards.
+
+This is **not** the same problem as §1.13's GO short-circuit. §1.13 prevents redundant pipeline runs after a GO; §1.14 handles the case where main has moved and the PR resyncs but does not add content — `review-entry.yml`'s GO short-circuit can't fire because the new HEAD has no `All Required Agent Reviews = success` of its own yet. Both rules together: a PR that has converged stays converged across both no-op pushes (§1.13) and clean main resyncs (§1.14).
+**Evidence:** PR #477
+
+### 1.15 Terminal NO-GO paths must finalize labels and the merge-gate status without depending on judge artifacts
+**Why:** `review-finalize.yml`'s `Download verdict artifact` step (`name: verdict-${sha}`) only finds an artifact when the judge has run. Cap-exhausted (§1.14) and inherit-on-merge-from-main bypass the judge entirely, so the artifact does not exist on those paths; an unconditional download fails the job before the label/status work runs. Result before fix: PR ends with `agent-reviews-passed` label still set (cycle 2 GO) AND no `All Required Agent Reviews` status on HEAD — branch protection blocks but the PR's labels look green, exactly the inconsistent state surfaced by PR #477.
+
+Contract: any pipeline-exit path that calls `review-finalize.yml` without a `verdict-${sha}` artifact must pass `skip_verdict_artifact: true` so finalize can synthesize REASONS inline. Optionally pass `synthesized_reason_text` to override the default "cycle cap exceeded" message (the inherit path uses this). Both cap-exhausted and inherit jobs in `review-pipeline.yml` follow this contract.
+
+Single-writer rule from §1.1 still holds: label transitions and the `All Required Agent Reviews` status are still written exclusively from `review-finalize.yml`. `skip_verdict_artifact` is a parameterization, not a duplicate writer.
+**Evidence:** PR #477
+
 ---
 
 ## 2. CI Runtime Infrastructure

--- a/docs/agentic-pipeline-learnings.md
+++ b/docs/agentic-pipeline-learnings.md
@@ -29,7 +29,7 @@ Two meta-lessons:
 **Evidence:** #303, #315, #301
 
 ### 1.4 Merge-decision verdict shape: binary GO / NO-GO
-**Why:** Two states — GO / NO-GO. Cost-control is structural: fixer runs after reviewers + before judge; judge has `permissions: contents: read` and cannot push; fixer publishes new commit first then writes `review/pipeline` status immediately (GitHub rejects status for unpublished SHA). Re-review loops on finalized GO SHAs prevented by GO-only `All Required Agent Reviews = success` short-circuit at entry. NO-GO = human escalation: labels PR `needs-human-review`, posts one sticky comment, does **not** close PR or auto-create replacement issue (avoids lessons-learned-issue → new PR → NO-GO infinite loop).
+**Why:** Two states — GO / NO-GO. Cost-control is structural: fixer runs after reviewers + before judge; judge has `permissions: contents: read` and cannot push; fixer publishes new commit first then writes `review/pipeline` status immediately (GitHub rejects status for unpublished SHA). Re-review loops on finalized GO SHAs prevented by GO-only `All Required Agent Reviews = success` short-circuit at entry. NO-GO = human escalation: labels PR `needs-human-review`, posts a Merge Decision comment, does **not** close PR or auto-create replacement issue (avoids lessons-learned-issue → new PR → NO-GO infinite loop).
 **Historical context:** A previous three-state pipeline (GO-CLEAN / GO-WITH-RESERVATIONS / NO-GO) tried to collapse re-review loops at the verdict layer; the current pipeline solves the same cost problem at the orchestration layer instead, which is why two states suffice.
 **Evidence:** #315, #320, #322, #274, #336, #341, #342, #343
 


### PR DESCRIPTION
## Summary

PR #477 surfaced two compounding defects in the v2 review pipeline that together leave a PR with stale `agent-reviews-passed` **and** no `All Required Agent Reviews` status on HEAD — branch protection blocks but the labels look green.

### Defect A — cycle counter increments on innocuous merge-from-main

A `git merge main` into a PR branch creates a new HEAD that adds zero new PR-side content but consumes a cycle. With prior cycle 2 GO, cycle 3 trips `MAX='2'` and routes through `cap-exhausted`, invalidating the prior verdict.

### Defect B — cap-exhausted finalize crashes before its label/status work

`review-finalize.yml`'s `Download verdict artifact` step pulls `verdict-${sha}` unconditionally. `cap-exhausted` bypasses the judge, so the artifact does not exist, the step fails, and the label/status transitions never run.

## Fixes

- **`review-finalize.yml`**: introduce `skip_verdict_artifact: bool` + `synthesized_reason_text: string` inputs. Gate the artifact download on `skip_verdict_artifact != true`. Synthesize `REASONS`/`BLOCKERS` inline in both NO-GO and GO blocks.
- **`review-pipeline.yml`**: add `Detect merge-from-main no-content-delta` step in `gather` (HEAD has 2+ parents AND `HEAD^2` is ancestor of `origin/main` ⇒ inherit). Add a new `inherit` job that calls `review-finalize.yml` with the prior verdict (read from `review/verdict` on the prior cycle SHA via the existing `read-status` op) and the inherit-flavored synthesized reason. Existing reviewer/fixer/judge/finalize jobs gain an `inherited != 'true'` guard alongside the existing `capped != 'true'` guard. `cap-exhausted` now passes `skip_verdict_artifact: true`.
- **`review-state/action.yml`**: add `cycle_sha` output to `read-cycle` so the inherit path knows which SHA to read prior verdict from.
- **`docs/agentic-pipeline-learnings.md`**: append §1.14 (cycle = new PR content, not branch-HEAD churn) and §1.15 (terminal NO-GO must finalize without judge artifacts).

## Test plan

- [x] `bash scripts/run-required-checks.sh ci-workflows` — actionlint + workflow-ref validators pass
- [x] `bash scripts/run-required-checks.sh ci-docs` — doc-link + spec-catalog + Mermaid validators pass
- [ ] After merge: re-trigger pipeline on PR #477; expect cap-exhausted finalize to run end-to-end and transition labels (`agent-reviews-passed` → `needs-human-review`) and post `All Required Agent Reviews=failure` on HEAD
- [ ] After merge: confirm the inherit path on a fresh test PR — branch with `cycle=2 GO` + `git merge main` → expect `gather` to log "HEAD is merge-from-main; inheriting prior cycle 2", reviewers/fixer/judge skip, and `inherit` job re-stamps `All Required Agent Reviews=success` on the new HEAD

## Why this is safe

- Single-writer rule from §1.1 still holds: label transitions and the `All Required Agent Reviews` status are still written exclusively from `review-finalize.yml`. The new inputs are parameterizations, not duplicate writers.
- Inherit detection is conservative: it requires HEAD to be a merge commit AND `HEAD^2` to be reachable from `origin/main`. A merge from any other branch (feature merge, prior PR re-merge) does not match and falls through to the normal cycle path.
- Inherit only fires when prior cycle ≥ 1; first-cycle pushes are unaffected.

## Recovery for PR #477 specifically

This fix does not retroactively re-stamp the failed run on `6bdaae6`. After merge, the operator can either push an empty re-trigger commit to PR #477 (the new HEAD will hit the inherit path via Fix B) or admin-merge given cycle 2 already produced a real GO verdict on `1b0a11f`.