### PR TITLE
Add stop-hook filter for reminder reasoning leaks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,15 +12,14 @@
         ]
       }
     ],
-    "PostToolUse": [
+    "Stop": [
       {
-        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "if echo \"$TOOL_INPUT\" | grep -q 'create-reminder' && python3 -c \"import json,os,sys; raw=os.environ.get('TOOL_OUTPUT','') or ''; d=json.loads(raw) if raw else {}; out=d.get('output',raw) if isinstance(d,dict) else raw; r=json.loads(out) if out else {}; sys.exit(0 if isinstance(r,dict) and r.get('object')=='page' else 1)\" 2>/dev/null; then echo 'USER-FACING REMINDER CONFIRMATION ONLY. No internal notes. No mention of cron, polling, scheduling internals, tool use, hidden reasoning, or implementation triggers. Use approximate timing (e.g., around 6pm PT not at exactly 6pm PT) since delivery may lag up to ~75 min. Reply with one brief confirmation sentence containing only the reminder details.'; fi",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/block-reminder-reasoning-leak.sh",
             "timeout": 5,
-            "statusMessage": "Reinforcing reminder confirmation guardrails..."
+            "statusMessage": "Checking reminder confirmation output..."
           }
         ]
       }

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -188,20 +188,19 @@ OpenClaw gateway = WebSocket server managing agent sessions, channel routing, co
 1. Must be running for agent to work (`openclaw gateway`)
 2. `controlUi.allowedOrigins` controls who can access web management interface
 
-## Tool-Use Hooks (.claude/settings.json)
+## Claude Code Hooks (.claude/settings.json)
 
 OpenClaw agent sessions built on Claude Code REPL. Claude Code hook system works inside OpenClaw — `.claude/settings.json` at project level respected.
 
-We use `PostToolUse` hook to enforce reminder confirmation and suppress internal reminder commentary:
+We use a `Stop` hook to validate the final reminder confirmation before Claude ends the turn. If the reply contains a reminder confirmation plus leak markers like `Note:` or `trigger automatically`, the hook blocks stop and tells Claude to rewrite the response as a single user-facing sentence:
 
 ```json
 {
   "hooks": {
-    "PostToolUse": [{
-      "matcher": "Bash",
+    "Stop": [{
       "hooks": [{
         "type": "command",
-        "command": "if echo \"$TOOL_INPUT\" | grep -q 'create-reminder'; then echo 'USER-FACING REMINDER CONFIRMATION ONLY. No internal notes. No mention of cron, polling, scheduling internals, tool use, hidden reasoning, or whether something will trigger automatically. Reply with one brief confirmation sentence containing only the reminder details.'; fi",
+        "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/block-reminder-reasoning-leak.sh",
         "timeout": 5
       }]
     }]
@@ -209,11 +208,13 @@ We use `PostToolUse` hook to enforce reminder confirmation and suppress internal
 }
 ```
 
-Claude Code mechanism, not OpenClaw. OpenClaw has own hook system (`openclaw hooks`) for platform-level events like `agent:bootstrap`, but for tool-use triggers we use Claude Code layer.
+Why `Stop` instead of `PostToolUse`: `PostToolUse` fires after the tool succeeds and can only add more context for Claude; it does not inspect or rewrite the final assistant reply. The leak happens in the rendered reminder confirmation itself, so the enforcement point has to sit on the final response boundary. Claude Code does not expose a pre-response rewrite hook, so `Stop` is the structural guardrail available here.
+
+Claude Code mechanism, not OpenClaw. OpenClaw has own hook system (`openclaw hooks`) for platform-level events like `agent:bootstrap`; the reminder confirmation leak guard lives in the Claude Code layer because it validates Claude's final reply text.
 
 **Key distinction:**
 - **OpenClaw hooks** (`openclaw hooks list`): Platform events — bootstrap, session-memory, command-logging. Configured in `openclaw.json`.
