### PR TITLE
feat(review): persist resolve-issue author session, resume in fixer

### DIFF
--- a/.github/actions/review-claude-resume/action.yml
+++ b/.github/actions/review-claude-resume/action.yml
@@ -1,0 +1,235 @@
+---
+name: Resume a Claude Code author session in the CI image
+description: >
+  Resumes the original resolve-issue Claude Code session as the v2
+  review pipeline's fixer for cycles ≥ 2. The author's session state
+  was persisted by the resolve-issue workflow into a host directory;
+  this action bind-mounts that directory back into /home/ci/.claude
+  so `claude --continue` continues the same conversation, this time
+  with reviewer artifacts in scope.
+
+  Topology mirrors review-claude-run, plus the session bind-mount and
+  the --continue invocation.
+
+  Captures Claude output to <workspace>/.review-output/<role>-output.jsonl
+  and expects the inner prompt to write a structured JSON artifact at
+  <workspace>/.review-output/<role>-result.json. The caller validates
+  that JSON against the fix-result-v1 schema.
+
+inputs:
+  agent:
+    description: Author agent identifier; must be 'claude' for this action.
+    required: true
+  session_host_dir:
+    description: >
+      Absolute host path to the per-(issue, run-id) session directory
+      written by scripts/ci-session-store.sh prepare claude ... during
+      resolve-issue. Bind-mounted into the container at /home/ci/.claude.
+    required: true
+  role:
+    description: 'Role label used in artifact filenames (for example "fixer")'
+    required: true
+  prompt_path:
+    description: Repo-relative path to the standalone prompt markdown file (relative to workspace_folder)
+    required: true
+  image:
+    description: CI image tag (default ghcr.io/nickborgersprobably/hide-my-list-ci:latest)
+    required: false
+    default: ghcr.io/nickborgersprobably/hide-my-list-ci:latest
+  workspace_folder:
+    description: >
+      Workspace folder containing the PR checkout, relative to
+      $GITHUB_WORKSPACE. This is what the container sees as /workspace.
+    required: true
+  pr_number:
+    description: PR number being reviewed. Empty disables the PR metadata lookup.
+    required: false
+    default: ''
+  reviewed_sha:
+    description: Frozen reviewed SHA (40-char hex)
+    required: true
+  cycle:
+    description: Pipeline cycle number for this run
+    required: true
+  read_only:
+    description: Compatibility input with review-codex-run. The fixer passes "false".
+    required: false
+    default: 'false'
+  workflow_pat:
+    description: PAT used as GH_TOKEN inside the container (rule 2.3)
+    required: true
+  extra_env:
+    description: 'Additional KEY=VALUE pairs (newline-separated) to forward'
+    required: false
+    default: ''
+  pull:
+    description: When 'true' (default), docker pull the image before running
+    required: false
+    default: 'true'
+
+outputs:
+  output_artifact:
+    description: Host path to the captured Claude output JSONL
+    value: ${{ steps.paths.outputs.output_artifact }}
+  result_json:
+    description: Host path to the structured JSON artifact the prompt wrote
+    value: ${{ steps.paths.outputs.result_json }}
+
+runs:
+  using: composite
+  steps:
+    - name: Pre-create output directory in workspace
+      shell: bash
+      env:
+        WORKSPACE_FOLDER: ${{ inputs.workspace_folder }}
+      run: |
+        set -euo pipefail
+        OUTPUT_DIR="${GITHUB_WORKSPACE}/${WORKSPACE_FOLDER}/.review-output"
+        mkdir -p "$OUTPUT_DIR"
+        chmod 777 "$OUTPUT_DIR"
+
+    - name: Log in to GHCR
+      shell: bash
+      env:
+        GHCR_USERNAME: ${{ github.actor }}
+        GHCR_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
+
+    - name: Ensure CI image
+      if: inputs.pull == 'true'
+      shell: bash
+      run: scripts/ensure-ci-image.sh "${{ inputs.image }}"
+
+    - name: Fetch current PR metadata
+      id: pr-meta
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.workflow_pat }}
+        REPO: ${{ github.repository }}
+        PR_NUMBER: ${{ inputs.pr_number }}
+      run: |
+        set -euo pipefail
+
+        if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "0" ]; then
+          PR_TITLE=""
+          PR_BODY=""
+        else
+          PR_JSON=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")
+          PR_TITLE=$(echo "$PR_JSON" | jq -r '.title // ""')
+          PR_BODY=$(echo "$PR_JSON" | jq -r '.body // ""')
+        fi
+
+        echo "pr_title_b64=$(printf '%s' "$PR_TITLE" | base64 -w0)" >> "$GITHUB_OUTPUT"
+        echo "pr_body_b64=$(printf '%s' "$PR_BODY" | base64 -w0)" >> "$GITHUB_OUTPUT"
+
+    - name: Stage env file
+      id: stage-env
+      shell: bash
+      env:
+        ROLE: ${{ inputs.role }}
+        PROMPT_PATH: ${{ inputs.prompt_path }}
+        READ_ONLY: ${{ inputs.read_only }}
+        PR_NUMBER: ${{ inputs.pr_number }}
+        REVIEWED_SHA: ${{ inputs.reviewed_sha }}
+        CYCLE: ${{ inputs.cycle }}
+        WORKFLOW_PAT: ${{ inputs.workflow_pat }}
+        EXTRA_ENV: ${{ inputs.extra_env }}
+        REPO: ${{ github.repository }}
+        PR_TITLE_B64: ${{ steps.pr-meta.outputs.pr_title_b64 }}
+        PR_BODY_B64: ${{ steps.pr-meta.outputs.pr_body_b64 }}
+      run: |
+        set -euo pipefail
+        STAGING_DIR="${RUNNER_TEMP:-/tmp}/ci-agent"
+        mkdir -p "$STAGING_DIR"
+        ENV_FILE="$(mktemp "${STAGING_DIR}/env.XXXXXX")"
+        cat > "$ENV_FILE" <<EOF
+        ANTHROPIC_API_KEY=fake-key
+        ANTHROPIC_BASE_URL=https://llm.featherback-mermaid.ts.net/anthropic/
+        GH_TOKEN=${WORKFLOW_PAT}
+        REVIEW_ROLE=${ROLE}
+        REVIEW_PROMPT_PATH=${PROMPT_PATH}
+        REVIEW_READ_ONLY=${READ_ONLY}
+        PR_NUMBER=${PR_NUMBER}
+        REVIEWED_SHA=${REVIEWED_SHA}
+        REVIEW_CYCLE=${CYCLE}
+        OUTPUT_PATH=.review-output/${ROLE}-result.json
+        OUTPUT_LOG_PATH=.review-output/${ROLE}-output.jsonl
+        REPO=${REPO}
+        PR_TITLE_B64=${PR_TITLE_B64}
+        PR_BODY_B64=${PR_BODY_B64}
+        EOF
+        if [ -n "$EXTRA_ENV" ]; then
+          printf '%s\n' "$EXTRA_ENV" | grep -Ev '^\s*(#|$)' >> "$ENV_FILE" || true
+        fi
+        chmod 600 "$ENV_FILE"
+        echo "env_file=$ENV_FILE" >> "$GITHUB_OUTPUT"
+
+    - name: Validate session directory exists
+      shell: bash
+      env:
+        AGENT: ${{ inputs.agent }}
+        SESSION_HOST_DIR: ${{ inputs.session_host_dir }}
+      run: |
+        set -euo pipefail
+        if [ "$AGENT" != "claude" ]; then
+          echo "::error::review-claude-resume requires agent=claude (got '$AGENT')"
+          exit 1
+        fi
+        if [ ! -d "$SESSION_HOST_DIR" ] || [ -z "$(ls -A "$SESSION_HOST_DIR" 2>/dev/null)" ]; then
+          echo "::error::review-claude-resume: session dir missing or empty: $SESSION_HOST_DIR"
+          exit 1
+        fi
+
+    - name: Run Claude resume
+      shell: bash
+      env:
+        CI_AGENT_IMAGE: ${{ inputs.image }}
+        CI_AGENT_ENV_FILE: ${{ steps.stage-env.outputs.env_file }}
+        WORKSPACE_FOLDER: ${{ inputs.workspace_folder }}
+        SESSION_HOST_DIR: ${{ inputs.session_host_dir }}
+      run: |
+        set -euo pipefail
+
+        WORKSPACE_HOST="${GITHUB_WORKSPACE}/${WORKSPACE_FOLDER}"
+        CONTAINER_SCRIPT="${GITHUB_WORKSPACE}/.github/actions/review-claude-resume/run-in-container.sh"
+
+        # In addition to review-claude-run topology, bind-mount the
+        # author's persisted session at /home/ci/.claude so
+        # `claude --continue` finds prior turns. Per-(issue, run-id)
+        # subdirs guarantee the dir contains exactly the session we
+        # want resumed.
+        docker run --rm \
+          --network host \
+          --workdir /workspace \
+          -v "$WORKSPACE_HOST:/workspace" \
+          -v "$CONTAINER_SCRIPT:/run-in-container.sh:ro" \
+          -v "$SESSION_HOST_DIR:/home/ci/.claude" \
+          --env-file "$CI_AGENT_ENV_FILE" \
+          -e GIT_CONFIG_COUNT=1 \
+          -e GIT_CONFIG_KEY_0=safe.directory \
+          -e GIT_CONFIG_VALUE_0=/workspace \
+          "$CI_AGENT_IMAGE" \
+          -lc '/run-in-container.sh'
+
+    - name: Clean up staged env file
+      if: always()
+      shell: bash
+      env:
+        CI_AGENT_ENV_FILE: ${{ steps.stage-env.outputs.env_file }}
+      run: rm -f "$CI_AGENT_ENV_FILE"
+
+    - name: Echo result paths
+      id: paths
+      shell: bash
+      env:
+        ROLE: ${{ inputs.role }}
+        WORKSPACE_FOLDER: ${{ inputs.workspace_folder }}
+      run: |
+        set -euo pipefail
+        BASE="${GITHUB_WORKSPACE}/${WORKSPACE_FOLDER}/.review-output"
+        {
+          echo "output_artifact=${BASE}/${ROLE}-output.jsonl"
+          echo "result_json=${BASE}/${ROLE}-result.json"
+        } >> "$GITHUB_OUTPUT"

--- a/.github/actions/review-claude-resume/action.yml
+++ b/.github/actions/review-claude-resume/action.yml
@@ -2,11 +2,12 @@
 name: Resume a Claude Code author session in the CI image
 description: >
   Resumes the original resolve-issue Claude Code session as the v2
-  review pipeline's fixer for cycles ≥ 2. The author's session state
-  was persisted by the resolve-issue workflow into a host directory;
-  this action bind-mounts that directory back into /home/ci/.claude
-  so `claude --continue` continues the same conversation, this time
-  with reviewer artifacts in scope.
+  review pipeline's fixer. The author's session state was persisted by
+  the resolve-issue workflow into a host directory; this action bind-
+  mounts that directory back into /home/ci/.claude so `claude --continue`
+  continues the same conversation, this time with reviewer artifacts in
+  scope. Used on every cycle for which a valid Author-Session trailer
+  is present (cycle 1, cycle 2, etc.) — not just retry cycles.
 
   Topology mirrors review-claude-run, plus the session bind-mount and
   the --continue invocation.

--- a/.github/actions/review-claude-resume/action.yml
+++ b/.github/actions/review-claude-resume/action.yml
@@ -213,6 +213,27 @@ runs:
           "$CI_AGENT_IMAGE" \
           -lc '/run-in-container.sh'
 
+    - name: Reset workspace ownership after container run
+      # The container writes files into the bind-mounted workspace as
+      # UID 1000 (`ci` user). The self-hosted runner is a different UID
+      # (typically 1001). Without resetting ownership, those UID-1000
+      # files persist on the runner across jobs — the next job's
+      # `actions/checkout` clean step then fails with "Permission denied"
+      # on `.git/index.lock` or on rmdir of leftover dirs (e.g. `.claude`,
+      # `pr-head`), and the whole pipeline aborts before any reviewer
+      # finishes. Reset under `if: always()` so failed `docker run`
+      # invocations still clean up their mess.
+      if: always()
+      shell: bash
+      env:
+        WORKSPACE_FOLDER: ${{ inputs.workspace_folder }}
+      run: |
+        set -euo pipefail
+        WORKSPACE_HOST="${GITHUB_WORKSPACE}/${WORKSPACE_FOLDER}"
+        if [ -d "$WORKSPACE_HOST" ]; then
+          sudo chown -R "$(id -u):$(id -g)" "$WORKSPACE_HOST"
+        fi
+
     - name: Clean up staged env file
       if: always()
       shell: bash

