### PR TITLE
Tighten reminder confirmations to block reasoning leaks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,19 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if echo \"$TOOL_INPUT\" | grep -q 'create-reminder'; then echo 'USER-FACING REMINDER CONFIRMATION ONLY. No internal notes. No mention of cron, polling, scheduling internals, tool use, hidden reasoning, or whether something will trigger automatically. Reply with one brief confirmation sentence containing only the reminder details.'; fi",
+            "timeout": 5,
+            "statusMessage": "Reinforcing reminder confirmation guardrails..."
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if echo \"$TOOL_INPUT\" | grep -q 'create-reminder'; then echo 'USER-FACING REMINDER CONFIRMATION ONLY. No internal notes. No mention of cron, polling, scheduling internals, tool use, hidden reasoning, or whether something will trigger automatically. Reply with one brief confirmation sentence containing only the reminder details.'; fi",
+            "command": "if echo \"$TOOL_INPUT\" | grep -q 'create-reminder' && python3 -c \"import json,os,sys; raw=os.environ.get('TOOL_OUTPUT','') or ''; d=json.loads(raw) if raw else {}; out=d.get('output',raw) if isinstance(d,dict) else raw; r=json.loads(out) if out else {}; sys.exit(0 if isinstance(r,dict) and r.get('object')=='page' else 1)\" 2>/dev/null; then echo 'USER-FACING REMINDER CONFIRMATION ONLY. No internal notes. No mention of cron, polling, scheduling internals, tool use, hidden reasoning, or implementation triggers. Use approximate timing (e.g., around 6pm PT not at exactly 6pm PT) since delivery may lag up to ~75 min. Reply with one brief confirmation sentence containing only the reminder details.'; fi",
             "timeout": 5,
             "statusMessage": "Reinforcing reminder confirmation guardrails..."
           }

--- a/docs/ai-prompts/intake.md
+++ b/docs/ai-prompts/intake.md
@@ -214,6 +214,13 @@ If task is too vague and clarification_count < 3:
 CONFIRMATION MESSAGE FORMAT:
 - For inline steps: "Got it — [work type], ~[time]. Here's your plan: 1) X, 2) Y, 3) Z"
 - For hidden sub-tasks: "Got it — [work type], ~[time]. First step: [step]. This is 1 of [N] steps."
+- For reminders: "Got it — I'll remind you Wednesday evening to set up your video call software for therapy."
+
+REMINDER CONFIRMATION SAFETY:
+- Reminder confirmations are user-facing only.
+- Do not append notes about cron jobs, polling windows, handoff files, scheduling internals, tool calls, or whether something will trigger automatically.
+- Do not include self-commentary about what you did, did not do, or considered internally.
+- If the reminder was saved successfully, confirm the reminder details once and stop.
 
 IMPORTANT:
 - The user should always see specific next actions, never just "Added - focus work, ~30 min".
@@ -222,6 +229,7 @@ IMPORTANT:
 - Minimize questions. Minimize decisions. Infer aggressively and move forward.
 - If you must ask, ask ONE simple question. Never batch questions together.
 - After 3 clarifying questions, stop asking and save with your best inference.
+- Reminder confirmations must never leak internal reasoning or implementation details into the visible reply.
 ```
 
 ### Storage Decision Rules

--- a/docs/ai-prompts/shared.md
+++ b/docs/ai-prompts/shared.md
@@ -58,6 +58,8 @@ CONSTRAINTS:
 - Prefer inference over questions during task intake — ask only when truly needed
 - Keep responses under 50 words unless explaining something complex
 - Always be ready to add a task or suggest one
+- User-visible replies must contain only user-facing content
+- Never surface hidden reasoning, self-checks, tool-status narration, or internal implementation details
 
 SHAME PREVENTION (MANDATORY — applies to every response):
 Rejection and criticism can feel intensely personal for some people.
@@ -82,7 +84,18 @@ RESPONSE STYLE:
 - No formal greetings ("Hello!", "Thank you for...")
 - Use contractions naturally
 - Acknowledge briefly, then move forward
+- Do not append meta commentary like "Note:" or internal self-assessments after the user-facing answer
 ```
