### PR TITLE
Clarify reward delivery to avoid narration leaks and duplicate sends

### DIFF
--- a/docs/reward-system.md
+++ b/docs/reward-system.md
@@ -260,23 +260,28 @@ file.
 
 #### Reward Delivery Contract (Issue #511)
 
-When `scripts/generate-reward-image.sh` returns a `.png`, the user-facing reward
-reply must contain only:
+When `scripts/generate-reward-image.sh` returns a `.png`, the assistant-authored
+reward turn passed to OpenClaw should contain only:
 
 1. Celebration text for the completion
 2. One `MEDIA:<absolute-path-to-image>` line
 
-Example:
+OpenClaw consumes the `MEDIA:` line as attachment markup. End users should see
+only the celebration text plus the rendered image attachment — never the raw
+filesystem path or transport syntax.
+
+Example assistant-authored reply:
 
 ```text
 CRUSHED IT! 🔥💪✨
-MEDIA:/tmp/reward-1714682000.png
+MEDIA:/absolute/path/to/image.png
 ```
 
 Reward Delivery Checklist:
 
-- [ ] Celebration copy only — no orchestration notes, no "Now let me...", no tool narration
-- [ ] Exactly one `MEDIA:` line for the image
+- [ ] Visible user copy is celebration only — no orchestration notes, no "Now let me...", no tool narration
+- [ ] Exactly one `MEDIA:` line in the assistant-authored turn
+- [ ] User sees rendered attachment, not raw `MEDIA:` syntax or filesystem path
 - [ ] No inline media tags such as `<media:image>` in the same reply
 - [ ] No second send of the same image via the `message` tool in the same turn
 - [ ] If the script returns a `.txt` fallback instead of `.png`, read the suggestion and send plain text only — no `MEDIA:` line

--- a/docs/reward-system.md
+++ b/docs/reward-system.md
@@ -227,8 +227,8 @@ flowchart TD
     end
 
     subgraph Delivery["Image Delivery"]
-        Chat[Embed in Chat Message]
-        Signal[Send via Signal/Telegram]
+        Reply[Celebration text only]
+        Media[Single MEDIA attachment]
     end
 
     Complete --> Intensity
@@ -257,6 +257,30 @@ Output: writes PNG to `/tmp/reward-<timestamp>.png` and prints the path.
 OpenClaw then stages attachment delivery through `~/.openclaw/media/outbound/`,
 which must stay traversable (for example `0755`) so Signal can read the staged
 file.
+
+#### Reward Delivery Contract (Issue #511)
+
+When `scripts/generate-reward-image.sh` returns a `.png`, the user-facing reward
+reply must contain only:
+
+1. Celebration text for the completion
+2. One `MEDIA:<absolute-path-to-image>` line
+
+Example:
+
+```text
+CRUSHED IT! 🔥💪✨
+MEDIA:/tmp/reward-1714682000.png
+```
+
+Reward Delivery Checklist:
+
+- [ ] Celebration copy only — no orchestration notes, no "Now let me...", no tool narration
+- [ ] Exactly one `MEDIA:` line for the image
+- [ ] No inline media tags such as `<media:image>` in the same reply
+- [ ] No second send of the same image via the `message` tool in the same turn
+- [ ] If the script returns a `.txt` fallback instead of `.png`, read the suggestion and send plain text only — no `MEDIA:` line
+- [ ] If the turn also includes an outing suggestion or other follow-up, send that as a separate plain-text message after the attachment-bearing reward reply
 
 #### Theme Pools by Intensity
 
@@ -767,13 +791,13 @@ sequenceDiagram
     R->>R: Select reward channels
 
     par Parallel Reward Delivery
-        R->>AI: Emoji celebration message
-        R->>AI: AI-generated celebration image
+        R->>AI: Celebration message text
+        R->>AI: AI-generated image path
         R->>HA: Play victory music
         R->>SMS: Text significant other
     end
 
-    AI->>U: "CRUSHED IT! 🔥💪✨ [unique AI celebration image]"
+    AI->>U: "CRUSHED IT! 🔥💪✨" + single MEDIA attachment
 
     opt High intensity + cleared schedule
         R->>AI: Outing suggestion

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -867,7 +867,7 @@ flowchart TD
 
     subgraph RewardDelivery["Reward Delivery"]
         Emoji[Emoji celebration]