--- a/.github/actions/review-claude-resume/run-in-container.sh
+++ b/.github/actions/review-claude-resume/run-in-container.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# review-claude-resume — resume the original resolve-issue Claude
+# author with reviewer artifacts handed in as the next turn. Prior
+# session state lives at $HOME/.claude (bind-mounted from the host)
+# so `claude --continue` finds it.
+
+if [ ! -f "$REVIEW_PROMPT_PATH" ]; then
+  echo "::error::review-claude-resume: prompt file not found at $REVIEW_PROMPT_PATH"
+  exit 1
+fi
+
+# Prepend caveman rules if available (optional — PRs branched
+# before caveman merged will not have the file).
+if [ -f .github/ci/caveman-rules.md ] && [ -f .github/ci/versions.env ]; then
+  # shellcheck disable=SC1091
+  source .github/ci/versions.env
+  if grep -Fq "v${CAVEMAN_VERSION}" .github/ci/caveman-rules.md; then
+    PROMPT_BODY=$(printf '%s\n\n%s' "$(cat .github/ci/caveman-rules.md)" "$(cat "$REVIEW_PROMPT_PATH")")
+  else
+    echo "::warning::review-claude-resume: caveman version mismatch; skipping rules"
+    PROMPT_BODY=$(cat "$REVIEW_PROMPT_PATH")
+  fi
+else
+  PROMPT_BODY=$(cat "$REVIEW_PROMPT_PATH")
+fi
+
+mkdir -p "$(dirname "$OUTPUT_PATH")"
+
+# `claude --continue` resumes the most recent session in cwd. The
+# bind-mounted /home/ci/.claude only contains the author's session
+# for this (issue, run-id), so --continue is unambiguous.
+timeout 30m claude -p \
+  --continue \
+  --dangerously-skip-permissions \
+  --permission-mode=bypassPermissions \
+  --model claude-sonnet-4-6 \
+  --verbose \
+  --output-format=stream-json \
+  "$PROMPT_BODY" \
+  < /dev/null 2>&1 \
+  | tee "$OUTPUT_LOG_PATH"
+
+if [ ! -s "$OUTPUT_PATH" ]; then
+  echo "::error::review-claude-resume: prompt did not produce $OUTPUT_PATH"
+  exit 1
+fi
+
+echo "review-claude-resume: ${REVIEW_ROLE} produced $OUTPUT_PATH"

--- a/.github/actions/review-codex-resume/action.yml
+++ b/.github/actions/review-codex-resume/action.yml
@@ -1,0 +1,253 @@
+---
+name: Resume a Codex author session in the CI image
+description: >
+  Resumes the original resolve-issue Codex session as the v2 review
+  pipeline's fixer for cycles ≥ 2. The author's session state was
+  persisted by the resolve-issue workflow into a host directory; this
+  action bind-mounts that directory back into /home/ci/.codex so
+  `codex exec resume --last` continues the same conversation, this
+  time with reviewer artifacts in scope.
+
+  Topology mirrors review-codex-run, plus the session bind-mount and
+  the resume invocation.
+
+  Captures Codex output to <workspace>/.review-output/<role>-output.jsonl
+  and expects the inner prompt to write a structured JSON artifact at
+  <workspace>/.review-output/<role>-result.json. The caller validates
+  that JSON against the fix-result-v1 schema.
+
+inputs:
+  agent:
+    description: Author agent identifier; must be 'codex' for this action.
+    required: true
+  session_host_dir:
+    description: >
+      Absolute host path to the per-(issue, run-id) session directory
+      written by scripts/ci-session-store.sh prepare codex ... during
+      resolve-issue. Bind-mounted into the container at /home/ci/.codex.
+    required: true
+  role:
+    description: 'Role label used in artifact filenames (e.g. "design", "fixer")'
+    required: true
+  prompt_path:
+    description: Repo-relative path to the standalone prompt markdown file (relative to workspace_folder)
+    required: true
+  image:
+    description: CI image tag (default ghcr.io/nickborgersprobably/hide-my-list-ci:latest)
+    required: false
+    default: ghcr.io/nickborgersprobably/hide-my-list-ci:latest
+  workspace_folder:
+    description: >
+      Workspace folder containing the PR checkout, relative to
+      $GITHUB_WORKSPACE. This is what the container sees as /workspace.
+    required: true
+  pr_number:
+    description: PR number being reviewed
+    required: true
+  reviewed_sha:
+    description: Frozen reviewed SHA (40-char hex)
+    required: true
+  cycle:
+    description: Pipeline cycle number for this run
+    required: true
+  read_only:
+    description: 'Compatibility input mirroring review-codex-run; the resumed fixer passes "false".'
+    required: false
+    default: 'false'
+  workflow_pat:
+    description: PAT used as GH_TOKEN inside the container (rule 2.3)
+    required: true
+  extra_env:
+    description: 'Additional KEY=VALUE pairs (newline-separated) to forward'
+    required: false
+    default: ''
+  pull:
+    description: When 'true' (default), docker pull the image before running
+    required: false
+    default: 'true'
+
+outputs:
+  output_artifact:
+    description: Host path to the captured Codex output JSONL
+    value: ${{ steps.paths.outputs.output_artifact }}
+  result_json:
+    description: Host path to the structured JSON artifact the prompt wrote
+    value: ${{ steps.paths.outputs.result_json }}
+
+runs:
+  using: composite
+  steps:
+    - name: Pre-create output directory in workspace
+      shell: bash
+      env:
+        WORKSPACE_FOLDER: ${{ inputs.workspace_folder }}
+      run: |
+        set -euo pipefail
+        # Codex writes its result JSON to a path inside the workspace
+        # folder. Because the workspace is bind-mounted into the
+        # container (via -v $GITHUB_WORKSPACE:/workspace), files written
+        # there from inside the container are visible to subsequent host
+        # steps for upload-artifact and schema validation.
+        #
+        # chmod 777: the runner user (typically UID 1001) creates this
+        # directory, but the container writes to it as the `ci` user
+        # (UID 1000). Without world-write, every reviewer fails with
+        # `PermissionError: [Errno 13] Permission denied:
+        # '.review-output/<role>-result.json'` — see the docs reviewer
+        # log on https://github.com/NickBorgersProbably/hide-my-list/actions/runs/24295328532.
+        # Agents improvise around the permission denial with sudo,
+        # which works on the image (NOPASSWD) but compounds shell
+        # escaping issues and still fails the verify step.
+        OUTPUT_DIR="${GITHUB_WORKSPACE}/${WORKSPACE_FOLDER}/.review-output"
+        mkdir -p "$OUTPUT_DIR"
+        chmod 777 "$OUTPUT_DIR"
+
+    - name: Log in to GHCR
+      shell: bash
+      env:
+        GHCR_USERNAME: ${{ github.actor }}
+        GHCR_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
+
+    - name: Ensure CI image
+      if: inputs.pull == 'true'
+      shell: bash
+      run: scripts/ensure-ci-image.sh "${{ inputs.image }}"
+
+    - name: Fetch current PR metadata
+      id: pr-meta
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.workflow_pat }}
+        REPO: ${{ github.repository }}
+        PR_NUMBER: ${{ inputs.pr_number }}
+      run: |
+        set -euo pipefail
+        # Fetch current PR title and body so reviewers evaluate against
+        # up-to-date metadata, not whatever was set at push time.
+        PR_JSON=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")
+        PR_TITLE=$(echo "$PR_JSON" | jq -r '.title // ""')
+        PR_BODY=$(echo "$PR_JSON" | jq -r '.body // ""')
+        # Base64 encode to avoid env-file escaping issues with newlines
+        echo "pr_title_b64=$(printf '%s' "$PR_TITLE" | base64 -w0)" >> "$GITHUB_OUTPUT"
+        echo "pr_body_b64=$(printf '%s' "$PR_BODY" | base64 -w0)" >> "$GITHUB_OUTPUT"
+
+    - name: Stage env file
+      id: stage-env
+      shell: bash
+      env:
+        ROLE: ${{ inputs.role }}
+        PROMPT_PATH: ${{ inputs.prompt_path }}
+        READ_ONLY: ${{ inputs.read_only }}
+        PR_NUMBER: ${{ inputs.pr_number }}
+        REVIEWED_SHA: ${{ inputs.reviewed_sha }}
+        CYCLE: ${{ inputs.cycle }}
+        WORKFLOW_PAT: ${{ inputs.workflow_pat }}
+        EXTRA_ENV: ${{ inputs.extra_env }}
+        REPO: ${{ github.repository }}
+        PR_TITLE_B64: ${{ steps.pr-meta.outputs.pr_title_b64 }}
+        PR_BODY_B64: ${{ steps.pr-meta.outputs.pr_body_b64 }}
+      run: |
+        set -euo pipefail
+        # Stage the env file under $RUNNER_TEMP so --env-file can read it.
+        # (It's client-side in docker, so it only needs to be runner-
+        # visible, but keeping it under $RUNNER_TEMP is consistent with
+        # the other staging files and survives any future daemon-side
+        # requirements.)
+        STAGING_DIR="${RUNNER_TEMP:-/tmp}/ci-agent"
+        mkdir -p "$STAGING_DIR"
+        ENV_FILE="$(mktemp "${STAGING_DIR}/env.XXXXXX")"
+        cat > "$ENV_FILE" <<EOF
+        OPENAI_API_KEY=fake-key
+        GH_TOKEN=${WORKFLOW_PAT}
+        REVIEW_ROLE=${ROLE}
+        REVIEW_PROMPT_PATH=${PROMPT_PATH}
+        REVIEW_READ_ONLY=${READ_ONLY}
+        PR_NUMBER=${PR_NUMBER}
+        REVIEWED_SHA=${REVIEWED_SHA}
+        REVIEW_CYCLE=${CYCLE}
+        OUTPUT_PATH=.review-output/${ROLE}-result.json
+        OUTPUT_LOG_PATH=.review-output/${ROLE}-output.jsonl
+        REPO=${REPO}
+        PR_TITLE_B64=${PR_TITLE_B64}
+        PR_BODY_B64=${PR_BODY_B64}
+        EOF
+        # Append caller-supplied extras, stripping blank/comment lines.
+        if [ -n "$EXTRA_ENV" ]; then
+          printf '%s\n' "$EXTRA_ENV" | grep -Ev '^\s*(#|$)' >> "$ENV_FILE" || true
+        fi
+        chmod 600 "$ENV_FILE"
+        echo "env_file=$ENV_FILE" >> "$GITHUB_OUTPUT"
+
+    - name: Validate session directory exists
+      shell: bash
+      env:
+        AGENT: ${{ inputs.agent }}
+        SESSION_HOST_DIR: ${{ inputs.session_host_dir }}
+      run: |
+        set -euo pipefail
+        if [ "$AGENT" != "codex" ]; then
+          echo "::error::review-codex-resume requires agent=codex (got '$AGENT')"
+          exit 1
+        fi
+        if [ ! -d "$SESSION_HOST_DIR" ] || [ -z "$(ls -A "$SESSION_HOST_DIR" 2>/dev/null)" ]; then
+          echo "::error::review-codex-resume: session dir missing or empty: $SESSION_HOST_DIR"
+          exit 1
+        fi
+
+    - name: Run Codex resume
+      shell: bash
+      env:
+        CI_AGENT_IMAGE: ${{ inputs.image }}
+        CI_AGENT_ENV_FILE: ${{ steps.stage-env.outputs.env_file }}
+        WORKSPACE_FOLDER: ${{ inputs.workspace_folder }}
+        SESSION_HOST_DIR: ${{ inputs.session_host_dir }}
+      run: |
+        set -euo pipefail
+
+        WORKSPACE_HOST="${GITHUB_WORKSPACE}/${WORKSPACE_FOLDER}"
+        CONTAINER_SCRIPT="${GITHUB_WORKSPACE}/.github/actions/review-codex-resume/run-in-container.sh"
+
+        # In addition to the review-codex-run topology, bind-mount the
+        # author's persisted session at /home/ci/.codex so codex resume
+        # finds prior turns. Per-(issue, run-id) host subdirs guarantee
+        # the dir contains exactly the session we want resumed — `--last`
+        # in run-in-container.sh has only one candidate.
+        docker run --rm \
+          --network host \
+          --workdir /workspace \
+          -v "$WORKSPACE_HOST:/workspace" \
+          -v "$CONTAINER_SCRIPT:/run-in-container.sh:ro" \
+          -v "$SESSION_HOST_DIR:/home/ci/.codex" \
+          --env-file "$CI_AGENT_ENV_FILE" \
+          -e GIT_CONFIG_COUNT=1 \
+          -e GIT_CONFIG_KEY_0=safe.directory \
+          -e GIT_CONFIG_VALUE_0=/workspace \
+          "$CI_AGENT_IMAGE" \
+          -lc '/run-in-container.sh'
+
+    - name: Clean up staged env file
+      if: always()
+      shell: bash
+      env:
+        CI_AGENT_ENV_FILE: ${{ steps.stage-env.outputs.env_file }}
+      run: rm -f "$CI_AGENT_ENV_FILE"
+
+    - name: Echo result paths
+      id: paths
+      shell: bash
+      env:
+        ROLE: ${{ inputs.role }}
+        WORKSPACE_FOLDER: ${{ inputs.workspace_folder }}
+      run: |
+        set -euo pipefail
+        # Emit absolute host paths so downstream host steps (validate,
+        # publish, upload-artifact) can locate the files the container
+        # wrote into the workspace bind-mount.
+        BASE="${GITHUB_WORKSPACE}/${WORKSPACE_FOLDER}/.review-output"
+        {
+          echo "output_artifact=${BASE}/${ROLE}-output.jsonl"
+          echo "result_json=${BASE}/${ROLE}-result.json"
+        } >> "$GITHUB_OUTPUT"