+
+## Visible Output Boundary
+
+Everything the user sees should read like direct conversation, not system narration.
+
+Rules:
+- Never expose internal reasoning, chain-of-thought, hidden compliance checks, or tool-status narration.
+- Never mention reminder infrastructure like cron jobs, polling, handoff files, Notion writes, tool calls, or whether something will trigger automatically unless the user explicitly asks.
+- After a successful reminder create call, send only the reminder confirmation itself. No appended caveats, diagnostics, or self-evaluation.
+- If an internal distinction matters operationally, keep it internal unless the user explicitly asks for technical detail.
 
 
 ---

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -202,7 +202,7 @@ We use `PostToolUse` hook to enforce reminder confirmation and suppress internal
       "hooks": [{
         "type": "command",
         "command": "if echo \"$TOOL_INPUT\" | grep -q 'create-reminder'; then echo 'USER-FACING REMINDER CONFIRMATION ONLY. No internal notes. No mention of cron, polling, scheduling internals, tool use, hidden reasoning, or whether something will trigger automatically. Reply with one brief confirmation sentence containing only the reminder details.'; fi",
-        "timeout": 3000
+        "timeout": 5
       }]
     }]
   }

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -192,7 +192,7 @@ OpenClaw gateway = WebSocket server managing agent sessions, channel routing, co
 
 OpenClaw agent sessions built on Claude Code REPL. Claude Code hook system works inside OpenClaw — `.claude/settings.json` at project level respected.
 
-We use `PostToolUse` hook to enforce reminder confirmation:
+We use `PostToolUse` hook to enforce reminder confirmation and suppress internal reminder commentary:
 
 ```json
 {
@@ -201,7 +201,7 @@ We use `PostToolUse` hook to enforce reminder confirmation:
       "matcher": "Bash",
       "hooks": [{
         "type": "command",
-        "command": "if echo \"$TOOL_INPUT\" | grep -q 'create-reminder'; then echo 'HOOK: Confirm reminder details to user.'; fi",
+        "command": "if echo \"$TOOL_INPUT\" | grep -q 'create-reminder'; then echo 'USER-FACING REMINDER CONFIRMATION ONLY. No internal notes. No mention of cron, polling, scheduling internals, tool use, hidden reasoning, or whether something will trigger automatically. Reply with one brief confirmation sentence containing only the reminder details.'; fi",
         "timeout": 3000
       }]
     }]

--- a/docs/user-interactions.md
+++ b/docs/user-interactions.md
@@ -802,7 +802,9 @@ AI detects reminder-style language and sets:
 - `urgency = 90` (time-critical)
 
 **Confirmation message style:**
-> "Got it — I'll queue a reminder for 6pm PT to email Melanie. You'll usually hear from me within an hour of that — up to ~75 min if things are quiet — so treat it as a check-in, not a stopwatch."
+> "Got it — I'll remind you at 6pm PT to email Melanie."
+
+Reminder confirmations stay user-facing and brief. They should not include internal scheduling notes, delivery-path explanations, or self-assessment about what the model did behind the scenes.
 
 User timezone defaults to US Central. AI converts timezone references (PT, CT, ET) to UTC offsets at intake.
 

--- a/docs/user-interactions.md
+++ b/docs/user-interactions.md
@@ -802,7 +802,7 @@ AI detects reminder-style language and sets:
 - `urgency = 90` (time-critical)
 
 **Confirmation message style:**
-> "Got it — I'll remind you at 6pm PT to email Melanie."
+> "Got it — I'll remind you around 6pm PT to email Melanie."
 
 Reminder confirmations stay user-facing and brief. They should not include internal scheduling notes, delivery-path explanations, or self-assessment about what the model did behind the scenes.
 


### PR DESCRIPTION
Resolves #486

## Summary
- add a PostToolUse reminder hook that forces a single user-facing confirmation after `create-reminder`
- tighten shared and intake prompt rules so reminder confirmations never include internal notes, scheduling commentary, or self-assessment
- update reminder-facing docs/examples to match the new visible-output boundary

## Test Plan
- `shellcheck scripts/*.sh`
- `yamllint .github/workflows/*.yml`
- `bash scripts/check-doc-links.sh`
- `jq empty .claude/settings.json`

Generated with Codex