### PR TITLE
fix(review): chmod a+rwX after unpacking author session

### DIFF
--- a/scripts/ci-session-store.sh
+++ b/scripts/ci-session-store.sh
@@ -156,6 +156,13 @@ ci_session_unpack() {
   local dir
   dir="$(ci_session_prepare "$agent" "$issue" "$run_id")"
   tar -xzf "$tar_path" -C "$dir"
+  # Tar preserves the original file permissions (typically 0644 owned by
+  # container UID 1000 from the author run). After extraction on a different
+  # ephemeral runner, the files are owned by the host runner user — but the
+  # resume container runs as UID 1000 and needs write access so codex/claude
+  # can append new turns to the resumed session. Grant read+write to all,
+  # plus execute on directories only (capital X).
+  chmod -R a+rwX "$dir"
   printf '%s\n' "$dir"
 }
 

--- a/scripts/test-ci-session-store.sh
+++ b/scripts/test-ci-session-store.sh
@@ -129,6 +129,17 @@ fi
 assert_exit "unpack-extracted dir validates" 0 \
   bash -c "CI_SESSION_ROOT='$UNPACK_ROOT' '$HELPER' validate codex 300 400"
 
+# Container UID 1000 must be able to write to extracted session files
+# (codex/claude resume appends new turns). Verify a+w bits on file + dir.
+PERM_FILE="$(stat -c '%a' "$UNPACK_ROOT/codex/300/400/2026-01-01.jsonl")"
+case "$PERM_FILE" in *6|*7) passes=$((passes+1)); printf 'ok    unpack chmod grants world-write to file (%s)\n' "$PERM_FILE" ;;
+  *) failures=$((failures+1)); printf 'FAIL  unpack file perms not world-writable: %s\n' "$PERM_FILE" >&2 ;;
+esac
+PERM_DIR="$(stat -c '%a' "$UNPACK_ROOT/codex/300/400")"
+case "$PERM_DIR" in 777) passes=$((passes+1)); printf 'ok    unpack dir is 0777\n' ;;
+  *) failures=$((failures+1)); printf 'FAIL  unpack dir perms not 0777: %s\n' "$PERM_DIR" >&2 ;;
+esac
+
 assert_exit "unpack rejects missing tar" 1 "$HELPER" unpack codex 1 1 "/tmp/does-not-exist.tgz"
 assert_exit "unpack requires tar-path arg" 64 "$HELPER" unpack codex 1 1
 


### PR DESCRIPTION
## Summary

Codex resume in the fixer container fails with:
```
Error: thread/resume failed: ... failed to resume local thread recorder: Permission denied (os error 13)
```

Root cause: `tar` preserves file permissions from the author run (container UID 1000 wrote them with default umask = 0644). After unpack on a different ephemeral runner, files are owned by the host runner user. The resume container runs as UID 1000 — it can read the JSONLs but cannot append new turns. Codex's session-recorder write fails on the first turn.

Fix: after `tar -xzf` extraction, `chmod -R a+rwX` the unpacked dir so container UID 1000 has read+write access to all session files. Capital X grants exec only on directories, leaving JSONLs at `0666`.

This is the next-layer issue that surfaced once #501 (artifact transit) + #502 (codex bind-mount scope) + #504 (permissions chain) + #509 (stale guard) all landed and codex-resume actually started.

Direct evidence: PR #503's `/review` run 25146393325, fixer job 73707593742 — passed Parse trailer + Download artifact + Detect session + Validate session, then died at the codex-resume container's first session-file write.

## Test plan

- [x] `./scripts/test-ci-session-store.sh` — 38/38 pass; new assertions verify file→0666, dir→0777 post-unpack
- [x] `shellcheck` clean
- [ ] After merge: re-trigger `/review` on PR #503 → fixer should actually complete codex-resume + push a fix commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)