--- a/.github/actions/review-codex-resume/action.yml
+++ b/.github/actions/review-codex-resume/action.yml
@@ -196,6 +196,13 @@ runs:
           echo "::error::review-codex-resume: session dir missing or empty: $SESSION_HOST_DIR"
           exit 1
         fi
+        # A dir containing only config.toml is not resumable — real Codex
+        # conversation state lives under sessions/. Fail early so the fixer
+        # falls back to fresh Claude rather than resume starting a new thread.
+        if [ -z "$(ls -A "${SESSION_HOST_DIR}/sessions" 2>/dev/null)" ]; then
+          echo "::error::review-codex-resume: session dir has no conversation state (config-only): $SESSION_HOST_DIR"
+          exit 1
+        fi
 
     - name: Run Codex resume
       shell: bash
@@ -227,6 +234,27 @@ runs:
           -e GIT_CONFIG_VALUE_0=/workspace \
           "$CI_AGENT_IMAGE" \
           -lc '/run-in-container.sh'
+
+    - name: Reset workspace ownership after container run
+      # The container writes files into the bind-mounted workspace as
+      # UID 1000 (`ci` user). The self-hosted runner is a different UID
+      # (typically 1001). Without resetting ownership, those UID-1000
+      # files persist on the runner across jobs — the next job's
+      # `actions/checkout` clean step then fails with "Permission denied"
+      # on `.git/index.lock` or on rmdir of leftover dirs (e.g. `.claude`,
+      # `pr-head`), and the whole pipeline aborts before any reviewer
+      # finishes. Reset under `if: always()` so failed `docker run`
+      # invocations still clean up their mess.
+      if: always()
+      shell: bash
+      env:
+        WORKSPACE_FOLDER: ${{ inputs.workspace_folder }}
+      run: |
+        set -euo pipefail
+        WORKSPACE_HOST="${GITHUB_WORKSPACE}/${WORKSPACE_FOLDER}"
+        if [ -d "$WORKSPACE_HOST" ]; then
+          sudo chown -R "$(id -u):$(id -g)" "$WORKSPACE_HOST"
+        fi
 
     - name: Clean up staged env file
       if: always()

--- a/.github/actions/review-codex-resume/action.yml
+++ b/.github/actions/review-codex-resume/action.yml
@@ -2,11 +2,12 @@
 name: Resume a Codex author session in the CI image
 description: >
   Resumes the original resolve-issue Codex session as the v2 review
-  pipeline's fixer for cycles ≥ 2. The author's session state was
-  persisted by the resolve-issue workflow into a host directory; this
-  action bind-mounts that directory back into /home/ci/.codex so
-  `codex exec resume --last` continues the same conversation, this
-  time with reviewer artifacts in scope.
+  pipeline's fixer. The author's session state was persisted by the
+  resolve-issue workflow into a host directory; this action bind-mounts
+  that directory back into /home/ci/.codex so `codex exec resume --last`
+  continues the same conversation, this time with reviewer artifacts in
+  scope. Used on every cycle for which a valid Author-Session trailer
+  is present (cycle 1, cycle 2, etc.) — not just retry cycles.
 
   Topology mirrors review-codex-run, plus the session bind-mount and
   the resume invocation.

--- a/.github/actions/review-codex-resume/run-in-container.sh
+++ b/.github/actions/review-codex-resume/run-in-container.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# review-codex-resume — resume the original resolve-issue Codex
+# author with the reviewer artifacts handed in as the next turn.
+# Prior session state lives at $HOME/.codex (bind-mounted from the
+# host) so `codex exec resume --last` finds it.
+
+# shellcheck disable=SC1091
+source .devcontainer/configure-codex.sh
+
+if [ ! -f "$REVIEW_PROMPT_PATH" ]; then
+  echo "::error::review-codex-resume: prompt file not found at $REVIEW_PROMPT_PATH"
+  exit 1
+fi
+
+# Prepend caveman rules if available (optional — PRs branched
+# before caveman merged will not have the file).
+if [ -f .github/ci/caveman-rules.md ] && [ -f .github/ci/versions.env ]; then
+  # shellcheck disable=SC1091
+  source .github/ci/versions.env
+  if grep -Fq "v${CAVEMAN_VERSION}" .github/ci/caveman-rules.md; then
+    PROMPT_BODY=$(printf '%s\n\n%s' "$(cat .github/ci/caveman-rules.md)" "$(cat "$REVIEW_PROMPT_PATH")")
+  else
+    echo "::warning::review-codex-resume: caveman version mismatch — skipping rules"
+    PROMPT_BODY=$(cat "$REVIEW_PROMPT_PATH")
+  fi
+else
+  PROMPT_BODY=$(cat "$REVIEW_PROMPT_PATH")
+fi
+
+mkdir -p "$(dirname "$OUTPUT_PATH")"
+
+# `codex exec resume --last` continues the most recent session in
+# the cwd-filtered store. Per-(issue, run-id) bind ensures only the
+# author's session is in scope.
+timeout 30m codex exec resume \
+  --last \
+  --json \
+  --dangerously-bypass-approvals-and-sandbox \
+  "$PROMPT_BODY" \
+  < /dev/null 2>&1 \
+  | tee "$OUTPUT_LOG_PATH"
+
+if [ ! -s "$OUTPUT_PATH" ]; then
+  echo "::error::review-codex-resume: prompt did not produce $OUTPUT_PATH"
+  exit 1
+fi
+
+echo "review-codex-resume: ${REVIEW_ROLE} produced $OUTPUT_PATH"

--- a/.github/ci/README.md
+++ b/.github/ci/README.md
@@ -22,7 +22,7 @@ through the shared socket" bugs.
 |---|---|
 | `Dockerfile` | Image recipe. `ubuntu:24.04` base, UID-1000 `ci` user, pinned Claude Code / Codex / actionlint / Node major. Installs shellcheck, yamllint, gh, Mermaid npm globals, envsubst. |
 | `versions.env` | Single source of truth for CLI version pins. Consumed by `.github/workflows/ci-image.yml` as `--build-arg`s. |
-| `caveman-rules.md` | Canonical CI-only caveman prompt contract. `review-codex-run` and `review-claude-run` prepend it to review prompts and validate its pinned source version against `CAVEMAN_VERSION`. |
+| `caveman-rules.md` | Canonical CI-only caveman prompt contract. `review-codex-run`, `review-claude-run`, `review-codex-resume`, and `review-claude-resume` prepend it to review prompts and validate its pinned source version against `CAVEMAN_VERSION`. |
 | `README.md` | This file. |
 
 ## Relationship to `.devcontainer/`
@@ -40,11 +40,13 @@ through the shared socket" bugs.
 
 ## How workflows consume the image
 
-Review pipeline v2 uses two direct-`docker run` composite actions
+Review pipeline v2 uses four direct-`docker run` composite actions
 against the CI image:
 
-- `./.github/actions/review-codex-run` for the read-only reviewers
-- `./.github/actions/review-claude-run` for the single-writer fixer
+- `./.github/actions/review-codex-run` — read-only reviewers (Codex)
+- `./.github/actions/review-claude-run` — fresh-Claude fixer fallback (human PRs, missing-trailer cases)
+- `./.github/actions/review-codex-resume` — resumed Codex author session as fixer (`codex exec resume --last`)
+- `./.github/actions/review-claude-resume` — resumed Claude Code author session as fixer (`claude --continue`)
 
 The other agent workflows (`codex`, `codex-diagnose-workflow-failure`,
 `review-coverage-evaluator`) invoke `docker run` inline.
@@ -84,9 +86,20 @@ home-automation refactor:
 PRs for trusted issue-resolution requests. It has two entry points:
 
 - Issue lifecycle events: `opened`, `reopened`, or `unlabeled` after
-  `codex-started`
-- `/autoresolve` issue comments on open non-PR issues from trusted
-  original authors
+  `codex-started` or `claude-started`
+- `/autoresolve [codex|claude]` issue comments on open non-PR issues
+  from trusted original authors
+
+Both Codex and Claude Code are first-class authors. The agent is
+selected by:
+1. `/autoresolve codex` or `/autoresolve claude` comment command
+2. `agent:codex` or `agent:claude` issue label
+3. Repo default (currently Codex)
+
+The author's session is persisted to `/srv/ci-sessions/<agent>/<issue>/<run-id>/`
+and an `Author-Session: <agent>/<run-id>` trailer is written into the
+PR body. The v2 fixer reads this trailer to resume the original author
+session for context-aware fixes rather than using a fresh model.
 
 The comment-command path is intentionally narrower than "any
 collaborator can point Codex at any issue": the commenter still has to

--- a/.github/ci/caveman-rules.md
+++ b/.github/ci/caveman-rules.md
@@ -1,6 +1,6 @@
 <!-- Canonical CI-only caveman rules.
      Derived from JuliusBrussee/caveman v1.5.1 full mode.
-     review-codex-run and review-claude-run validate this header against CAVEMAN_VERSION in .github/ci/versions.env. -->
+     review-codex-run, review-claude-run, review-codex-resume, and review-claude-resume validate this header against CAVEMAN_VERSION in .github/ci/versions.env. -->
 
 # CI Caveman Rules
 

--- a/.github/ci/prompts/claude-resolve-issue.md
+++ b/.github/ci/prompts/claude-resolve-issue.md
@@ -19,7 +19,7 @@ IMPORTANT RULES:
 - Reference `docs/architecture.md` for system design
 - Never use `git push --no-verify`
 
-BRANCH NAMING: Use `codex/issue-${ISSUE_NUMBER}`.
+BRANCH NAMING: Use `claude/issue-${ISSUE_NUMBER}`.
 
 PR CREATION:
 gh pr create --title '<brief description of what this PR accomplishes>' \
@@ -32,12 +32,12 @@ gh pr create --title '<brief description of what this PR accomplishes>' \
 ## Test Plan
 <how to verify the fix>
 
-Generated with Codex
+Generated with Claude Code
 
-Author-Session: codex/${RUN_ID}' \
-  --head codex/issue-${ISSUE_NUMBER}
+Author-Session: claude/${RUN_ID}' \
+  --head claude/issue-${ISSUE_NUMBER}
 
-The `Author-Session: codex/${RUN_ID}` trailer at the end of the body is
+The `Author-Session: claude/${RUN_ID}` trailer at the end of the body is
 REQUIRED. The review pipeline reads it to resume this session in the
 fixer stage so you receive reviewer feedback in the same conversation.
 Do not omit, move, or change the line. `${RUN_ID}` is substituted from

--- a/.github/ci/versions.env
+++ b/.github/ci/versions.env
@@ -9,6 +9,7 @@ ACTIONLINT_VERSION=1.7.7
 NODE_MAJOR=20
 # Canonical CI-only caveman rules in `.github/ci/caveman-rules.md`
 # are derived from JuliusBrussee/caveman full mode at this version.
-# `review-codex-run` and `review-claude-run` validate the file header
-# against this pin before prepending those rules to review prompts.
+# `review-codex-run`, `review-claude-run`, `review-codex-resume`, and
+# `review-claude-resume` validate the file header against this pin
+# before prepending those rules to review prompts.
 CAVEMAN_VERSION=1.5.1

