### PR TITLE
fix(review): propagate actions:read up the reusable-workflow chain

### DIFF
--- a/.github/workflows/review-entry.yml
+++ b/.github/workflows/review-entry.yml
@@ -28,11 +28,19 @@ permissions:
   # GH validates that reusable callees declare a SUBSET of the
   # caller's permissions block, so this read-only declaration
   # forces every downstream review-*.yml to also declare read-only.
+  #
+  # `actions: read` is required so the fixer's downstream
+  # review-fixer.yml can call actions/download-artifact@v4 with a
+  # cross-run lookup against the original resolve-issue run (the
+  # author-session artifact). Reusable-workflow subset rule applies
+  # transitively, so the entry workflow has to declare it too even
+  # though entry never directly calls download-artifact.
   contents: read
   issues: read
   packages: read
   pull-requests: read
   statuses: write
+  actions: read
 
 concurrency:
   # Each /review comment gets its own concurrency slot (keyed by comment ID)

--- a/.github/workflows/review-pipeline.yml
+++ b/.github/workflows/review-pipeline.yml
@@ -38,11 +38,17 @@ permissions:
   # GITHUB_TOKEN. The downstream callees are also read-only on
   # GITHUB_TOKEN; this declaration must be a subset of the
   # caller's (review-entry.yml) permissions.
+  #
+  # `actions: read` is required for review-fixer.yml's
+  # actions/download-artifact@v4 cross-run lookup against the
+  # original resolve-issue run. Subset rule is transitive — entry
+  # declares it too.
   contents: read
   issues: read
   packages: read
   pull-requests: read
   statuses: write
+  actions: read
 
 jobs:
   gather:


### PR DESCRIPTION
## Summary

PR #501 added `actions: read` to `review-fixer.yml` so its `actions/download-artifact@v4` step could fetch the author-session artifact from a different workflow run. The reusable-workflow subset rule was not respected — callee permissions must be a subset of the caller's, and neither `review-entry.yml` nor `review-pipeline.yml` declared `actions: read`. GitHub validates this at workflow startup, which is why every `Review pipeline v2 — entry` run since PR #501's branch creation (02:36 UTC 2026-04-30) has come back as `startup_failure` with `run_duration_ms=1000`, no jobs created, no logs. (User saw it as "auto review pipeline failed.")

This is the third PR in the chain that started with #501:
- PR #501: switch session transit to artifact (broke `actions:read` subset chain — this PR)
- PR #502: scope codex bind-mount to `~/.codex/sessions` (latent regression unmasked by #501)
- PR #503 (currently open from `/autoresolve` on #496): the test PR — has been showing `startup_failure` on review-entry as direct evidence of this bug

## Fix

Add `actions: read` to both `review-entry.yml` and `review-pipeline.yml`. Transitive chain:

```
review-entry        → actions: read
↳ review-pipeline   → actions: read
  ↳ review-fixer    → actions: read   (consumed by download-artifact)
  ↳ review-reviewer → (no actions declaration)
  ↳ review-judge    → (no actions declaration)
  ↳ review-finalize → (no actions declaration)
```

Other callees don't declare `actions:` and don't need to.

## Verification

- [x] `actionlint` clean (`./scripts/run-required-checks.sh ci-workflows`)
- [ ] After merge: re-trigger review pipeline on PR #503 (push `/review` comment) → expect entry job runs to completion instead of startup-failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)