### PR TITLE
fix(review): remove stale nested-sessions guard in codex-resume

### DIFF
--- a/.github/actions/review-codex-resume/action.yml
+++ b/.github/actions/review-codex-resume/action.yml
@@ -197,15 +197,13 @@ runs:
           echo "::error::review-codex-resume requires agent=codex (got '$AGENT')"
           exit 1
         fi
+        # SESSION_HOST_DIR is now the sessions dir directly (mounted at
+        # /home/ci/.codex/sessions inside the container — see Run Codex
+        # resume below). A non-empty dir means real session JSONLs from
+        # the author run; an empty dir means the trailer was present but
+        # the artifact had no usable content.
         if [ ! -d "$SESSION_HOST_DIR" ] || [ -z "$(ls -A "$SESSION_HOST_DIR" 2>/dev/null)" ]; then
           echo "::error::review-codex-resume: session dir missing or empty: $SESSION_HOST_DIR"
-          exit 1
-        fi
-        # A dir containing only config.toml is not resumable — real Codex
-        # conversation state lives under sessions/. Fail early so the fixer
-        # falls back to fresh Claude rather than resume starting a new thread.
-        if [ -z "$(ls -A "${SESSION_HOST_DIR}/sessions" 2>/dev/null)" ]; then
-          echo "::error::review-codex-resume: session dir has no conversation state (config-only): $SESSION_HOST_DIR"
           exit 1
         fi
 


### PR DESCRIPTION
## Summary

PR #502 scoped the codex bind-mount from `/home/ci/.codex` to `/home/ci/.codex/sessions` (to avoid shadowing the codex 0.125 standalone-install symlink chain). I missed a second guard inside the codex-resume action's `Validate session directory exists` step that still expected the pre-#502 layout — it re-checked `${SESSION_HOST_DIR}/sessions` was non-empty. Post-#502 SESSION_HOST_DIR IS the sessions dir directly, so that nested check always fires:

```
##[error]review-codex-resume: session dir has no conversation state (config-only):
/tmp/.../ci-sessions/codex/<issue>/<run-id>
```

This is why every fixer dispatch into codex-resume on the in-flight PRs (#503, #505, #506, #507, #508) failed at the same step despite Parse Author-Session trailer + Download author session artifact + Detect author session for resume all succeeding. End-to-end direct evidence: PR #503's `/review` run 25145414457 → fixer job 73704506695.

## Fix

Drop the nested `${SESSION_HOST_DIR}/sessions` check. The simpler "SESSION_HOST_DIR non-empty" check immediately above already gives us the same property — a non-empty dir means real session JSONLs from the author run.

## Test plan

- [x] `./scripts/run-required-checks.sh ci-workflows` clean (actionlint + cross-file refs)
- [ ] After merge: re-trigger `/review` on PR #503 → expect codex-resume to actually start the container instead of failing at the validate step

🤖 Generated with [Claude Code](https://claude.com/claude-code)