--- a/.github/scripts/review/prompts/fixer-resume.md
+++ b/.github/scripts/review/prompts/fixer-resume.md
@@ -1,0 +1,98 @@
+You = ORIGINAL AUTHOR, resumed. PR #${PR_NUMBER} on ${REPO}. Reviewed SHA ${REVIEWED_SHA}, cycle ${REVIEW_CYCLE}.
+
+You authored this PR earlier in the same conversation. The reviewer panel
+has now examined what you produced. Their findings are below. Decide what
+to do, then leave the working tree updated.
+
+You stay in the conversation. Reviewers and judge are read-only.
+
+## Current PR metadata
+
+Decode current PR title/body before starting:
+```bash
+echo "$PR_TITLE_B64" | base64 -d
+echo "$PR_BODY_B64" | base64 -d
+```
+Reflects current PR state, not what you opened.
+
+## How this differs from a cold fixer
+
+You have full context — every choice you made authoring the PR is in your
+scrollback. A misreading by a reviewer (mistaking intent for a bug) is
+something only you can spot. A real bug, you can revisit at the level you
+made the original decision, not just patch the surface.
+
+For each reviewer blocker, decide:
+- **Real**: revisit your earlier choice. Apply the right fix at the right
+  level. Add the blocker id to `addressed[]`.
+- **Misread of intent**: do not change code. Sharpen the PR body so the
+  reader sees the same intent the reviewer missed. Add to `addressed[]`
+  only if the body edit closes the misread; otherwise add to `skipped[]`
+  with a brief reason.
+- **Out of scope**: leave it; add to `skipped[]` with reason "out of scope
+  for this PR — file follow-up issue".
+
+## Hard constraints
+
+1. **Apply only what reviewers asked for.** Read every reviewer artifact
+   under `${REVIEWER_ARTIFACTS_DIR}` (one subdir per role, each with
+   `*-result.json`).
+2. **No new scope.** No unrelated refactors, features, improvements.
+   Unrelated bugs → leave for a future PR.
+3. **Deterministic CI fixes NOT your job.** Lint/format/typecheck/test
+   repair = upstream CI. Lint failure found → abort + report.
+4. **Do NOT touch `.git/`.** No `git add`, `git commit`, `git push`,
+   `git config`, `git rebase`. The host runner commits and pushes after
+   you exit — `.git/` is bind-mounted under a different UID, and any
+   git-write inside the container corrupts it (see PR #409).
+5. **Read-only git fine.** `git diff`, `git log`, `git status`,
+   `git show`, `git ls-files` all work. Container sets
+   `safe.directory=/workspace` — use freely.
+6. **One logical fix batch, unstaged.** Write files, edit text. No
+   `git add`. Host step captures the working tree via `git add -A` and
+   commits as one. Commit message is built from your `addressed[]` list.
+
+## Procedure
+
+1. List reviewer artifacts:
+   ```bash
+   find "${REVIEWER_ARTIFACTS_DIR}" -name '*-result.json'
+   ```
+2. No reviewer files or unparseable → no edits. Write a no-op fix result
+   to `$OUTPUT_PATH` and stop.
+3. Read every blocker. Categorize each as real / misread / out-of-scope.
+4. Apply real-blocker fixes at the level you originally decided. If a
+   group of files needs the same change, apply uniformly — no per-file
+   improvisation.
+5. For misreads: edit the PR body via `gh pr edit ${PR_NUMBER} --body
+   "..."` to clarify intent. Preserve the existing
+   `Author-Session: <agent>/<run-id>` trailer exactly — the next cycle
+   reads it to resume you again.
+6. Leave file changes unstaged. Host step commits.
+7. Write fix-result JSON to `$OUTPUT_PATH`.
+
+## Output contract
+
+Write to `$OUTPUT_PATH`, conforming to
+`.github/scripts/review/schema/fix-result-v1.json`:
+
+```json
+{
+  "schema_version": "1",
+  "input_sha": "${REVIEWED_SHA}",
+  "new_sha": "${REVIEWED_SHA}",
+  "addressed": ["security/sec-001", "docs/doc-001"],
+  "skipped": [
+    { "id": "design/d-002", "reason": "out of scope; opened follow-up #NNN" }
+  ]
+}
+```
+
+Always set `new_sha` to `${REVIEWED_SHA}`. Host commit step rewrites it
+with the real post-commit SHA before judge reads.
+
+`addressed[]` and `skipped[].id` MUST be namespaced as `<role>/<id>`.
+Judge fails closed on bare ids — prevents two reviewers' colliding ids
+from cross-clearing.
+
+`input_sha` MUST equal `${REVIEWED_SHA}`. Judge fails closed on mismatch.

--- a/.github/scripts/review/prompts/fixer-resume.md
+++ b/.github/scripts/review/prompts/fixer-resume.md
@@ -64,9 +64,12 @@ For each reviewer blocker, decide:
 4. Apply real-blocker fixes at the level you originally decided. If a
    group of files needs the same change, apply uniformly — no per-file
    improvisation.
-5. For misreads: edit the PR body via `gh pr edit ${PR_NUMBER} --body
-   "..."` to clarify intent. Start from the decoded current PR body.
-   Preserve both of the following exactly as they appear:
+5. For misreads: decode the current PR body to a temp file, edit that
+   file to clarify intent, then run
+   `gh pr edit ${PR_NUMBER} --body-file "$BODY_FILE"` so markdown,
+   backticks, and `$VAR` references are passed verbatim without shell
+   reinterpretation. Preserve both of the following exactly as they
+   appear in the file:
    - An issue-closing line of the form `Resolves #N`, `Fixes #N`, or
      `Closes #N` on its own line — `review-fixer.yml` parses this to
      recover the issue number for session-dir lookup; dropping it

--- a/.github/scripts/review/prompts/fixer-resume.md
+++ b/.github/scripts/review/prompts/fixer-resume.md
@@ -65,9 +65,15 @@ For each reviewer blocker, decide:
    group of files needs the same change, apply uniformly — no per-file
    improvisation.
 5. For misreads: edit the PR body via `gh pr edit ${PR_NUMBER} --body
-   "..."` to clarify intent. Preserve the existing
-   `Author-Session: <agent>/<run-id>` trailer exactly — the next cycle
-   reads it to resume you again.
+   "..."` to clarify intent. Start from the decoded current PR body.
+   Preserve both of the following exactly as they appear:
+   - An issue-closing line of the form `Resolves #N`, `Fixes #N`, or
+     `Closes #N` on its own line — `review-fixer.yml` parses this to
+     recover the issue number for session-dir lookup; dropping it
+     disables author-resume on the next cycle and falls back to fresh
+     Claude.
+   - The `Author-Session: <agent>/<run-id>` trailer — the next cycle
+     reads it to resume you again.
 6. Leave file changes unstaged. Host step commits.
 7. Write fix-result JSON to `$OUTPUT_PATH`.
 

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -90,13 +90,16 @@ jobs:
     outputs:
       autoresolve_requested: ${{ steps.detect.outputs.autoresolve_requested }}
       issue_title_b64: ${{ steps.detect.outputs.issue_title_b64 }}
+      agent: ${{ steps.detect.outputs.agent }}
     steps:
-      - name: Detect /autoresolve command
+      - name: Detect /autoresolve command and select agent
         id: detect
         env:
           EVENT_NAME: ${{ github.event_name }}
           COMMENT_BODY: ${{ github.event.comment.body }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_LABELS_JSON: ${{ toJSON(github.event.issue.labels.*.name) }}
+          DEFAULT_AGENT: codex
         run: |
           set -eu
 
@@ -105,11 +108,48 @@ jobs:
             printf '%s\n' "$1" | grep -Eq '^[[:space:]]*/autoresolve([[:space:]]|$)'
           }
 
+          # Optional `/autoresolve <agent>` form picks the author per invocation.
+          extract_agent_from_comment() {
+            printf '%s\n' "$1" \
+              | grep -Eim1 '^[[:space:]]*/autoresolve[[:space:]]+(codex|claude)([[:space:]]|$)' \
+              | sed -E 's|.*/autoresolve[[:space:]]+(codex|claude).*|\1|i' \
+              | tr '[:upper:]' '[:lower:]' \
+              || true
+          }
+
+          # `agent:codex` or `agent:claude` label on the issue is a persistent
+          # per-issue override.
+          extract_agent_from_labels() {
+            printf '%s' "$1" \
+              | jq -r '(. // []) | .[]? // empty' 2>/dev/null \
+              | grep -Eim1 '^agent:(codex|claude)$' \
+              | sed -E 's/^agent:(codex|claude)$/\1/i' \
+              | tr '[:upper:]' '[:lower:]' \
+              || true
+          }
+
           if [ "$EVENT_NAME" = "issue_comment" ] && autoresolve_invocation "${COMMENT_BODY:-}"; then
             echo "autoresolve_requested=true" >> "$GITHUB_OUTPUT"
           else
             echo "autoresolve_requested=false" >> "$GITHUB_OUTPUT"
           fi
+
+          # Agent priority: comment override > issue label > repo default.
+          AGENT=""
+          if [ "$EVENT_NAME" = "issue_comment" ]; then
+            AGENT="$(extract_agent_from_comment "${COMMENT_BODY:-}")"
+          fi
+          if [ -z "$AGENT" ]; then
+            AGENT="$(extract_agent_from_labels "${ISSUE_LABELS_JSON:-[]}")"
+          fi
+          if [ -z "$AGENT" ]; then
+            AGENT="$DEFAULT_AGENT"
+          fi
+          case "$AGENT" in
+            codex|claude) ;;
+            *) AGENT="$DEFAULT_AGENT" ;;
+          esac
+          echo "agent=${AGENT}" >> "$GITHUB_OUTPUT"
 
           printf 'issue_title_b64=%s\n' "$(printf '%s' "${ISSUE_TITLE:-}" | base64 -w0)" >> "$GITHUB_OUTPUT"
 