-- **Claude Code hooks** (`.claude/settings.json`): Tool-use events — PostToolUse, PreToolUse. Configured per-project.
+- **Claude Code hooks** (`.claude/settings.json`): Response/tool lifecycle events like Stop, PostToolUse, and PreToolUse. Configured per-project.
 
 ## OpenClaw Hooks (Platform-Level)
 

--- a/scripts/block-reminder-reasoning-leak.sh
+++ b/scripts/block-reminder-reasoning-leak.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# block-reminder-reasoning-leak.sh
+#
+# Claude Code Stop hook guard for reminder confirmations. This validates the
+# actual final assistant reply and blocks stop when a reminder confirmation
+# includes leaked internal commentary such as "Note:" or scheduling internals.
+
+set -euo pipefail
+
+HOOK_INPUT="$(cat)"
+
+HOOK_INPUT="$HOOK_INPUT" python3 - <<'PY'
+import json
+import os
+import pathlib
+import re
+import sys
+import tempfile
+
+
+CONFIRMATION_PATTERN = re.compile(
+    r"\bi.?ll\s+(?:remind|ping|nudge)\s+you\b",
+    re.IGNORECASE,
+)
+LEAK_PATTERN = re.compile(
+    r"(^\s*note:)"
+    r"|"
+    r"\b("
+    r"i did not"
+    r"|this will not trigger"
+    r"|trigger automatically"
+    r"|this turn"
+    r"|cron"
+    r"|poll(?:ing)?"
+    r"|handoff"
+    r"|tool call"
+    r"|hidden reasoning"
+    r"|scheduling internals?"
+    r")\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+MAX_ATTEMPTS = 2
+
+
+def attempt_file(session_id: str) -> pathlib.Path:
+    state_dir = pathlib.Path(tempfile.gettempdir()) / "hide-my-list-stop-hook"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    return state_dir / f"{session_id}.reminder"
+
+
+def read_attempt_count(path: pathlib.Path) -> int:
+    try:
+        return int(path.read_text(encoding="utf-8").strip() or "0")
+    except (OSError, ValueError):
+        return 0
+
+
+def clear_attempt_count(path: pathlib.Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+    except OSError:
+        return
+
+
+def main() -> int:
+    data = json.loads(os.environ["HOOK_INPUT"])
+    message = (data.get("last_assistant_message") or "").strip()
+    session_id = data.get("session_id") or "unknown-session"
+    state_path = attempt_file(session_id)
+
+    if not message:
+        clear_attempt_count(state_path)
+        return 0
+
+    if not CONFIRMATION_PATTERN.search(message) or not LEAK_PATTERN.search(message):
+        clear_attempt_count(state_path)
+        return 0
+
+    attempts = read_attempt_count(state_path)
+    if attempts >= MAX_ATTEMPTS:
+        clear_attempt_count(state_path)
+        return 0
+
+    state_path.write_text(str(attempts + 1), encoding="utf-8")
+    json.dump(
+        {
+            "decision": "block",
+            "reason": (
+                "Your last reply mixed a reminder confirmation with internal "
+                "scheduling commentary. Rewrite it as exactly one brief "
+                "user-facing reminder confirmation sentence. Remove any note "
+                "or explanation about tool use, cron, polling, delivery "
+                "windows, hidden reasoning, trigger behavior, or what "
+                "happened 'in this turn'."
+            ),
+        },
+        sys.stdout,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+PY


### PR DESCRIPTION
Resolves #489

## Summary
- replace the failed `.claude/settings.json` `PostToolUse` reminder guard with a `Stop` hook
- add `scripts/block-reminder-reasoning-leak.sh` to inspect the final assistant reply and block reminder confirmations that append internal scheduling commentary
- update `docs/openclaw-integration.md` to describe the stop-hook boundary and remove the stale `PostToolUse` guidance

## Test Plan
- `shellcheck scripts/*.sh`
- `yamllint .github/workflows/*.yml`
- `bash scripts/check-doc-links.sh`
- `jq empty .claude/settings.json`
- pipe reproduced leak and clean reminder samples through `scripts/block-reminder-reasoning-leak.sh`

Generated with Codex