### PR TITLE
Default compaction model to claude-haiku-4-5

### DIFF
--- a/setup/openclaw.json.template
+++ b/setup/openclaw.json.template
@@ -82,7 +82,7 @@
       "workspace": "{{OPENCLAW_HOME}}/workspace",
       "envelopeTimezone": "{{TZ_IDENTIFIER}}",
       "compaction": {
-        "mode": "safeguard"
+        "model": "litellm/claude-haiku-4-5"
       },
       "heartbeat": {
         "every": "60m",


### PR DESCRIPTION
Resolves #499

## Summary
- replace `agents.defaults.compaction.mode: safeguard` in `setup/openclaw.json.template` with `agents.defaults.compaction.model: litellm/claude-haiku-4-5`
- leave `modelTiers` and heartbeat config unchanged so the cheap tier remains `gemma4-small`

## Test Plan
- `shellcheck scripts/*.sh`
- `yamllint .github/workflows/*.yml`
- `scripts/check-doc-links.sh`
- `scripts/validate-model-refs.sh`

Generated with Codex

Author-Session: codex/25145569235