@@ -124,7 +164,10 @@ jobs:
         (github.event_name == 'issues' && (
           github.event.action == 'opened' ||
           github.event.action == 'reopened' ||
-          (github.event.action == 'unlabeled' && github.event.label.name == 'codex-started')
+          (github.event.action == 'unlabeled' && (
+            github.event.label.name == 'codex-started' ||
+            github.event.label.name == 'claude-started'
+          ))
         )) ||
         (github.event_name == 'issue_comment' &&
          !github.event.issue.pull_request &&
@@ -163,15 +206,24 @@ jobs:
             echo "skip=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Label issue as codex-started
+      - name: Label issue as <agent>-started
         if: steps.check-existing.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          AGENT: ${{ needs.detect_autoresolve.outputs.agent }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
         run: |
-          # Create the label if it doesn't exist (ignore error if it does)
-          gh label create "codex-started" --color "7057ff" --description "Codex is working on this issue" --repo ${{ github.repository }} 2>/dev/null || true
-          # Add the label to the issue
-          gh issue edit ${{ github.event.issue.number }} --add-label "codex-started" --repo ${{ github.repository }}
+          set -euo pipefail
+          LABEL="${AGENT}-started"
+          gh label create "${LABEL}" --color "7057ff" --description "${AGENT} is working on this issue" --repo "${REPO}" 2>/dev/null || true
+          gh issue edit "${ISSUE_NUM}" --add-label "${LABEL}" --repo "${REPO}"
+          # Backwards compat: keep adding `codex-started` regardless of agent
+          # so prior automation that watches that specific label still fires.
+          if [ "${AGENT}" != "codex" ]; then
+            gh label create "codex-started" --color "7057ff" --description "Codex is working on this issue" --repo "${REPO}" 2>/dev/null || true
+            gh issue edit "${ISSUE_NUM}" --add-label "codex-started" --repo "${REPO}"
+          fi
 
       - name: Log in to GHCR
         if: steps.check-existing.outputs.skip != 'true'
@@ -185,15 +237,36 @@ jobs:
         if: steps.check-existing.outputs.skip != 'true'
         run: scripts/ensure-ci-image.sh "${CI_IMAGE}"
 
-      # Note: GH_TOKEN uses WORKFLOW_PAT because PRs created with GITHUB_TOKEN don't trigger workflows
-      - name: Resolve issue with Codex
+      - name: Prepare author session host dir
         if: steps.check-existing.outputs.skip != 'true'
+        id: session
+        env:
+          AGENT: ${{ needs.detect_autoresolve.outputs.agent }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          DIR="$(./scripts/ci-session-store.sh prepare "${AGENT}" "${ISSUE_NUMBER}" "${RUN_ID}")"
+          HOME_PATH="$(./scripts/ci-session-store.sh home-path "${AGENT}")"
+          {
+            echo "host_dir=${DIR}"
+            echo "container_home=${HOME_PATH}"
+          } >> "$GITHUB_OUTPUT"
+
+      # Note: GH_TOKEN uses WORKFLOW_PAT because PRs created with GITHUB_TOKEN don't trigger workflows.
+      # The host session dir is bind-mounted into the agent's home so the session
+      # persists after the container exits and the fixer can resume it.
+      - name: Resolve issue with Codex
+        if: steps.check-existing.outputs.skip != 'true' && needs.detect_autoresolve.outputs.agent == 'codex'
         env:
           OPENAI_API_KEY: ${{ vars.AI_API_KEY }}
           GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_TITLE_B64: ${{ needs.detect_autoresolve.outputs.issue_title_b64 }}
           REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          SESSION_HOST_DIR: ${{ steps.session.outputs.host_dir }}
+          SESSION_CONTAINER_HOME: ${{ steps.session.outputs.container_home }}
         run: |
           set -euo pipefail
 
@@ -207,11 +280,13 @@ jobs:
             --workdir /workspace \
             -v "${{ github.workspace }}:/workspace" \
             -v "$OUTPUT_STAGING:/output" \
+            -v "$SESSION_HOST_DIR:$SESSION_CONTAINER_HOME" \
             -e OPENAI_API_KEY \
             -e GH_TOKEN \
             -e ISSUE_NUMBER \
             -e ISSUE_TITLE_B64 \
             -e REPO \
+            -e RUN_ID \
             "${CI_IMAGE}" \
             -lc '
               set -euo pipefail
@@ -238,6 +313,81 @@ jobs:
           mkdir -p "${RUNNER_TEMP}"
           cp "$OUTPUT_STAGING/resolve-issue-conversation.jsonl" "${RUNNER_TEMP}/resolve-issue-conversation.jsonl" 2>/dev/null || true
           rm -rf "$OUTPUT_STAGING"
+
+      - name: Resolve issue with Claude Code
+        if: steps.check-existing.outputs.skip != 'true' && needs.detect_autoresolve.outputs.agent == 'claude'
+        env:
+          ANTHROPIC_API_KEY: fake-key
+          ANTHROPIC_BASE_URL: https://llm.featherback-mermaid.ts.net/anthropic/
+          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE_B64: ${{ needs.detect_autoresolve.outputs.issue_title_b64 }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          SESSION_HOST_DIR: ${{ steps.session.outputs.host_dir }}
+          SESSION_CONTAINER_HOME: ${{ steps.session.outputs.container_home }}
+        run: |
+          set -euo pipefail
+
+          STAGING_ROOT="${RUNNER_TEMP:-/tmp}/ci-agent"
+          mkdir -p "$STAGING_ROOT"
+          OUTPUT_STAGING=$(mktemp -d "${STAGING_ROOT}/resolve.XXXXXX")
+          chmod 777 "$OUTPUT_STAGING"
+
+          docker run --rm \
+            --network host \
+            --workdir /workspace \
+            -v "${{ github.workspace }}:/workspace" \
+            -v "$OUTPUT_STAGING:/output" \
+            -v "$SESSION_HOST_DIR:$SESSION_CONTAINER_HOME" \
+            -e ANTHROPIC_API_KEY \
+            -e ANTHROPIC_BASE_URL \
+            -e GH_TOKEN \
+            -e ISSUE_NUMBER \
+            -e ISSUE_TITLE_B64 \
+            -e REPO \
+            -e RUN_ID \
+            -e GIT_CONFIG_COUNT=1 \
+            -e GIT_CONFIG_KEY_0=safe.directory \
+            -e GIT_CONFIG_VALUE_0=/workspace \
+            "${CI_IMAGE}" \
+            -lc '
+              set -euo pipefail
+
+              ISSUE_TITLE=$(printf "%s" "$ISSUE_TITLE_B64" | base64 -d 2>/dev/null || echo "")
+              export ISSUE_TITLE
+
+              PROMPT=$(envsubst < .github/ci/prompts/claude-resolve-issue.md)
+
+              timeout 60m claude -p \
+                --dangerously-skip-permissions \
+                --permission-mode=bypassPermissions \
+                --model claude-sonnet-4-6 \
+                --verbose \
+                --output-format=stream-json \
+                "$PROMPT" \
+                < /dev/null 2>&1 \
+                | tee /output/resolve-issue-conversation.jsonl
+            '
+
+          mkdir -p "${RUNNER_TEMP}"
+          cp "$OUTPUT_STAGING/resolve-issue-conversation.jsonl" "${RUNNER_TEMP}/resolve-issue-conversation.jsonl" 2>/dev/null || true
+          rm -rf "$OUTPUT_STAGING"
+
+      - name: Validate author session persisted
+        if: steps.check-existing.outputs.skip != 'true'
+        env:
+          AGENT: ${{ needs.detect_autoresolve.outputs.agent }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          RUN_ID: ${{ github.run_id }}
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          if ./scripts/ci-session-store.sh validate "${AGENT}" "${ISSUE_NUMBER}" "${RUN_ID}"; then
+            echo "Author session persisted at $(./scripts/ci-session-store.sh host-dir "${AGENT}" "${ISSUE_NUMBER}" "${RUN_ID}")"
+          else
+            echo "::warning::Author session not persisted; review-pipeline fixer will fall back to fresh Claude."
+          fi
 
       - name: Upload issue resolution conversation log
         uses: actions/upload-artifact@v4

--- a/.github/workflows/review-fixer-resume-smoke.yml
+++ b/.github/workflows/review-fixer-resume-smoke.yml
@@ -1,0 +1,56 @@
+---
+name: Review pipeline v2 — author-resume smoke test
+
+# Pre-merge smoke for the resume-fixer paths added by the agent-team
+# redesign. Runs scripts/test-ci-session-store.sh, which exercises the
+# path-naming, validation, and trailer-parse logic the resolve-issue
+# workflow and the v2 review-fixer dispatch depend on.
+#
+# Auto-runs on any PR that touches the resume code paths so a broken
+# helper / action / prompt / dispatch regression surfaces here instead
+# of in the next real review cycle (rule 2.9). The full cross-container
+# round-trip (codex exec resume / claude --continue) is empirically
+# validated by the first resolve-issue PR that exercises a multi-cycle
+# review loop in production — that requires a real LiteLLM call, which
+# is too expensive for every PR.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+      - '**'
+    paths:
+      - '.github/actions/review-codex-resume/**'
+      - '.github/actions/review-claude-resume/**'
+      - '.github/scripts/review/prompts/fixer-resume.md'
+      - '.github/workflows/review-fixer.yml'
+      - '.github/workflows/review-fixer-resume-smoke.yml'
+      - '.github/workflows/codex.yml'
+      - '.github/ci/prompts/codex-resolve-issue.md'
+      - '.github/ci/prompts/claude-resolve-issue.md'
+      - 'scripts/ci-session-store.sh'
+      - 'scripts/test-ci-session-store.sh'
+  workflow_dispatch:
+
+concurrency:
+  group: review-fixer-resume-smoke-${{ github.event.pull_request.head.ref || github.ref_name }}-${{ github.event.pull_request.head.sha || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  ci-session-store:
+    name: ci-session-store unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current ref
+        uses: actions/checkout@v4
+
+      - name: Run helper unit tests
+        run: ./scripts/test-ci-session-store.sh
+
+      - name: Lint helper + tests
+        run: |
+          shellcheck scripts/ci-session-store.sh scripts/test-ci-session-store.sh

--- a/.github/workflows/review-fixer.yml
+++ b/.github/workflows/review-fixer.yml
@@ -144,10 +144,10 @@ jobs:
           SESSION_HOST_DIR=""
           if [ -n "$AGENT" ] && [ -n "$RUN_ID" ] && [ -n "$ISSUE_NUM" ]; then
             SESSION_HOST_DIR=$(./scripts/ci-session-store.sh host-dir "$AGENT" "$ISSUE_NUM" "$RUN_ID")
-            if [ -d "$SESSION_HOST_DIR" ] && [ -n "$(ls -A "$SESSION_HOST_DIR" 2>/dev/null)" ]; then
+            if ./scripts/ci-session-store.sh validate "$AGENT" "$ISSUE_NUM" "$RUN_ID" 2>/dev/null; then
               MODE="${AGENT}-resume"
             else
-              echo "::warning::Author-Session trailer present (${AGENT}/${RUN_ID} for #${ISSUE_NUM}) but session dir missing or empty: ${SESSION_HOST_DIR}; falling back to fresh Claude"
+              echo "::warning::Author-Session trailer present (${AGENT}/${RUN_ID} for #${ISSUE_NUM}) but session validation failed: ${SESSION_HOST_DIR}; falling back to fresh Claude"
               SESSION_HOST_DIR=""
             fi
           fi

--- a/.github/workflows/review-fixer.yml
+++ b/.github/workflows/review-fixer.yml
@@ -108,8 +108,96 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run Claude fixer in CI image
-        id: run
+      - name: Detect author session for resume
+        # Three-way fixer dispatch: if the PR body carries an
+        # `Author-Session: <agent>/<run-id>` trailer (written by
+        # resolve-issue) AND that session dir still exists on the
+        # host, resume the original author. Otherwise the fixer is a
+        # fresh Claude session, same as before this redesign.
+        id: detect-session
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          set -euo pipefail
+
+          PR_BODY=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.body // ""')
+
+          TRAILER="$(./scripts/ci-session-store.sh parse-trailer "$PR_BODY" || true)"
+          AGENT=""
+          RUN_ID=""
+          if [ -n "$TRAILER" ]; then
+            AGENT="$(printf '%s' "$TRAILER" | cut -f1)"
+            RUN_ID="$(printf '%s' "$TRAILER" | cut -f2)"
+          fi
+
+          ISSUE_NUM=""
+          if [ -n "$AGENT" ] && [ -n "$RUN_ID" ]; then
+            ISSUE_NUM=$(printf '%s\n' "$PR_BODY" \
+              | grep -Eim1 '^(Resolves|Fixes|Closes) #[0-9]+' \
+              | sed -E 's/^(Resolves|Fixes|Closes) #([0-9]+).*/\2/' \
+              || true)
+          fi
+
+          MODE="fallback"
+          SESSION_HOST_DIR=""
+          if [ -n "$AGENT" ] && [ -n "$RUN_ID" ] && [ -n "$ISSUE_NUM" ]; then
+            SESSION_HOST_DIR=$(./scripts/ci-session-store.sh host-dir "$AGENT" "$ISSUE_NUM" "$RUN_ID")
+            if [ -d "$SESSION_HOST_DIR" ] && [ -n "$(ls -A "$SESSION_HOST_DIR" 2>/dev/null)" ]; then
+              MODE="${AGENT}-resume"
+            else
+              echo "::warning::Author-Session trailer present (${AGENT}/${RUN_ID} for #${ISSUE_NUM}) but session dir missing or empty: ${SESSION_HOST_DIR}; falling back to fresh Claude"
+              SESSION_HOST_DIR=""
+            fi
+          fi
+
+          {
+            echo "agent=${AGENT}"
+            echo "run_id=${RUN_ID}"
+            echo "issue_num=${ISSUE_NUM}"
+            echo "session_host_dir=${SESSION_HOST_DIR}"
+            echo "mode=${MODE}"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "fixer dispatch: mode=${MODE} agent=${AGENT:-none} run_id=${RUN_ID:-none} issue=${ISSUE_NUM:-none}"
+
+      - name: Run Codex fixer (resumed author)
+        if: steps.detect-session.outputs.mode == 'codex-resume'
+        uses: ./.github/actions/review-codex-resume
+        with:
+          agent: codex
+          session_host_dir: ${{ steps.detect-session.outputs.session_host_dir }}
+          role: fixer
+          prompt_path: .github/scripts/review/prompts/fixer-resume.md
+          image: ${{ inputs.devcontainer_image }}
+          workspace_folder: ${{ env.PR_WORKSPACE_PATH }}
+          pr_number: ${{ inputs.pr_number }}
+          reviewed_sha: ${{ inputs.reviewed_sha }}
+          cycle: ${{ inputs.cycle }}
+          workflow_pat: ${{ secrets.WORKFLOW_PAT }}
+          extra_env: |
+            REVIEWER_ARTIFACTS_DIR=.review-output/reviewer-artifacts
+
+      - name: Run Claude fixer (resumed author)
+        if: steps.detect-session.outputs.mode == 'claude-resume'
+        uses: ./.github/actions/review-claude-resume
+        with:
+          agent: claude
+          session_host_dir: ${{ steps.detect-session.outputs.session_host_dir }}
+          role: fixer
+          prompt_path: .github/scripts/review/prompts/fixer-resume.md
+          image: ${{ inputs.devcontainer_image }}
+          workspace_folder: ${{ env.PR_WORKSPACE_PATH }}
+          pr_number: ${{ inputs.pr_number }}
+          reviewed_sha: ${{ inputs.reviewed_sha }}
+          cycle: ${{ inputs.cycle }}
+          workflow_pat: ${{ secrets.WORKFLOW_PAT }}
+          extra_env: |
+            REVIEWER_ARTIFACTS_DIR=.review-output/reviewer-artifacts
+
+      - name: Run Claude fixer (fresh fallback)
+        if: steps.detect-session.outputs.mode == 'fallback'
         uses: ./.github/actions/review-claude-run
         with:
           role: fixer
@@ -124,9 +212,23 @@ jobs:
           extra_env: |
             REVIEWER_ARTIFACTS_DIR=.review-output/reviewer-artifacts
 
+      - name: Resolve fixer artifact path
+        # All three fixer paths above write to the same workspace
+        # location. Pin the absolute host path here so downstream
+        # validate / commit / push / upload steps don't have to
+        # branch on which fixer ran.
+        id: artifact-path
+        run: |
+          set -euo pipefail
+          BASE="${GITHUB_WORKSPACE}/${{ env.PR_WORKSPACE_PATH }}/.review-output"
+          {
+            echo "result_json=${BASE}/fixer-result.json"
+            echo "output_jsonl=${BASE}/fixer-output.jsonl"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Validate fix-result against schema
         env:
-          ARTIFACT: ${{ steps.run.outputs.result_json }}
+          ARTIFACT: ${{ steps.artifact-path.outputs.result_json }}
         run: |
           set -euo pipefail
           # Schema declares $schema: draft/2020-12. ajv-cli@5 needs an
@@ -154,7 +256,7 @@ jobs:
       - name: Commit fixer working-tree changes
         id: commit
         env:
-          ARTIFACT: ${{ steps.run.outputs.result_json }}
+          ARTIFACT: ${{ steps.artifact-path.outputs.result_json }}
           REVIEWED_SHA: ${{ inputs.reviewed_sha }}
         working-directory: ${{ env.PR_WORKSPACE_PATH }}
         run: |
@@ -198,7 +300,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
           REPO: ${{ github.repository }}
-          ARTIFACT: ${{ steps.run.outputs.result_json }}
+          ARTIFACT: ${{ steps.artifact-path.outputs.result_json }}
           REVIEWED_SHA: ${{ inputs.reviewed_sha }}
           HEAD_REF: ${{ inputs.head_ref }}
         run: |

--- a/DEV-AGENTS.md
+++ b/DEV-AGENTS.md
@@ -48,14 +48,23 @@ Support dev pipeline. Not OpenClaw prompt. Edit directly via PRs — any contrib
 
 - `.github/workflows/` — GitHub Actions workflow definitions
 - `.github/actions/` — Composite actions used by workflows
-- `.github/actions/review-claude-run/` — Direct-`docker run` composite invoking Claude Code against the LiteLLM Anthropic endpoint; v2 pipeline single-writer fixer
+- `.github/actions/review-claude-run/` — Direct-`docker run` composite invoking Claude Code against the LiteLLM Anthropic endpoint; v2 pipeline single-writer fixer (fresh-Claude fallback path for human-authored PRs)
+- `.github/actions/review-codex-resume/` — Composite that resumes the original `resolve-issue` Codex author session as the v2 fixer; bind-mounts the persisted session into `/home/ci/.codex` and runs `codex exec resume --last`
+- `.github/actions/review-claude-resume/` — Composite that resumes the original `resolve-issue` Claude Code author session as the v2 fixer; bind-mounts the persisted session into `/home/ci/.claude` and runs `claude --continue`
 - `.github/scripts/review/prompts/fixer-claude-smoke.md` — Prompt for the Claude fixer auth/IO smoke test
+- `.github/scripts/review/prompts/fixer-resume.md` — Prompt loaded by both resume actions; the resumed author already has full authoring context, so the prompt only hands over reviewer artifacts and reasserts the `.git/`-don't-touch + output-contract constraints
 - `.github/workflows/review-fixer-claude-smoke.yml` — Pre-merge smoke test exercising the Claude fixer container path on PRs touching that path
+- `.github/workflows/review-fixer-resume-smoke.yml` — Pre-merge smoke test exercising the resume-fixer dispatch logic (`scripts/test-ci-session-store.sh`); full cross-container resume validated by the first multi-cycle review on a `resolve-issue` PR
+- `.github/ci/prompts/codex-resolve-issue.md` — Codex author prompt invoked by the `codex` agent path in `resolve-issue`; carries the `Author-Session: codex/${RUN_ID}` PR-body trailer contract
+- `.github/ci/prompts/claude-resolve-issue.md` — Claude Code author prompt invoked by the `claude` agent path in `resolve-issue`; carries the `Author-Session: claude/${RUN_ID}` PR-body trailer contract
 - `.github/scripts/review/render-finalize-comment.sh` — Renders and posts the operator-facing "Agent Review Summary" merge-decision comment for `review-finalize.yml`; branches on verdict category (`go`, `reviewer_blockers`, `pipeline_error`, `cycle_capped`, `inherited`)
-- `.github/ci/caveman-rules.md` — Canonical CI-only caveman prompt contract prepended by `review-codex-run` and `review-claude-run`
+- `.github/ci/caveman-rules.md` — Canonical CI-only caveman prompt contract prepended by `review-codex-run`, `review-claude-run`, `review-codex-resume`, and `review-claude-resume`
 - `docs/agentic-pipeline-learnings.md` — Prescriptive review/CI pipeline contract + guardrail doc
 - `scripts/create-deduped-workflow-failure-issue.sh` — Creates/reuses canonical deduplicated GH Actions failure issue for diagnosis workflow
 - `scripts/check-doc-links.sh` — Internal doc link validator for local hooks + CI doc checks
+- `scripts/ci-session-store.sh` — Path-naming + trailer-parse helper for the per-(agent, issue, run-id) author-session store (`/srv/ci-sessions/<agent>/<issue>/<run-id>/`); used by both `resolve-issue` and v2 review-fixer
+- `scripts/cleanup-ci-sessions.sh` — Periodic prune of `/srv/ci-sessions/`; preserves sessions for open PRs, deletes others past `MAX_AGE_DAYS`
+- `scripts/test-ci-session-store.sh` — Self-contained unit tests for `ci-session-store.sh`; invoked by `review-fixer-resume-smoke.yml`
 - `scripts/pull-main.sh` — Branch sync helper
 - `scripts/run-required-checks.sh` — Canonical local/CI runner for required script, doc, workflow validations
 - `scripts/security-update.sh` — Security update automation
@@ -81,7 +90,7 @@ Treat OpenClaw prompt + spec file edits with care — change live app behavior. 
 
 ## Review Pipeline
 
-PRs reviewed by multi-agent review pipeline (Codex reviewers + Claude fixer in v2). Roles same in both versions; orchestration differs.
+PRs reviewed by multi-agent review pipeline (Codex reviewers + fixer in v2). Roles same in both versions; orchestration differs.
 
 **Reviewer roles**:
 1. Design Review — validates intent + design quality; runs docs-as-spec consistency check on spec-critical changes
@@ -92,6 +101,19 @@ PRs reviewed by multi-agent review pipeline (Codex reviewers + Claude fixer in v
 6. Judge / Merge Decision — synthesizes all reviews into verdict
 
 Lives in `.github/workflows/review-entry.yml`, dispatches `review-pipeline.yml` (orchestrator) → `review-reviewer.yml` (matrix) → `review-fixer.yml` → `review-judge.yml` → `review-finalize.yml`. Judge = deterministic Node script (`.github/scripts/review/aggregate.mjs`) with `permissions: contents: read` — cannot push by construction. Fixer runs after reviewers, before judge; pushes new commit first, then claims that SHA on `review/pipeline` immediately after push (GitHub rejects status for unpublished commit); only stage with write permission. Verdicts binary **GO** / **NO-GO**; NO-GO labels PR `needs-human-review`, stops without closing or auto-creating issues. Reviewer prompts = standalone files in `.github/scripts/review/prompts/`. See `docs/agentic-pipeline-learnings.md` §1.4 + §1.5 for design decisions.
+
+### Author-resume in the fixer stage
+
+`resolve-issue` accepts both **Codex** and **Claude Code** as first-class authors (selected per run via `/autoresolve <agent>` comment, `agent:codex` / `agent:claude` issue label, or repo default). The author's session state is bind-mounted from a per-(agent, issue, run-id) host directory under `/srv/ci-sessions/`, so it survives container exit. The author writes an `Author-Session: <agent>/<run-id>` trailer into the PR body.
+
+When `review-fixer.yml` runs, `Detect author session for resume` parses the trailer. Three-way dispatch:
+- **`codex-resume`** → `review-codex-resume` action runs `codex exec resume --last` against the persisted session
+- **`claude-resume`** → `review-claude-resume` action runs `claude --continue`
+- **`fallback`** → existing `review-claude-run` (fresh Claude session) — used for human-authored PRs and any case where the trailer is absent or the session dir is missing
+
+The resumed author re-enters the same conversation it had while authoring, this time with `${REVIEWER_ARTIFACTS_DIR}` available in scope. Because it has full context for the choices it originally made, it can revisit those choices instead of patching surface-level symptoms. Reviewers + judge always run regardless of dispatch mode — backstop catches anything the resumed author misses.
+
+Symmetric two-agent support means the fixer must understand both `codex exec resume` and `claude --continue` semantics; `fixer-resume.md` is the shared prompt loaded by both resume actions.
 
 ### Review prompt file architecture
 

--- a/docs/agentic-pipeline-learnings.md
+++ b/docs/agentic-pipeline-learnings.md
@@ -123,6 +123,22 @@ This is **not** the same problem as §1.14's merge-from-main inherit. §1.14 cov
 **Before:** PR #492 — local push on top of cycle 2 GO immediately tripped `cycle_capped`, requiring an admin-merge or force-push to recover.
 **Evidence:** PR #492
 
+### 1.17 Author stays alive across review cycles via session resume
+**Why:** Pre-redesign, `resolve-issue` ran a one-shot Codex that opened the PR and exited. The v2 fixer was a fresh Claude session that only saw reviewer JSON — it could patch what was literally flagged but had no memory of the structural choices the author made. Reviewer feedback on those choices reached the wrong agent: a stand-in fixer with no context for *why* the original author wrote it the way it did.
+
+Fix is to persist the author's session state into a per-(agent, issue, run-id) host directory under `/srv/ci-sessions/`, write an `Author-Session: <agent>/<run-id>` trailer into the PR body, and have `review-fixer.yml` read the trailer to bind-mount the same session back into the fixer container — then `codex exec resume --last` (or `claude --continue`) drops the original author back into the same conversation, this time with the reviewer artifacts in scope.
+
+Required properties:
+
+- **Symmetric two-agent support.** `resolve-issue` must accept Codex *and* Claude Code as first-class authors (selected per run via `/autoresolve <agent>` comment, `agent:codex` / `agent:claude` issue label, or repo default). The fixer must dispatch to a matching resume action (`review-codex-resume` / `review-claude-resume`) per the trailer.
+- **Backstop reviewers always run.** Specialty reviewers (psych/security/docs/prompt) bring distinct domain expertise the generic resume model doesn't replicate. Reviewer + judge stages run regardless of dispatch mode, so a resumed-author PR receives the same scrutiny as a human-authored PR. Cost is bounded; regression cost from skipping isn't.
+- **Per-run subdirs avoid `--last` poisoning.** Layout is `/srv/ci-sessions/<agent>/<issue>/<run-id>/`, not `/srv/ci-sessions/<agent>/<issue>/`. Leftover state from a prior `/autoresolve` attempt would otherwise be picked up by `codex exec resume --last`. Per-run isolation eliminates the cleanup race.
+- **Defensive fallback.** Trailer absent, malformed, or session dir missing → fixer falls back to fresh Claude (today's behavior). Human-authored PRs and PRs from before the redesign keep working unchanged.
+- **Host bind-mount, not artifact upload.** Self-hosted runner has writable `/srv/ci-sessions/` that persists across runs; bind-mount is lower-latency than artifact upload + survives runner restarts. If runner-portable storage ever becomes a requirement, switch to artifact upload (slower, but cross-runner-safe).
+- **Cleanup decoupled from review path.** `scripts/cleanup-ci-sessions.sh` prunes sessions for closed/merged PRs older than `MAX_AGE_DAYS`; review path never deletes (resume must always find what's there).
+
+`scripts/ci-session-store.sh` is the single source of path conventions and trailer parsing — workflows call its subcommands rather than recomputing paths inline. `scripts/test-ci-session-store.sh` covers the helper logic and is run by `review-fixer-resume-smoke.yml` on PRs that touch the resume code paths. Full cross-container resume round-trip is empirically validated by the first multi-cycle review on a `resolve-issue` PR — that requires real LiteLLM calls, too expensive for every PR's smoke.
+
 ---
 
 ## 2. CI Runtime Infrastructure

--- a/docs/agentic-pipeline-learnings.md
+++ b/docs/agentic-pipeline-learnings.md
@@ -168,8 +168,8 @@ Required properties:
 ### 2.6 Run steps go through purpose-built composites against the right base image
 **Why:** `devcontainers/ci@v0.3` hit post-step cleanup crash on self-hosted runners. Two stable patterns:
 - **Non-review workflows** — build/push with `devcontainers/ci@v0.3`, then run via `.github/actions/run-devcontainer/action.yml` (uses `@devcontainers/cli up/exec` directly).
-- **Review pipeline v2** — direct-`docker run` against the dedicated CI image (`.github/ci/Dockerfile`) via `.github/actions/review-codex-run` (read-only reviewers) and `.github/actions/review-claude-run` (single-writer fixer). The CI image is purpose-built for agent jobs and avoids the devcontainer's shared-socket fragility.
-**Evidence:** #179, #475
+- **Review pipeline v2** — direct-`docker run` against the dedicated CI image (`.github/ci/Dockerfile`) via four composites: `.github/actions/review-codex-run` (read-only reviewers), `.github/actions/review-claude-run` (fresh-Claude fixer fallback for human PRs and missing-trailer cases), `.github/actions/review-codex-resume` (resumed Codex author session, `codex exec resume --last`), and `.github/actions/review-claude-resume` (resumed Claude Code author session, `claude --continue`). The CI image is purpose-built for agent jobs and avoids the devcontainer's shared-socket fragility.
+**Evidence:** #179, #475, #494
 
 ### 2.7 Bake the Codex CLI into the Dockerfile; route models via LiteLLM with explicit `CODEX_MODEL`
 **Why:** Runtime CLI downloads stalled on slow networks; missing model defaults caused fallback to mismatched models. Downgrading three of six review stages to `gpt-5-mini` cut review cost ~45% with no measurable quality loss.

--- a/scripts/ci-session-store.sh
+++ b/scripts/ci-session-store.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+#
+# ci-session-store.sh — manage agent author-session storage on the
+# self-hosted runner host.
+#
+# Background: the v2 review pipeline now resumes the original
+# resolve-issue author (Codex or Claude Code) in the fixer stage so
+# the author can revisit structural decisions in light of reviewer
+# feedback. Resume requires the agent's session state to persist
+# between containers. We bind-mount a per-(agent, issue, run-id)
+# host directory into the agent's home dir; this script owns the
+# path conventions.
+#
+# Per-run subdirs (not per-issue) — leftover state from a previous
+# /autoresolve attempt would otherwise poison `codex exec resume
+# --last`, which picks the newest cwd-filtered session. Isolating
+# each run avoids the cleanup-race entirely; old subdirs are pruned
+# by scripts/cleanup-ci-sessions.sh against closed/merged PRs.
+#
+# Subcommands:
+#   home-path <agent>                       — print container path to
+#                                              mount onto (codex:
+#                                              /home/ci/.codex,
+#                                              claude: /home/ci/.claude)
+#   host-dir <agent> <issue> <run-id>       — print host path to bind
+#   prepare <agent> <issue> <run-id>        — mkdir + chmod 0777
+#                                              (UID 1000 inside the
+#                                              container needs write
+#                                              access regardless of
+#                                              host ownership)
+#   validate <agent> <issue> <run-id>       — non-zero exit if host
+#                                              dir missing or empty
+#                                              after an author run
+#   format-trailer <agent> <run-id>         — print the canonical PR
+#                                              body trailer line
+#   parse-trailer <pr-body>                 — print "<agent>\t<run-id>"
+#                                              (TAB-separated) extracted
+#                                              from `Author-Session:`
+#                                              PR trailer; empty if
+#                                              absent or malformed
+#
+# Host store root defaults to /srv/ci-sessions; override via
+# CI_SESSION_ROOT for tests or alternate runners.
+
+set -euo pipefail
+
+ci_session_container_home_path() {
+  local agent="$1"
+  case "$agent" in
+    codex) printf '%s\n' "/home/ci/.codex" ;;
+    claude) printf '%s\n' "/home/ci/.claude" ;;
+    *)
+      printf 'ci-session-store: unknown agent %q (expected codex|claude)\n' "$agent" >&2
+      return 64
+      ;;
+  esac
+}
+
+_ci_session_validate_args() {
+  local agent="$1" issue="$2" run_id="$3"
+  case "$agent" in codex|claude) ;; *)
+    printf 'ci-session-store: unknown agent %q\n' "$agent" >&2; return 64 ;;
+  esac
+  case "$issue" in '' | *[!0-9]*)
+    printf 'ci-session-store: issue must be numeric, got %q\n' "$issue" >&2; return 64 ;;
+  esac
+  case "$run_id" in '' | *[!0-9]*)
+    printf 'ci-session-store: run-id must be numeric, got %q\n' "$run_id" >&2; return 64 ;;
+  esac
+}
+
+ci_session_host_dir() {
+  _ci_session_validate_args "$1" "$2" "$3"
+  local root="${CI_SESSION_ROOT:-/srv/ci-sessions}"
+  printf '%s\n' "${root}/${1}/${2}/${3}"
+}
+
+ci_session_prepare() {
+  local dir
+  dir="$(ci_session_host_dir "$1" "$2" "$3")"
+  mkdir -p "$dir"
+  chmod 0777 "$dir"
+  printf '%s\n' "$dir"
+}
+
+ci_session_validate() {
+  local dir
+  dir="$(ci_session_host_dir "$1" "$2" "$3")"
+  if [ ! -d "$dir" ]; then
+    printf 'ci-session-store: missing %q\n' "$dir" >&2
+    return 1
+  fi
+  if [ -z "$(ls -A "$dir" 2>/dev/null)" ]; then
+    printf 'ci-session-store: %q is empty (author did not persist state)\n' "$dir" >&2
+    return 1
+  fi
+}
+
+ci_session_format_trailer() {
+  local agent="$1" run_id="$2"
+  case "$agent" in codex|claude) ;; *)
+    printf 'ci-session-store: unknown agent %q\n' "$agent" >&2; return 64 ;;
+  esac
+  case "$run_id" in '' | *[!0-9]*)
+    printf 'ci-session-store: run-id must be numeric, got %q\n' "$run_id" >&2; return 64 ;;
+  esac
+  printf 'Author-Session: %s/%s\n' "$agent" "$run_id"
+}
+
+ci_session_parse_trailer() {
+  local body="$1" line
+  line="$(printf '%s\n' "$body" \
+    | grep -Eim1 '^Author-Session:[[:space:]]+(codex|claude)/[0-9]+[[:space:]]*$' \
+    || true)"
+  [ -n "$line" ] || return 0
+  printf '%s\n' "$line" \
+    | sed -E 's#^Author-Session:[[:space:]]+(codex|claude)/([0-9]+)[[:space:]]*$#\1\t\2#i' \
+    | tr -d '\r' \
+    | awk -F'\t' '{ printf "%s\t%s\n", tolower($1), $2 }'
+}
+
+usage() {
+  sed -n '3,46p' "$0"
+}
+
+main() {
+  local sub="${1:-}"; shift || true
+  case "$sub" in
+    home-path) ci_session_container_home_path "$@" ;;
+    host-dir) ci_session_host_dir "$@" ;;
+    prepare) ci_session_prepare "$@" ;;
+    validate) ci_session_validate "$@" ;;
+    format-trailer) ci_session_format_trailer "$@" ;;
+    parse-trailer) ci_session_parse_trailer "$@" ;;
+    -h|--help|help|"") usage; [ -z "$sub" ] && return 64 || return 0 ;;
+    *)
+      printf 'ci-session-store: unknown subcommand %q\n' "$sub" >&2
+      usage >&2
+      return 64
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/ci-session-store.sh
+++ b/scripts/ci-session-store.sh
@@ -84,8 +84,9 @@ ci_session_prepare() {
 }
 
 ci_session_validate() {
+  local agent="$1"
   local dir
-  dir="$(ci_session_host_dir "$1" "$2" "$3")"
+  dir="$(ci_session_host_dir "$agent" "$2" "$3")"
   if [ ! -d "$dir" ]; then
     printf 'ci-session-store: missing %q\n' "$dir" >&2
     return 1
@@ -93,6 +94,16 @@ ci_session_validate() {
   if [ -z "$(ls -A "$dir" 2>/dev/null)" ]; then
     printf 'ci-session-store: %q is empty (author did not persist state)\n' "$dir" >&2
     return 1
+  fi
+  # config.toml is written by .devcontainer/configure-codex.sh before any
+  # conversation state exists. A Codex dir that contains only config artefacts
+  # is not resumable — `codex exec resume --last` would start a fresh thread.
+  # Require non-empty sessions/ to confirm real conversation state was persisted.
+  if [ "$agent" = "codex" ]; then
+    if [ -z "$(ls -A "${dir}/sessions" 2>/dev/null)" ]; then
+      printf 'ci-session-store: %q has no session state (config-only dir; not resumable)\n' "$dir" >&2
+      return 1
+    fi
   fi
 }
 

--- a/scripts/cleanup-ci-sessions.sh
+++ b/scripts/cleanup-ci-sessions.sh
@@ -58,12 +58,14 @@ while IFS= read -r run_dir; do
 
   # Determine PR state for the issue. Search by closing keywords;
   # match the same heuristic resolve-issue uses to find duplicate PRs.
+  # Preserve when ANY matching PR is OPEN — .[0] alone can be a closed
+  # stale PR when a newer open PR also references the same issue.
   pr_state=$(gh pr list \
     --repo "$REPO" \
     --state all \
     --search "Resolves #${issue} OR Fixes #${issue} OR Closes #${issue}" \
     --json state \
-    --jq '.[0].state // "NONE"' 2>/dev/null || echo "NONE")
+    --jq 'if any(.[]; .state == "OPEN") then "OPEN" else (.[0].state // "NONE") end' 2>/dev/null || echo "NONE")
 
   if [ "$pr_state" = "OPEN" ]; then
     skipped=$((skipped + 1))

