### PR TITLE
fix(review): reset workspace ownership in container-run composites

### DIFF
--- a/.github/actions/review-claude-run/action.yml
+++ b/.github/actions/review-claude-run/action.yml
@@ -186,6 +186,27 @@ runs:
           "$CI_AGENT_IMAGE" \
           -lc '/run-in-container.sh'
 
+    - name: Reset workspace ownership after container run
+      # The container writes files into the bind-mounted workspace as
+      # UID 1000 (`ci` user). The self-hosted runner is a different UID
+      # (typically 1001). Without resetting ownership, those UID-1000
+      # files persist on the runner across jobs — the next job's
+      # `actions/checkout` clean step then fails with "Permission denied"
+      # on `.git/index.lock` or on rmdir of leftover dirs (e.g. `.claude`,
+      # `pr-head`), and the whole pipeline aborts before any reviewer
+      # finishes. Reset under `if: always()` so failed `docker run`
+      # invocations still clean up their mess.
+      if: always()
+      shell: bash
+      env:
+        WORKSPACE_FOLDER: ${{ inputs.workspace_folder }}
+      run: |
+        set -euo pipefail
+        WORKSPACE_HOST="${GITHUB_WORKSPACE}/${WORKSPACE_FOLDER}"
+        if [ -d "$WORKSPACE_HOST" ]; then
+          sudo chown -R "$(id -u):$(id -g)" "$WORKSPACE_HOST"
+        fi
+
     - name: Clean up staged env file
       if: always()
       shell: bash

--- a/.github/actions/review-codex-run/action.yml
+++ b/.github/actions/review-codex-run/action.yml
@@ -221,6 +221,27 @@ runs:
           "$CI_AGENT_IMAGE" \
           -lc '/run-in-container.sh'
 
+    - name: Reset workspace ownership after container run
+      # The container writes files into the bind-mounted workspace as
+      # UID 1000 (`ci` user). The self-hosted runner is a different UID
+      # (typically 1001). Without resetting ownership, those UID-1000
+      # files persist on the runner across jobs — the next job's
+      # `actions/checkout` clean step then fails with "Permission denied"
+      # on `.git/index.lock` or on rmdir of leftover dirs (e.g. `.claude`,
+      # `pr-head`), and the whole pipeline aborts before any reviewer
+      # finishes. Reset under `if: always()` so failed `docker run`
+      # invocations still clean up their mess.
+      if: always()
+      shell: bash
+      env:
+        WORKSPACE_FOLDER: ${{ inputs.workspace_folder }}
+      run: |
+        set -euo pipefail
+        WORKSPACE_HOST="${GITHUB_WORKSPACE}/${WORKSPACE_FOLDER}"
+        if [ -d "$WORKSPACE_HOST" ]; then
+          sudo chown -R "$(id -u):$(id -g)" "$WORKSPACE_HOST"
+        fi
+
     - name: Clean up staged env file
       if: always()
       shell: bash

--- a/.github/workflows/review-fixer.yml
+++ b/.github/workflows/review-fixer.yml
@@ -151,16 +151,6 @@ jobs:
       # this step computes the real new_sha and patches it into the
       # artifact so the downstream push step reads a consistent SHA.
 
-      - name: Reset workspace ownership after container run
-        # The fixer may run `sudo chown 1000:1000 /workspace` (the
-        # container's UID) to ensure it has write access. Because
-        # /workspace is bind-mounted from pr-head/ on the host, this
-        # changes pr-head/'s owner to UID 1000 on the host. Git then
-        # refuses to operate from pr-head/ as the runner (UID 1001),
-        # treating it as "dubious ownership". Reset ownership to the
-        # runner UID so subsequent git steps work correctly.
-        run: sudo chown -R "$(id -u):$(id -g)" "${{ env.PR_WORKSPACE_PATH }}"
-
       - name: Commit fixer working-tree changes
         id: commit
         env:


### PR DESCRIPTION
## Summary

- The `review-codex-run` and `review-claude-run` composite actions bind-mount the host workspace into containers running as UID 1000 (`ci`). The self-hosted runner is UID 1001. Files written by the container persist on the runner as UID-1000-owned across jobs.
- On the next job, `actions/checkout@v4` with `clean: true` runs `git checkout --detach` → fails with `Permission denied` on `.git/index.lock`, then attempts to recreate the workspace and fails again with `EACCES` on `rmdir .claude` (and/or leftover `pr-head`). Pipeline aborts in ~7 s before the reviewer ever runs.
- Add an `if: always()` ownership-reset step at the end of each composite action so a failed `docker run` still cleans up. Cleanup now lives at the source of contamination, not in each calling workflow.
- Drop the now-redundant `Reset workspace ownership after container run` step from `review-fixer.yml` — the action covers it.

## Repro

PR #490 psych reviewer, run 25032161937:

```
fatal: Unable to create '.../.git/index.lock': Permission denied
File was unable to be removed Error: EACCES: permission denied,
rmdir '.../hide-my-list/hide-my-list/.claude'
```

The `review-fixer-claude-smoke.yml` job passes `workspace_folder: .` to `review-claude-run`, mounting the **outer** `\$GITHUB_WORKSPACE` into the container — which is how outer `.claude/` and `.git/` end up UID-1000-owned. Reviewer jobs use `pr-head/` and have the same issue at one level deeper.

## Why this approach

- **Composite-level reset**: every caller covered automatically. No workflow has to remember.
- **Alternative considered**: `docker run --user \$(id -u):\$(id -g)`. Rejected because the CI image's `codex`/`claude` binaries are configured for `ci`/UID 1000 with `\$HOME=/home/ci`; remapping UID would break CLI configs baked into the image.
- Requires `sudo` NOPASSWD on runner (already assumed by the previous fixer-level reset).

## Manual recovery for stuck runner

This PR prevents future occurrences but does **not** un-stick a runner already polluted with UID-1000 files. Run once on `homelab-hide-my-list-3` (and any other affected runner):

```
sudo chown -R 1001:1001 /tmp/runner-work-hide-my-list-3/hide-my-list/hide-my-list
```

After that, rerun the failed psych job on PR #490: `gh run rerun 25032161937 --failed`.

## Test plan

- [ ] Smoke test workflow (`review-fixer-claude-smoke.yml`) passes on this PR — exercises `review-claude-run` with `workspace_folder: .`, the worst case for outer-workspace contamination.
- [ ] PR's own review pipeline completes (psych reviewer succeeds) — exercises `review-codex-run` with `workspace_folder: pr-head`.
- [ ] After merge, subsequent PRs no longer hit `Permission denied` on `.git/index.lock` / `.claude` rmdir during checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)