-        AIImage[AI-Generated Image]
+        AIImage[Single MEDIA image attachment]
         Music[Play music via home audio]
         TextSO[Text significant other]
     end

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -907,11 +907,11 @@ flowchart TD
 | Trigger | Intensity | Rewards Activated |
 |---------|-----------|-------------------|
 | Initiation only | Lightest | Brief encouragement, no image |
-| Quick task (< 15 min) | Low | 1-2 emoji + gentle AI image |
-| Standard task | Medium | 2-4 emoji + enthusiastic AI image |
-| Focus/difficult task | High | 4-6 emoji + majestic AI image + Music + Text SO |
-| Parent task complete | Epic | 6+ emoji + cosmic AI image + Music + Text SO + Outing |
-| All tasks cleared | Epic | Maximum celebration |
+| Quick task (< 15 min) | Low | 1-2 emoji + single `MEDIA:` image attachment (gentle theme) |
+| Standard task | Medium | 2-4 emoji + single `MEDIA:` image attachment (enthusiastic theme) |
+| Focus/difficult task | High | 4-6 emoji + single `MEDIA:` image attachment (majestic theme) + Music + Text SO |
+| Parent task complete | Epic | 6+ emoji + single `MEDIA:` image attachment (cosmic theme) + Music + Text SO + Outing |
+| All tasks cleared | Epic | Maximum celebration + single `MEDIA:` image attachment + Music + Text SO + Outing |
 
 ## Phase 7: Scheduled Reminder Delivery
 
@@ -992,7 +992,7 @@ journey
       User marks done: 5: User
     section Celebration
       Emoji explosion displayed: 5: AI
-      AI-generated celebration image: 5: AI
+      Single celebration image attachment delivered: 5: AI
       Victory song plays on speakers: 5: System
       Partner receives celebration text: 5: System
       AI suggests coffee at favorite cafe: 4: AI

--- a/docs/user-interactions.md
+++ b/docs/user-interactions.md
@@ -222,12 +222,12 @@ sequenceDiagram
     R->>R: Calculate intensity score
 
     par Parallel Reward Delivery
-        R->>AI: Emoji + AI-generated image
+        R->>AI: Celebration text + image path
         R->>HA: Play victory music
         R->>SMS: Text significant other
     end
 
-    AI->>U: "CRUSHED IT! 🔥💪✨ [unique AI celebration image]"
+    AI->>U: "CRUSHED IT! 🔥💪✨" + single MEDIA attachment
 
     Note over HA: "We Are The Champions" plays
 
@@ -258,13 +258,13 @@ flowchart TD
     Score --> Level{Intensity Level}
 
     Level -->|Low| LowReward["Emoji only<br/>#quot;Nice! ✨#quot;"]
-    Level -->|Medium| MedReward["Emoji + AI image<br/>#quot;Crushing it! 🎉💪#quot;"]
-    Level -->|High| HighReward[Emoji + AI image + Music + Text SO]
+    Level -->|Medium| MedReward["Emoji + single MEDIA image<br/>#quot;Crushing it! 🎉💪#quot;"]
+    Level -->|High| HighReward[Emoji + single MEDIA image + Music + Text SO]
     Level -->|Epic| EpicReward[All rewards + AI Video + Outing]
 
     subgraph SystemRewards["System-Generated Rewards"]
         Emoji[Emoji Explosion]
-        AIImage[AI-Generated Image<br/>Unique per completion]
+        AIImage[AI image attachment<br/>Single MEDIA line]
         
         Music[Home Audio Playback<br/>Sonos/HomePod/Echo]
     end
@@ -939,7 +939,7 @@ sequenceDiagram
     U->>AI: Done
 
     par Celebration
-        AI->>U: FIRST ONE DOWN! 🎯✨💪 [unique AI celebration image]
+        AI->>U: FIRST ONE DOWN! 🎯✨💪 + single MEDIA attachment
         HA->>HA: Plays victory jingle (15 sec)
         SMS->>SMS: "[Partner], your person just knocked out their first task! 🙌"
     end


### PR DESCRIPTION
Resolves #511

## Summary
- define a single reward image delivery contract in `docs/reward-system.md`
- require celebration-only copy plus one `MEDIA:<path>` line, with no inline media tag or duplicate `message`-tool send
- align lifecycle and user interaction examples with the single-attachment flow

## Test Plan
- ./scripts/check-doc-links.sh
- shellcheck scripts/*.sh
- yamllint .github/workflows/*.yml

Generated with Codex

Author-Session: codex/25166391577