--- a/scripts/cleanup-ci-sessions.sh
+++ b/scripts/cleanup-ci-sessions.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# cleanup-ci-sessions.sh — prune persisted resolve-issue author
+# sessions from the self-hosted runner host once they're no longer
+# needed for review cycles.
+#
+# Layout (see scripts/ci-session-store.sh):
+#   /srv/ci-sessions/<agent>/<issue>/<run-id>/
+#
+# Pruning policy (defensive — keeps any session that might still be
+# resumed by an active review cycle):
+#   - Skip if the issue's PR is open. Open PRs may still iterate.
+#   - Otherwise, delete subdirs older than $MAX_AGE_DAYS.
+#
+# Usage:
+#   ./scripts/cleanup-ci-sessions.sh                # dry-run
+#   ./scripts/cleanup-ci-sessions.sh --apply        # actually delete
+#   MAX_AGE_DAYS=14 ./scripts/cleanup-ci-sessions.sh --apply
+#
+# Run on the runner host (where the bind-mounted dirs live), not in a
+# container. Requires `gh` authenticated against the repo. Uses `sudo
+# rm -rf` because the dirs are owned by the container's `ci` UID
+# (1000), which differs from the runner UID.
+
+set -euo pipefail
+
+ROOT="${CI_SESSION_ROOT:-/srv/ci-sessions}"
+MAX_AGE_DAYS="${MAX_AGE_DAYS:-7}"
+APPLY="false"
+
+if [ "${1:-}" = "--apply" ]; then
+  APPLY="true"
+fi
+
+if [ ! -d "$ROOT" ]; then
+  echo "cleanup-ci-sessions: nothing to do; ${ROOT} does not exist"
+  exit 0
+fi
+
+REPO="${REPO:-$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)}"
+if [ -z "$REPO" ]; then
+  echo "cleanup-ci-sessions: REPO not set and gh repo view failed; aborting" >&2
+  exit 1
+fi
+
+skipped=0
+deleted=0
+preserved=0
+
+# find directories at depth 3: <root>/<agent>/<issue>/<run-id>/
+while IFS= read -r run_dir; do
+  issue=$(basename "$(dirname "$run_dir")")
+  agent=$(basename "$(dirname "$(dirname "$run_dir")")")
+
+  if [ -z "$issue" ] || [ -z "$agent" ]; then
+    continue
+  fi
+
+  # Determine PR state for the issue. Search by closing keywords;
+  # match the same heuristic resolve-issue uses to find duplicate PRs.
+  pr_state=$(gh pr list \
+    --repo "$REPO" \
+    --state all \
+    --search "Resolves #${issue} OR Fixes #${issue} OR Closes #${issue}" \
+    --json state \
+    --jq '.[0].state // "NONE"' 2>/dev/null || echo "NONE")
+
+  if [ "$pr_state" = "OPEN" ]; then
+    skipped=$((skipped + 1))
+    echo "skip  ${agent}/${issue}/$(basename "$run_dir") (PR still open)"
+    continue
+  fi
+
+  age_minutes=$(( ($(date +%s) - $(stat -c %Y "$run_dir")) / 60 ))
+  age_days=$(( age_minutes / 60 / 24 ))
+
+  if [ "$age_days" -lt "$MAX_AGE_DAYS" ]; then
+    preserved=$((preserved + 1))
+    echo "keep  ${agent}/${issue}/$(basename "$run_dir") (${age_days}d < ${MAX_AGE_DAYS}d)"
+    continue
+  fi
+
+  if [ "$APPLY" = "true" ]; then
+    sudo rm -rf "$run_dir"
+    deleted=$((deleted + 1))
+    echo "rm    ${agent}/${issue}/$(basename "$run_dir") (${age_days}d, PR=${pr_state})"
+  else
+    deleted=$((deleted + 1))
+    echo "would-rm  ${agent}/${issue}/$(basename "$run_dir") (${age_days}d, PR=${pr_state})"
+  fi
+done < <(find "$ROOT" -mindepth 3 -maxdepth 3 -type d 2>/dev/null)
+
+if [ "$APPLY" = "true" ]; then
+  echo "cleanup-ci-sessions: deleted=${deleted} preserved=${preserved} skipped=${skipped}"
+else
+  echo "cleanup-ci-sessions (dry run): would-delete=${deleted} preserved=${preserved} skipped=${skipped}"
+  echo "Re-run with --apply to actually delete."
+fi

--- a/scripts/test-ci-session-store.sh
+++ b/scripts/test-ci-session-store.sh
@@ -77,8 +77,26 @@ assert_eq "prepare chmods 0777" "777" "$PERM"
 
 # --- validate ---
 assert_exit "validate empty dir fails" 1 "$HELPER" validate codex 100 200
-echo "session-data" > "$DIR/marker"
-assert_exit "validate populated dir succeeds" 0 "$HELPER" validate codex 100 200
+
+# A bare config.toml (which configure-codex.sh writes before any conversation
+# happens) is non-empty but not resumable. The codex-specific check rejects
+# config-only dirs so the fixer falls back to fresh Claude rather than starting
+# a new thread under the resume contract.
+echo 'model = "x"' > "$DIR/config.toml"
+assert_exit "validate codex config-only dir fails" 1 "$HELPER" validate codex 100 200
+
+# Real codex sessions live under sessions/. Seed that to mark the dir resumable.
+mkdir -p "$DIR/sessions"
+echo "session-data" > "$DIR/sessions/2026-01-01.jsonl"
+assert_exit "validate codex populated dir succeeds" 0 "$HELPER" validate codex 100 200
+
+# Claude validate has no sessions/ requirement — any non-empty dir suffices,
+# since claude --continue picks up state from whatever ~/.claude layout the CLI
+# wrote, not from a known-named subdir.
+CLAUDE_DIR="$("$HELPER" prepare claude 100 200)"
+echo "anything" > "$CLAUDE_DIR/projects.placeholder"
+assert_exit "validate claude populated dir succeeds" 0 "$HELPER" validate claude 100 200
+
 assert_exit "validate missing dir fails" 1 "$HELPER" validate codex 999 999
 
 # --- format-trailer ---

--- a/scripts/test-ci-session-store.sh
+++ b/scripts/test-ci-session-store.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# test-ci-session-store.sh — Unit tests for scripts/ci-session-store.sh.
+# Covers the path-naming, validation, and trailer-parse logic that the
+# resolve-issue workflow and the v2 review-fixer dispatch depend on.
+#
+# Runs as a self-contained test: no network, no docker, no LLM.
+# Suitable for the pre-merge resume-smoke workflow + local verification.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HELPER="${REPO_ROOT}/scripts/ci-session-store.sh"
+TEST_ROOT="$(mktemp -d /tmp/ci-session-test.XXXXXX)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+export CI_SESSION_ROOT="$TEST_ROOT"
+
+failures=0
+passes=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    passes=$((passes + 1))
+    printf 'ok    %s\n' "$label"
+  else
+    failures=$((failures + 1))
+    printf 'FAIL  %s\n      expected: %q\n      actual:   %q\n' \
+      "$label" "$expected" "$actual" >&2
+  fi
+}
+
+assert_exit() {
+  local label="$1" expected="$2"
+  shift 2
+  local actual=0
+  "$@" >/dev/null 2>&1 || actual=$?
+  if [ "$expected" = "$actual" ]; then
+    passes=$((passes + 1))
+    printf 'ok    %s (exit=%s)\n' "$label" "$actual"
+  else
+    failures=$((failures + 1))
+    printf 'FAIL  %s\n      expected exit: %s\n      actual exit:   %s\n' \
+      "$label" "$expected" "$actual" >&2
+  fi
+}
+
+# --- home-path ---
+assert_eq "home-path codex"   "/home/ci/.codex"  "$("$HELPER" home-path codex)"
+assert_eq "home-path claude"  "/home/ci/.claude" "$("$HELPER" home-path claude)"
+assert_exit "home-path bogus rejected" 64 "$HELPER" home-path bogus
+
+# --- host-dir ---
+assert_eq "host-dir codex/123/45" \
+  "${TEST_ROOT}/codex/123/45" \
+  "$("$HELPER" host-dir codex 123 45)"
+assert_eq "host-dir claude/9/8" \
+  "${TEST_ROOT}/claude/9/8" \
+  "$("$HELPER" host-dir claude 9 8)"
+assert_exit "host-dir non-numeric issue rejected" 64 "$HELPER" host-dir codex abc 1
+assert_exit "host-dir non-numeric run-id rejected" 64 "$HELPER" host-dir codex 1 abc
+assert_exit "host-dir bogus agent rejected" 64 "$HELPER" host-dir bogus 1 1
+
+# --- prepare ---
+DIR="$("$HELPER" prepare codex 100 200)"
+assert_eq "prepare prints host dir" "${TEST_ROOT}/codex/100/200" "$DIR"
+if [ -d "$DIR" ]; then
+  passes=$((passes + 1))
+  printf 'ok    prepare creates dir\n'
+else
+  failures=$((failures + 1))
+  printf 'FAIL  prepare did not create dir\n' >&2
+fi
+PERM="$(stat -c '%a' "$DIR")"
+assert_eq "prepare chmods 0777" "777" "$PERM"
+
+# --- validate ---
+assert_exit "validate empty dir fails" 1 "$HELPER" validate codex 100 200
+echo "session-data" > "$DIR/marker"
+assert_exit "validate populated dir succeeds" 0 "$HELPER" validate codex 100 200
+assert_exit "validate missing dir fails" 1 "$HELPER" validate codex 999 999
+
+# --- format-trailer ---
+assert_eq "format-trailer codex" \
+  "Author-Session: codex/12345" \
+  "$("$HELPER" format-trailer codex 12345)"
+assert_eq "format-trailer claude" \
+  "Author-Session: claude/99" \
+  "$("$HELPER" format-trailer claude 99)"
+assert_exit "format-trailer bogus agent rejected" 64 "$HELPER" format-trailer bogus 1
+assert_exit "format-trailer non-numeric run-id rejected" 64 "$HELPER" format-trailer codex abc
+
+# --- parse-trailer ---
+body=$'feature\n\nFixes #42\n\nAuthor-Session: codex/12345\n'
+assert_eq "parse-trailer codex" $'codex\t12345' "$("$HELPER" parse-trailer "$body")"
+
+body=$'Author-Session: claude/99\nbody continues'
+assert_eq "parse-trailer claude" $'claude\t99' "$("$HELPER" parse-trailer "$body")"
+
+body="Author-Session: CODEX/777"
+assert_eq "parse-trailer uppercase normalized" $'codex\t777' "$("$HELPER" parse-trailer "$body")"
+
+body="no trailer here"
+assert_eq "parse-trailer absent → empty" "" "$("$HELPER" parse-trailer "$body")"
+
+body="Author-Session: bogus/1"
+assert_eq "parse-trailer bogus agent → empty" "" "$("$HELPER" parse-trailer "$body")"
+
+body="Author-Session: codex/abc"
+assert_eq "parse-trailer non-numeric run-id → empty" "" "$("$HELPER" parse-trailer "$body")"
+
+body="Author-Session: codex"
+assert_eq "parse-trailer missing run-id → empty" "" "$("$HELPER" parse-trailer "$body")"
+
+# --- round trip ---
+trailer="$("$HELPER" format-trailer codex 555)"
+parsed="$("$HELPER" parse-trailer "$trailer")"
+assert_eq "round-trip format → parse" $'codex\t555' "$parsed"
+
+# --- summary ---
+total=$((passes + failures))
+printf '\n%s passes, %s failures (out of %s assertions)\n' "$passes" "$failures" "$total"
+[ "$failures" -eq 0 ]


### PR DESCRIPTION
## Summary

- **resolve-issue now persists author session state** to `/srv/ci-sessions/<agent>/<issue>/<run-id>/` and writes an `Author-Session: <agent>/<run-id>` trailer into the PR body
- **review-fixer.yml three-way dispatches** on that trailer: `codex-resume` (`codex exec resume --last`) / `claude-resume` (`claude --continue`) / fresh-Claude fallback for human PRs and missing-trailer cases
- **Symmetric two-agent author** — both Codex and Claude Code are first-class, selected per run via `/autoresolve <agent>` comment, `agent:codex|claude` issue label, or repo default
- **Backstop reviewers + judge always run**, regardless of dispatch mode — specialty reviewers (psych/security/docs/prompt) bring expertise the resume model doesn't replicate
- New helper `scripts/ci-session-store.sh` owns path conventions; 26 unit tests in `scripts/test-ci-session-store.sh`; pre-merge smoke at `.github/workflows/review-fixer-resume-smoke.yml`
- Cleanup script `scripts/cleanup-ci-sessions.sh` prunes sessions for closed PRs past `MAX_AGE_DAYS`

Why this matters: pre-redesign, the v2 fixer was a fresh Claude session that only saw reviewer JSON. Reviewer feedback on structural choices reached a stand-in fixer with no memory of why the original author wrote things that way. Now the author rejoins the same conversation with reviewer artifacts in scope.

Plan: `/home/vscode/.claude/plans/i-like-these-skills-crystalline-gosling.md`. Design rationale captured as `docs/agentic-pipeline-learnings.md` §1.14.

## Test plan

- [ ] `scripts/run-required-checks.sh ci-scripts` — passes locally
- [ ] `scripts/run-required-checks.sh ci-workflows` — passes locally (actionlint + cross-file refs)
- [ ] `scripts/run-required-checks.sh ci-docs` — passes locally
- [ ] `scripts/test-ci-session-store.sh` — 26/26 assertions pass
- [ ] PR's own `review-fixer-resume-smoke` job runs + passes (it's path-filtered to fire on this PR)
- [ ] Full cross-container resume round-trip: validated empirically by the first multi-cycle review on a `resolve-issue` PR after merge (real LiteLLM calls — too costly per-PR)
- [ ] Manual: trigger `/autoresolve codex` on a low-stakes test issue → confirm `Author-Session: codex/...` trailer + `/srv/ci-sessions/codex/<n>/<run>/` populated
- [ ] Manual: trigger `/autoresolve claude` on another test issue → confirm `Author-Session: claude/...` trailer + `/srv/ci-sessions/claude/<n>/<run>/` populated
- [ ] Manual: human-authored PR → fixer routes to existing `review-claude-run` (today's behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)