### PR TITLE
Personalize reward images with task context and feedback logging

### DIFF
--- a/docs/reward-system.md
+++ b/docs/reward-system.md
@@ -292,9 +292,18 @@ Each intensity level still has 5+ theme candidates, but selection is now weighte
 | High | Majestic, powerful | Phoenix rising from golden flames, astronaut planting flag, whale in starfield |
 | Epic | Cosmic, transcendent | Galaxy forming a crown, reality folding into light cathedral, cosmic phoenix |
 
+#### Sensitive Task Guardrail
+
+When the task classifier detects a private or shame-heavy completion (therapy, medical, legal, financial, or private admin work), reward generation switches to a stricter mode:
+
+- `task_mode` forced to `metaphorical`
+- theme/style/palette chosen only from calm abstract-or-symbolic allowlists
+- humor forced to `subtle`
+- literal task artifacts, mascots, animal scenes, paperwork, money, medical tools, and joke imagery excluded
+
 #### Reward Preference Schema
 
-Reward image preferences live in `state.json.user_preferences.rewards`:
+Canonical reward image preferences live in `state.json.user_preferences.rewards`:
 
 ```json
 {
@@ -333,7 +342,7 @@ Streak count modifies generated image:
 Generated rewards now leave two metadata trails:
 
 - `rewards/manifest.log` - stable tab-delimited recap manifest (`timestamp`, `intensity`, `task_title`, `file_path`)
-- `rewards/manifest.jsonl` - rich metadata per reward (`reward_id`, theme family, style, palette, task mode, task tags, prompt version)
+- `rewards/manifest.jsonl` - feedback metadata only (`reward_id`, `prompt_version`, `generated_at`, `timestamp`, `intensity`, `task_mode`, `task_profile`, `task_tags`, `theme_id`, `theme_family`, `theme_tags`, `style`, `palette`, `archive_file`)
 
 The companion script `scripts/log-reward-feedback.sh` records lightweight reactions:
 
@@ -345,13 +354,13 @@ The companion script `scripts/log-reward-feedback.sh` records lightweight reacti
 ./scripts/log-reward-feedback.sh 2026-04-30_091530_medium_21422 negative "Too busy"
 ```
 
-Those reactions append to `rewards/feedback.jsonl` and are used to bias future style/theme/palette selection. No hard lock-in - positive feedback nudges selection, novelty still matters.
+Those reactions append to `rewards/feedback.jsonl` and are used to bias future style/theme/palette selection. Feedback is intentionally bounded: recent reactions decay over time, aggregate weights are capped, and the result is only a nudge so novelty still matters.
 
 #### Novelty Mechanics (Issue #12)
 
 Image generation system inherently addresses novelty:
 
-1. **Weighted theme selection** - each intensity has 5+ themes, with preferences and feedback nudging rather than dictating the outcome
+1. **Weighted theme selection** - each intensity has 5+ themes, with preferences and bounded feedback nudging rather than dictating the outcome
 2. **Task motifs** - the same theme can feel different because the accomplished task changes the scene details
 3. **AI variation** - same prompt still produces different images each time
 4. **Streak-responsive** - visual elements change as streaks grow
@@ -390,7 +399,7 @@ Every generated reward image auto-archived to `rewards/` with metadata:
 
 - **File naming**: `YYYY-MM-DD_HHMMSS_<intensity>.png`
 - **Recap manifest**: `rewards/manifest.log` tracks timestamp, intensity, task title, file path
-- **Metadata manifest**: `rewards/manifest.jsonl` tracks reward id, theme family, style, palette, task mode, and task tags
+- **Metadata manifest**: `rewards/manifest.jsonl` tracks only feedback-loop selection fields plus archive path; raw task title, task motif, sensitive reason, and full prompt text are intentionally excluded
 - **Feedback log**: `rewards/feedback.jsonl` stores positive/neutral/negative reactions for future weighting
 - **Persistent**: Images survive across sessions — celebration history preserved
 
@@ -777,11 +786,13 @@ initiation_score = min(initiation_ceiling, max(0, weighted_score - diminishing))
 
 ## Configuration Schema
 
-### User Preferences (stored in Notion or local config)
+### Reward Delivery Settings (runtime config)
+
+Image-style preferences live in `state.json.user_preferences.rewards`. The schema below is separate: it covers delivery-channel toggles and channel-specific runtime settings, not the user's reward-image taste profile.
 
 ```mermaid
 erDiagram
-    USER_REWARD_PREFS {
+    REWARD_CHANNEL_SETTINGS {
         boolean emoji_enabled "Default: true"
         boolean image_enabled "Default: true"
         boolean music_enabled "Default: false"

--- a/docs/reward-system.md
+++ b/docs/reward-system.md
@@ -220,9 +220,11 @@ flowchart TD
     end
 
     subgraph Generation["Image Generation"]
-        Theme[Select Random Theme Pool]
-        Prompt[Build Prompt]
-        Style[Apply Intensity Styling]
+        Analyze[Analyze Task + Sensitivity]
+        Prefs[Load Reward Preferences + Feedback]
+        Theme[Select Weighted Theme]
+        Prompt[Build Personalized Prompt]
+        Style[Apply Style + Palette Modifiers]
         Generate[OpenAI gpt-image-1 API]
     end
 
@@ -232,7 +234,9 @@ flowchart TD
     end
 
     Complete --> Intensity
-    Intensity --> Theme
+    Intensity --> Analyze
+    Analyze --> Prefs
+    Prefs --> Theme
     Theme --> Prompt
     Prompt --> Style
     Style --> Generate
@@ -251,6 +255,10 @@ flowchart TD
 ./scripts/generate-reward-image.sh low "Call dentist" 0
 ./scripts/generate-reward-image.sh medium "Review proposal" 2
 ./scripts/generate-reward-image.sh epic "Complete Q4 report" 5
+
+# Optional context from the caller:
+REWARD_WORK_TYPE=focus REWARD_ENERGY_LEVEL=low \
+  ./scripts/generate-reward-image.sh medium "Review proposal" 2
 ```
 
 Output: writes PNG to `/tmp/reward-<timestamp>.png` and prints the path.
@@ -258,9 +266,24 @@ OpenClaw then stages attachment delivery through `~/.openclaw/media/outbound/`,
 which must stay traversable (for example `0755`) so Signal can read the staged
 file.
 
+#### Prompt Personalization Pipeline
+
+Reward prompts are now built from four layers, not just a random theme:
+
+1. **Intensity theme pool** - low/medium/high/epic still control the overall celebration scale
+2. **Task motif extraction** - task title becomes a safe visual motif (call, writing, setup, cleanup, etc.)
+3. **Preference modifiers** - optional `state.json.user_preferences.rewards` values bias style, palette, and subject matter
+4. **Feedback weighting** - prior positive/negative reactions bias future theme-family, style, and palette selection
+
+Task titles are not copied blindly into the image prompt. The script first classifies the task and builds either:
+
+- **Literal motifs** for ordinary tasks: "glowing phone and confetti" for calls, "pages turning into stars" for writing
+- **Metaphorical motifs** for sensitive tasks: therapy/medical/personal/legal/financial tasks use abstract or symbolic celebration instead of literal depictions
+- **Generic progress imagery** when the title is too vague to trust
+
 #### Theme Pools by Intensity
 
-Each intensity level has 5+ thematic prompts. Random theme selected each time for variety.
+Each intensity level still has 5+ theme candidates, but selection is now weighted by preferences and feedback instead of being purely random.
 
 | Intensity | Theme Style | Examples |
 |-----------|-------------|---------|
@@ -268,6 +291,32 @@ Each intensity level has 5+ thematic prompts. Random theme selected each time fo
 | Medium | Enthusiastic, joyful | Fox dancing in wildflowers, confetti explosion, otter on rainbow waterfall |
 | High | Majestic, powerful | Phoenix rising from golden flames, astronaut planting flag, whale in starfield |
 | Epic | Cosmic, transcendent | Galaxy forming a crown, reality folding into light cathedral, cosmic phoenix |
+
+#### Reward Preference Schema
+
+Reward image preferences live in `state.json.user_preferences.rewards`:
+
+```json
+{
+  "user_preferences": {
+    "rewards": {
+      "preferred_styles": ["storybook watercolor", "paper collage illustration"],
+      "preferred_palettes": ["cozy pastel glow", "aurora jewel tones"],
+      "favorite_subjects": ["space", "cats", "nature"],
+      "avoid": ["medical literal", "spiders"],
+      "humor_level": "playful"
+    }
+  }
+}
+```
+
+Supported preference dimensions:
+
+- **Styles** - e.g. watercolor, collage, 3D, graphic illustration
+- **Palettes** - warm, pastel, jewel-tone, neon, nature-led
+- **Subjects** - space, animals, nature, abstract, cozy
+- **Avoid list** - tags or vibes to suppress
+- **Humor level** - `subtle`, `playful`, or `maximal`
 
 #### Streak Enhancements
 
@@ -279,19 +328,39 @@ Streak count modifies generated image:
 | 3-4 | Three orbiting stars added |
 | 5+ | Trail of five glowing orbs added |
 
+#### Feedback Loop
+
+Generated rewards now leave two metadata trails:
+
+- `rewards/manifest.log` - stable tab-delimited recap manifest (`timestamp`, `intensity`, `task_title`, `file_path`)
+- `rewards/manifest.jsonl` - rich metadata per reward (`reward_id`, theme family, style, palette, task mode, task tags, prompt version)
+
+The companion script `scripts/log-reward-feedback.sh` records lightweight reactions:
+
+```bash
+# Record feedback for the most recent reward
+./scripts/log-reward-feedback.sh latest positive "Loved the space vibe"
+
+# Record feedback for a specific reward
+./scripts/log-reward-feedback.sh 2026-04-30_091530_medium_21422 negative "Too busy"
+```
+
+Those reactions append to `rewards/feedback.jsonl` and are used to bias future style/theme/palette selection. No hard lock-in - positive feedback nudges selection, novelty still matters.
+
 #### Novelty Mechanics (Issue #12)
 
 Image generation system inherently addresses novelty:
 
-1. **Random theme selection** — each intensity has 5+ themes, randomly chosen
-2. **AI variation** — same prompt produces different images each time
-3. **Streak-responsive** — visual elements change as streaks grow
-4. **Expandable pools** — new themes added to script without code changes
+1. **Weighted theme selection** - each intensity has 5+ themes, with preferences and feedback nudging rather than dictating the outcome
+2. **Task motifs** - the same theme can feel different because the accomplished task changes the scene details
+3. **AI variation** - same prompt still produces different images each time
+4. **Streak-responsive** - visual elements change as streaks grow
+5. **Expandable pools** - new themes, styles, and palettes can be added without changing the delivery contract
 
 Future enhancements:
 - Seasonal/holiday theme injection
-- User preference learning (track which themes get positive reactions)
 - Milestone surprise themes (hidden achievements at 10th, 50th, 100th task)
+- Agent-side reaction capture directly from chat responses
 
 #### Graceful Degradation — Offline Fallback Rewards
 
@@ -311,13 +380,18 @@ Fallback writes suggestion to `.txt` file (instead of `.png`) and exits successf
 | Variable | Purpose |
 |----------|---------|
 | `OPENAI_API_KEY` | OpenAI API authentication for image generation |
+| `REWARD_STATE_FILE` | Optional override for where reward preferences are loaded from |
+| `REWARD_WORK_TYPE` | Optional task context used to shape composition |
+| `REWARD_ENERGY_LEVEL` | Optional task context used to tune intensity and gentleness |
 
 #### Image Archive & Collection
 
 Every generated reward image auto-archived to `rewards/` with metadata:
 
 - **File naming**: `YYYY-MM-DD_HHMMSS_<intensity>.png`
-- **Manifest log**: `rewards/manifest.log` tracks timestamp, intensity, task title, file path
+- **Recap manifest**: `rewards/manifest.log` tracks timestamp, intensity, task title, file path
+- **Metadata manifest**: `rewards/manifest.jsonl` tracks reward id, theme family, style, palette, task mode, and task tags
+- **Feedback log**: `rewards/feedback.jsonl` stores positive/neutral/negative reactions for future weighting
 - **Persistent**: Images survive across sessions — celebration history preserved
 
 #### Weekly Recap Video
@@ -835,6 +909,9 @@ Capabilities exposed via conversation commands, not HTTP endpoints. OpenClaw age
 | Variable | Purpose | Example |
 |----------|---------|---------|
 | `OPENAI_API_KEY` | OpenAI API for image generation | `sk-proj-xxxxxxxx` |
+| `REWARD_STATE_FILE` | Override reward preference source file | `/workspace/state.json` |
+| `REWARD_WORK_TYPE` | Optional work type hint for reward imagery | `focus` |
+| `REWARD_ENERGY_LEVEL` | Optional energy hint for reward imagery | `low` |
 | `TWILIO_ACCOUNT_SID` | Twilio authentication | `ACxxxxxxxx` |
 | `TWILIO_AUTH_TOKEN` | Twilio authentication | `xxxxxxxx` |
 | `TWILIO_PHONE_NUMBER` | Sender phone number | `+1234567890` |
@@ -873,7 +950,8 @@ gantt
     section Phase 5: Novelty
     Seasonal theme injection     :p5a, 6, 7
     Milestone surprises          :p5b, 6, 7
-    Preference learning          :p5c, 7, 8
+    Preference-weighted prompts  :done, p5c, 7, 8
+    Feedback capture baseline    :done, p5d, 7, 8
 
     section Phase 6: Polish
     Personalized outings         :p6a, 8, 9

--- a/docs/user-preferences.md
+++ b/docs/user-preferences.md
@@ -43,6 +43,7 @@ flowchart TB
         General[General Preferences]
         WorkType[Work Type Specific]
         TaskPattern[Task Pattern Specific]
+        RewardImage[Reward Image Specific]
     end
 
     subgraph Context["Context Factors"]
@@ -55,6 +56,7 @@ flowchart TB
         Breakdown[Task Breakdown]
         Prep[Prep Steps]
         Environment[Environment Setup]
+        Rewards[Reward Image Selection]
     end
 
     Storage --> Context
@@ -125,16 +127,29 @@ Preferences for recurring task patterns.
 | meetings | prep | "Review agenda, prepare 1 question" |
 | exercise | motivation | "Put on workout playlist" |
 
+### 4. Reward Image Preferences
+
+Preferences that shape celebration imagery after completions.
+
+| Preference | Example Values | Usage |
+|------------|----------------|-------|
+| preferred_styles | storybook watercolor, digital illustration, gouache poster art | Bias image rendering style |
+| preferred_palettes | aurora jewel tones, cozy pastel glow | Bias color treatment |
+| favorite_subjects | space, cats, nature, abstract | Bias theme family + subject matter |
+| avoid | spiders, medical literal, neon | Downweight imagery user dislikes |
+| humor_level | subtle, playful, maximal | Controls how whimsical rewards feel |
+
 ---
 
 ## Preference Schema
 
-### User Preferences Table (Notion or Config)
+### state.json `user_preferences` Schema
+
+Canonical source of truth = `state.json.user_preferences`. Notion task rows can reference outcomes influenced by preferences, but preference storage itself lives in session state.
 
 ```mermaid
 erDiagram
     USER_PREFERENCES {
-        string user_id PK "User identifier"
         string preferred_beverage "tea|coffee|water|none"
         string comfort_spot "Description of favorite spot"
         string transition_ritual "Between-task ritual"
@@ -142,6 +157,7 @@ erDiagram
         string break_activity "Preferred break activity"
         json work_type_prefs "Work type specific JSON"
         json task_pattern_prefs "Pattern specific JSON"
+        json rewards "Reward image preferences JSON"
         json time_of_day_prefs "Morning/afternoon/evening"
         json energy_level_prefs "High/medium/low energy"
     }
@@ -204,6 +220,20 @@ erDiagram
   }
 }
 ```
+
+### Reward Image Preferences JSON Structure
+
+```json
+{
+  "preferred_styles": ["storybook watercolor", "paper collage illustration"],
+  "preferred_palettes": ["cozy pastel glow", "aurora jewel tones"],
+  "favorite_subjects": ["space", "cats", "nature"],
+  "avoid": ["medical literal", "spiders"],
+  "humor_level": "playful"
+}
+```
+
+This subtree maps directly to `state.json.user_preferences.rewards` and is the same reward-image preference object referenced by `docs/reward-system.md`.
 
 ---
 

--- a/scripts/generate-reward-image.sh
+++ b/scripts/generate-reward-image.sh
@@ -342,9 +342,22 @@ TASK_PROFILES = [
 ]
 
 SENSITIVE_PATTERNS = [
-    (r"\b(therapy|therapist|counseling|counselling|psychiatry|psychiatrist|trauma|grief|breakup|funeral)\b", "personal"),
-    (r"\b(medical|doctor|hospital|clinic|prescription|medication|meds|diagnosis|lab|surgery|procedure|dentist|dental)\b", "medical"),
-    (r"\b(tax|bank|credit|debt|loan|lawsuit|lawyer|court|insurance appeal|claim)\b", "financial_or_legal"),
+    (
+        r"\b(therapy|therapist|counseling|counselling|psychiatry|psychiatrist|trauma|grief|breakup|funeral|divorce|custody|relationship)\b",
+        "personal",
+    ),
+    (
+        r"\b(medical|doctor|hospital|clinic|prescription|medication|meds|diagnosis|lab|surgery|procedure|dentist|dental|pharmacy|refill|specialist|physical therapy)\b",
+        "medical",
+    ),
+    (
+        r"\b(tax|taxes|bank|banking|credit|debt|loan|loans|mortgage|rent|pay|payment|bill|bills|budget|budgeting|invoice|expense|expenses|insurance|claim|claims|appeal|renew|renewal|utilities|utility|registration|license|licence|paperwork|forms?|dmv)\b",
+        "private_admin",
+    ),
+    (
+        r"\b(lawsuit|lawyer|attorney|court|hearing|settlement|legal|probate)\b",
+        "financial_or_legal",
+    ),
 ]
 
 GENERIC_TITLES = {
@@ -381,6 +394,30 @@ HUMOR_GUIDANCE = {
 }
 
 HUMOR_GUIDANCE_KEYS = set(HUMOR_GUIDANCE)
+FEEDBACK_REACTION_SCORES = {
+    "positive": 1.0,
+    "neutral": 0.0,
+    "negative": -1.0,
+}
+FEEDBACK_WINDOW = 24
+FEEDBACK_DECAY = 0.82
+FEEDBACK_MAX_ABS = 1.5
+SENSITIVE_THEME_ALLOWLIST = {
+    "low": {"twilight_firework", "sprout_glow"},
+    "medium": {"aurora_peak"},
+    "high": {"tree_of_light"},
+    "epic": {"light_cathedral"},
+}
+SENSITIVE_STYLE_ALLOWLIST = {
+    "digital illustration",
+    "storybook watercolor",
+    "gouache poster art",
+}
+SENSITIVE_PALETTE_ALLOWLIST = {
+    "aurora jewel tones",
+    "cozy pastel glow",
+    "meadow greens and sky blues",
+}
 
 
 def slugify(value: str) -> str:
@@ -413,6 +450,10 @@ def term_variants(term: str):
     else:
         variants.add(f"{term}s")
     return [variant for variant in variants if variant]
+
+
+def clamp(value: float, low: float, high: float) -> float:
+    return max(low, min(high, value))
 
 
 def load_reward_preferences(path: Path):
@@ -457,6 +498,10 @@ def load_reward_preferences(path: Path):
     }
 
 
+def update_feedback_bucket(bucket, key, delta):
+    bucket[key] = clamp(bucket.get(key, 0.0) + delta, -FEEDBACK_MAX_ABS, FEEDBACK_MAX_ABS)
+
+
 def load_feedback(path: Path):
     feedback = {
         "theme_family": {},
@@ -473,37 +518,36 @@ def load_feedback(path: Path):
     except OSError:
         return feedback
 
-    recent_lines = [line for line in lines if line.strip()][-50:]
-    for line in recent_lines:
+    recent_lines = [line for line in lines if line.strip()][-FEEDBACK_WINDOW:]
+    for age, line in enumerate(reversed(recent_lines)):
         try:
             entry = json.loads(line)
         except json.JSONDecodeError:
             continue
 
-        score = {
-            "positive": 2.0,
-            "neutral": 0.0,
-            "negative": -2.0,
-        }.get(str(entry.get("reaction", "")).lower())
-        if score is None:
+        reaction_score = FEEDBACK_REACTION_SCORES.get(str(entry.get("reaction", "")).lower())
+        if reaction_score is None:
+            continue
+        score = reaction_score * (FEEDBACK_DECAY ** age)
+        if score == 0:
             continue
 
         family = slugify(str(entry.get("theme_family") or ""))
         if family:
-            feedback["theme_family"][family] = feedback["theme_family"].get(family, 0.0) + score
+            update_feedback_bucket(feedback["theme_family"], family, score)
 
         style = slugify(str(entry.get("style") or ""))
         if style:
-            feedback["style"][style] = feedback["style"].get(style, 0.0) + score
+            update_feedback_bucket(feedback["style"], style, score)
 
         palette = slugify(str(entry.get("palette") or ""))
         if palette:
-            feedback["palette"][palette] = feedback["palette"].get(palette, 0.0) + score
+            update_feedback_bucket(feedback["palette"], palette, score)
 
         for tag in entry.get("theme_tags", []):
             tag_key = slugify(str(tag))
             if tag_key:
-                feedback["theme_tag"][tag_key] = feedback["theme_tag"].get(tag_key, 0.0) + score
+                update_feedback_bucket(feedback["theme_tag"], tag_key, score)
 
     return feedback
 
@@ -611,14 +655,9 @@ def theme_score(option, prefs, feedback, task_mode):
     score = 1.0
     score += preference_score(option, prefs["subjects"], 1.2)
     score -= avoidance_penalty(option, prefs["avoid"], 1.5)
-    score += feedback["theme_family"].get(slugify(option.get("family", "")), 0.0) * 0.35
+    score += feedback["theme_family"].get(slugify(option.get("family", "")), 0.0) * 0.25
     for tag in option.get("tags", []):
-        score += feedback["theme_tag"].get(slugify(tag), 0.0) * 0.12
-    if task_mode == "metaphorical":
-        if "playful" in option.get("tags", []):
-            score -= 0.25
-        if any(tag in option.get("tags", []) for tag in ("abstract", "light", "growth", "majestic")):
-            score += 0.45
+        score += feedback["theme_tag"].get(slugify(tag), 0.0) * 0.08
     return score
 
 
@@ -626,9 +665,7 @@ def style_score(option, prefs, feedback, task_mode):
     score = 1.0
     score += preference_score(option, prefs["styles"], 1.3)
     score -= avoidance_penalty(option, prefs["avoid"], 1.2)
-    score += feedback["style"].get(slugify(option["name"]), 0.0) * 0.4
-    if task_mode == "metaphorical" and "playful" in option.get("tags", []):
-        score -= 0.15
+    score += feedback["style"].get(slugify(option["name"]), 0.0) * 0.3
     return score
 
 
@@ -637,8 +674,29 @@ def palette_score(option, prefs, feedback):
     score += preference_score(option, prefs["palettes"], 1.3)
     score += preference_score(option, prefs["subjects"], 0.4)
     score -= avoidance_penalty(option, prefs["avoid"], 1.1)
-    score += feedback["palette"].get(slugify(option["name"]), 0.0) * 0.4
+    score += feedback["palette"].get(slugify(option["name"]), 0.0) * 0.3
     return score
+
+
+def sensitive_theme_candidates(intensity: str):
+    return [
+        option for option in THEMES[intensity]
+        if option["id"] in SENSITIVE_THEME_ALLOWLIST[intensity]
+    ]
+
+
+def sensitive_style_candidates():
+    return [
+        option for option in STYLE_OPTIONS
+        if option["name"] in SENSITIVE_STYLE_ALLOWLIST
+    ]
+
+
+def sensitive_palette_candidates():
+    return [
+        option for option in PALETTE_OPTIONS
+        if option["name"] in SENSITIVE_PALETTE_ALLOWLIST
+    ]
 
 
 reward_preferences = load_reward_preferences(STATE_FILE)
@@ -648,22 +706,30 @@ sensitive_reason = detect_sensitive_reason(TASK_TITLE)
 task_mode = build_task_mode(TASK_TITLE, sensitive_reason)
 task_motif = build_task_motif(task_profile, task_mode)
 
+theme_options = THEMES[INTENSITY]
+style_options = STYLE_OPTIONS
+palette_options = PALETTE_OPTIONS
+if task_mode == "metaphorical":
+    theme_options = sensitive_theme_candidates(INTENSITY)
+    style_options = sensitive_style_candidates()
+    palette_options = sensitive_palette_candidates()
+
 theme = pick_with_weights(
-    THEMES[INTENSITY],
+    theme_options,
     lambda option: theme_score(option, reward_preferences, feedback, task_mode),
 )
 style = pick_with_weights(
-    STYLE_OPTIONS,
+    style_options,
     lambda option: style_score(option, reward_preferences, feedback, task_mode),
 )
 palette = pick_with_weights(
-    PALETTE_OPTIONS,
+    palette_options,
     lambda option: palette_score(option, reward_preferences, feedback),
 )
 
 humor_level = reward_preferences["humor_level"]
-if sensitive_reason and humor_level == "maximal":
-    humor_level = "playful"
+if sensitive_reason:
+    humor_level = "subtle"
 
 prompt_parts = [
     "Create a square celebratory reward image for a completed task.",
@@ -673,7 +739,7 @@ prompt_parts = [
 
 if sensitive_reason:
     prompt_parts.append(
-        "Keep the celebration metaphorical and non-specific. Do not depict private medical, legal, financial, or relationship details literally."
+        "Sensitive-task mode: must use abstract or symbolic celebration only. Must not depict literal task artifacts, paperwork, screens, money, medical tools, people, animals, mascots, or joke imagery. Keep tone calm, dignified, and gently celebratory."
     )
 elif task_mode == "abstract":
     prompt_parts.append(
@@ -809,19 +875,27 @@ MANIFEST_RECORD="$(
     CONTEXT_JSON="$PROMPT_CONTEXT_JSON" \
     TIMESTAMP="$TIMESTAMP" \
     ARCHIVE_FILE="$ARCHIVE_FILE" \
-    OUTPUT_FILE="$OUTPUT" \
     python3 <<'PY'
 import json
 import os
 
-record = json.loads(os.environ["CONTEXT_JSON"])
-record.update(
-    {
-        "timestamp": int(os.environ["TIMESTAMP"]),
-        "archive_file": os.environ["ARCHIVE_FILE"],
-        "output_file": os.environ["OUTPUT_FILE"],
-    }
-)
+context = json.loads(os.environ["CONTEXT_JSON"])
+record = {
+    "reward_id": context["reward_id"],
+    "prompt_version": context["prompt_version"],
+    "generated_at": context["generated_at"],
+    "timestamp": int(os.environ["TIMESTAMP"]),
+    "intensity": context["intensity"],
+    "task_mode": context["task_mode"],
+    "task_profile": context["task_profile"],
+    "task_tags": context["task_tags"],
+    "theme_id": context["theme_id"],
+    "theme_family": context["theme_family"],
+    "theme_tags": context["theme_tags"],
+    "style": context["style"],
+    "palette": context["palette"],
+    "archive_file": os.environ["ARCHIVE_FILE"],
+}
 print(json.dumps(record, ensure_ascii=True))
 PY
 )"

--- a/scripts/generate-reward-image.sh
+++ b/scripts/generate-reward-image.sh
@@ -2,27 +2,33 @@
 # Generate a celebratory reward image using OpenAI's image generation API.
 # Usage: ./generate-reward-image.sh <intensity> [task_title] [streak_count]
 #
+# Optional context:
+#   REWARD_STATE_FILE=/path/to/state.json
+#   REWARD_WORK_TYPE=focus|creative|social|independent
+#   REWARD_ENERGY_LEVEL=low|medium|high
+#
 # Intensity levels: low, medium, high, epic
 # Output: writes image to /tmp/reward-<timestamp>.png and prints the path
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/.."
 
 # --- Offline fallback rewards ---
 # When image generation is unavailable (API outage, missing key, network error),
 # suggest a real-life non-digital reward so the user still gets a celebration.
 OFFLINE_REWARDS=(
-    "Grab your favorite snack — you earned it!"
+    "Grab your favorite snack - you earned it!"
     "Treat yourself to a cupcake or some ice cream!"
-    "Play your favorite video game for 30 minutes — guilt-free!"
+    "Play your favorite video game for 30 minutes - guilt-free!"
     "Make yourself a fancy coffee or hot chocolate."
     "Take a walk outside and enjoy the fresh air for 15 minutes."
     "Put on your favorite song and have a mini dance party!"
     "Call or text a friend you haven't talked to in a while."
-    "Watch an episode of your favorite show — you deserve a break!"
+    "Watch an episode of your favorite show - you deserve a break!"
     "Grab a piece of chocolate or your favorite candy."
-    "Do some stretches or a quick yoga session — treat your body!"
+    "Do some stretches or a quick yoga session - treat your body!"
     "Read a chapter of a book you've been meaning to get to."
     "Order your favorite takeout for dinner tonight."
 )
@@ -35,10 +41,9 @@ suggest_offline_reward() {
     local index=$((RANDOM % count))
     local suggestion="${OFFLINE_REWARDS[$index]}"
 
-    echo "Image generation unavailable ($reason) — here's a real-life reward instead:" >&2
-    echo "  🎁 $suggestion" >&2
+    echo "Image generation unavailable ($reason) - here's a real-life reward instead:" >&2
+    echo "  [reward] $suggestion" >&2
 
-    # Write the suggestion to a text file so callers can use it
     local fallback_file="/tmp/reward-${TIMESTAMP:-$(date +%s)}-fallback.txt"
     printf '%s\n' "$suggestion" > "$fallback_file"
     echo "$fallback_file"
@@ -54,103 +59,688 @@ if [ -z "${OPENAI_API_KEY:-}" ]; then
     suggest_offline_reward "OPENAI_API_KEY not set"
 fi
 
-# Check dependencies
 for cmd in python3 curl; do
-    if ! command -v "$cmd" &>/dev/null; then
+    if ! command -v "$cmd" >/dev/null 2>&1; then
         suggest_offline_reward "$cmd not found"
     fi
 done
 
 INTENSITY="${1:-medium}"
-TASK_TITLE="${2:-a task}"
+TASK_TITLE_RAW="${2:-a task}"
 STREAK="${3:-0}"
 TIMESTAMP="$(date +%s)"
 DATE_STR="$(date +%Y-%m-%d)"
 TIME_STR="$(date +%H%M%S)"
+REWARD_ID="${DATE_STR}_${TIME_STR}_${INTENSITY}_$RANDOM"
+STATE_FILE="${REWARD_STATE_FILE:-$REPO_ROOT/state.json}"
 
-# Archive directory — persistent collection of all reward images
-ARCHIVE_DIR="$SCRIPT_DIR/../rewards"
+case "$INTENSITY" in
+    low|medium|high|epic)
+        ;;
+    *)
+        echo "Unknown intensity: $INTENSITY" >&2
+        exit 1
+        ;;
+esac
+
+case "$STREAK" in
+    ''|*[!0-9]*)
+        STREAK=0
+        ;;
+esac
+
+TASK_TITLE="$(printf '%s' "$TASK_TITLE_RAW" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')"
+[ -n "$TASK_TITLE" ] || TASK_TITLE="a task"
+
+ARCHIVE_DIR="$REPO_ROOT/rewards"
+MANIFEST_FILE="$ARCHIVE_DIR/manifest.log"
+MANIFEST_JSONL="$ARCHIVE_DIR/manifest.jsonl"
+FEEDBACK_JSONL="$ARCHIVE_DIR/feedback.jsonl"
 mkdir -p "$ARCHIVE_DIR"
 
-# Output goes to both /tmp (for immediate use) and archive (for collection)
 OUTPUT="/tmp/reward-${TIMESTAMP}.png"
 ARCHIVE_FILE="${ARCHIVE_DIR}/${DATE_STR}_${TIME_STR}_${INTENSITY}.png"
 
-# Build a prompt based on intensity and context
-build_prompt() {
-    local base_style="Digital illustration, vibrant colors, celebratory mood, clean design, no text, no words, no letters, no numbers."
+build_reward_context() {
+    INTENSITY="$INTENSITY" \
+    TASK_TITLE="$TASK_TITLE" \
+    STREAK="$STREAK" \
+    REWARD_ID="$REWARD_ID" \
+    STATE_FILE="$STATE_FILE" \
+    FEEDBACK_FILE="$FEEDBACK_JSONL" \
+    REWARD_WORK_TYPE="${REWARD_WORK_TYPE:-}" \
+    REWARD_ENERGY_LEVEL="${REWARD_ENERGY_LEVEL:-}" \
+    python3 <<'PY'
+import json
+import os
+import random
+import re
+from datetime import datetime, timezone
+from pathlib import Path
 
-    case "$INTENSITY" in
-        low)
-            local themes=(
-                "A small cheerful bird landing on a branch with a tiny sparkle, soft warm colors"
-                "A single firework blooming in a twilight sky, gentle and pretty"
-                "A happy cat stretching contentedly in a sunbeam, cozy vibes"
-                "A little plant sprouting from soil with a tiny golden glow around it"
-                "A paper airplane soaring gracefully through cotton candy clouds"
-            )
-            ;;
-        medium)
-            local themes=(
-                "A fox doing a victory dance in a meadow full of wildflowers, joyful energy"
-                "Colorful confetti exploding from a gift box with sparkles everywhere"
-                "A rocket launching through a ring of stars, triumphant and exciting"
-                "An otter sliding down a rainbow waterfall, pure joy and fun"
-                "A mountain peak at golden hour with aurora borealis, sense of achievement"
-            )
-            ;;
-        high)
-            local themes=(
-                "A magnificent phoenix rising from golden flames into a starlit sky, powerful and majestic"
-                "A dragon made of northern lights soaring over a glowing cityscape, epic achievement"
-                "An astronaut planting a flag on a new planet with galaxies swirling behind them"
-                "A massive tree of light growing from the ground up through clouds into space"
-                "A whale breaching through an ocean of stars and nebulae, awe-inspiring"
-            )
-            ;;
-        epic)
-            local themes=(
-                "An entire galaxy forming the shape of a crown, supernovae exploding in celebration, cosmic triumph"
-                "A titan standing atop a mountain as reality itself celebrates with fractured light and prismatic explosions"
-                "The sun and moon aligned in a cosmic high-five with rings of fire and ice, universal celebration"
-                "A colossal phoenix made of galaxies rising above a planet, the ultimate achievement"
-                "Reality itself folding into a cathedral of light and color, the most epic moment imaginable"
-            )
-            ;;
-        *)
-            echo "Unknown intensity: $INTENSITY" >&2
-            exit 1
-            ;;
-    esac
 
-    # Pick a random theme
-    local count=${#themes[@]}
-    local index=$((RANDOM % count))
-    local theme="${themes[$index]}"
+INTENSITY = os.environ["INTENSITY"]
+TASK_TITLE = " ".join(os.environ["TASK_TITLE"].split())
+STREAK = int(os.environ.get("STREAK", "0") or 0)
+REWARD_ID = os.environ["REWARD_ID"]
+STATE_FILE = Path(os.environ["STATE_FILE"])
+FEEDBACK_FILE = Path(os.environ["FEEDBACK_FILE"])
+WORK_TYPE = os.environ.get("REWARD_WORK_TYPE", "").strip().lower()
+ENERGY_LEVEL = os.environ.get("REWARD_ENERGY_LEVEL", "").strip().lower()
 
-    # Add streak flavor for streaks
-    if [ "$STREAK" -ge 5 ]; then
-        theme="$theme, with a trail of five glowing orbs representing a winning streak"
-    elif [ "$STREAK" -ge 3 ]; then
-        theme="$theme, with three small stars orbiting nearby"
-    fi
-
-    echo "${theme}. ${base_style}"
+THEMES = {
+    "low": [
+        {
+            "id": "cozy_branch",
+            "family": "nature",
+            "scene": "a tiny bird landing on a branch while a small shower of sparkles drifts around it",
+            "tags": ["nature", "animal", "soft", "warm"],
+        },
+        {
+            "id": "twilight_firework",
+            "family": "abstract",
+            "scene": "a single elegant firework blooming in a dusk sky with soft pastel sparks",
+            "tags": ["abstract", "light", "soft", "celebration"],
+        },
+        {
+            "id": "sunbeam_cat",
+            "family": "cozy",
+            "scene": "a content cat stretching in a sunbeam while little celebratory glints hover nearby",
+            "tags": ["animal", "cozy", "warm", "playful"],
+        },
+        {
+            "id": "sprout_glow",
+            "family": "growth",
+            "scene": "a fresh sprout glowing gently as tiny lantern-like lights bloom around it",
+            "tags": ["growth", "nature", "light", "soft"],
+        },
+        {
+            "id": "paper_plane",
+            "family": "motion",
+            "scene": "a paper airplane arcing through peach sunrise clouds with subtle confetti trails",
+            "tags": ["motion", "sky", "light", "playful"],
+        },
+    ],
+    "medium": [
+        {
+            "id": "fox_meadow",
+            "family": "animals",
+            "scene": "a fox doing a victory dance in a meadow full of wildflowers",
+            "tags": ["animal", "nature", "playful", "joy"],
+        },
+        {
+            "id": "confetti_box",
+            "family": "celebration",
+            "scene": "colorful confetti exploding from a gift box with sparkles everywhere",
+            "tags": ["abstract", "confetti", "colorful", "joy"],
+        },
+        {
+            "id": "rocket_ring",
+            "family": "space",
+            "scene": "a rocket launching through a ring of stars with triumphant motion",
+            "tags": ["space", "motion", "triumph", "bold"],
+        },
+        {
+            "id": "otter_waterfall",
+            "family": "animals",
+            "scene": "an otter sliding down a rainbow waterfall with pure joy",
+            "tags": ["animal", "water", "playful", "joy"],
+        },
+        {
+            "id": "aurora_peak",
+            "family": "nature",
+            "scene": "a mountain peak at golden hour with aurora light pouring overhead",
+            "tags": ["nature", "mountain", "majestic", "light"],
+        },
+    ],
+    "high": [
+        {
+            "id": "phoenix_rise",
+            "family": "mythic",
+            "scene": "a magnificent phoenix rising from golden flames into a starlit sky",
+            "tags": ["mythic", "fire", "majestic", "triumph"],
+        },
+        {
+            "id": "aurora_dragon",
+            "family": "mythic",
+            "scene": "a dragon made of northern lights soaring over a glowing cityscape",
+            "tags": ["mythic", "light", "majestic", "space"],
+        },
+        {
+            "id": "astronaut_flag",
+            "family": "space",
+            "scene": "an astronaut planting a flag on a new planet with galaxies swirling behind them",
+            "tags": ["space", "triumph", "bold", "exploration"],
+        },
+        {
+            "id": "tree_of_light",
+            "family": "growth",
+            "scene": "a massive tree of light growing from the ground through clouds into space",
+            "tags": ["growth", "light", "nature", "majestic"],
+        },
+        {
+            "id": "whale_nebula",
+            "family": "space",
+            "scene": "a whale breaching through an ocean of stars and nebulae",
+            "tags": ["space", "animal", "majestic", "wonder"],
+        },
+    ],
+    "epic": [
+        {
+            "id": "galactic_crown",
+            "family": "cosmic",
+            "scene": "an entire galaxy forming the shape of a crown while supernovas bloom in celebration",
+            "tags": ["space", "cosmic", "crown", "epic"],
+        },
+        {
+            "id": "titan_prism",
+            "family": "abstract",
+            "scene": "a titan standing atop a mountain while reality fractures into prismatic light",
+            "tags": ["abstract", "light", "epic", "majestic"],
+        },
+        {
+            "id": "sun_moon_high_five",
+            "family": "cosmic",
+            "scene": "the sun and moon aligned in a cosmic high-five with rings of fire and ice",
+            "tags": ["space", "cosmic", "playful", "epic"],
+        },
+        {
+            "id": "galaxy_phoenix",
+            "family": "mythic",
+            "scene": "a colossal phoenix made of galaxies rising above a glowing planet",
+            "tags": ["mythic", "space", "fire", "epic"],
+        },
+        {
+            "id": "light_cathedral",
+            "family": "abstract",
+            "scene": "reality folding into a vast cathedral of light and color",
+            "tags": ["abstract", "light", "epic", "wonder"],
+        },
+    ],
 }
 
-PROMPT=$(build_prompt)
+STYLE_OPTIONS = [
+    {"name": "digital illustration", "tags": ["clean", "graphic", "versatile"]},
+    {"name": "storybook watercolor", "tags": ["soft", "warm", "nature"]},
+    {"name": "paper collage illustration", "tags": ["playful", "texture", "craft"]},
+    {"name": "soft 3D render", "tags": ["bold", "light", "playful"]},
+    {"name": "gouache poster art", "tags": ["graphic", "warm", "bold"]},
+]
 
-# Choose quality based on intensity
+PALETTE_OPTIONS = [
+    {"name": "sunrise citrus and confetti gold", "tags": ["warm", "bright", "celebration"]},
+    {"name": "aurora jewel tones", "tags": ["cool", "space", "bold"]},
+    {"name": "cozy pastel glow", "tags": ["soft", "warm", "cozy"]},
+    {"name": "meadow greens and sky blues", "tags": ["nature", "fresh", "calm"]},
+    {"name": "prismatic neon confetti", "tags": ["bold", "confetti", "playful"]},
+]
+
+TASK_PROFILES = [
+    {
+        "id": "communication",
+        "patterns": [
+            r"\b(call|phone|dial|email|text|message|reply|schedule|book|appointment|meeting)\b",
+        ],
+        "literal": "a glowing phone or note card bursting with confetti and relief",
+        "metaphor": "a bright doorway opening with warm light and tiny celebratory sparks",
+        "tags": ["communication", "admin", "relief"],
+    },
+    {
+        "id": "writing",
+        "patterns": [
+            r"\b(write|draft|edit|revise|review|report|proposal|essay|notes?|read|study)\b",
+        ],
+        "literal": "pages and pens transforming into a lifted ribbon of stars",
+        "metaphor": "scattered pages folding into one clear beam of light",
+        "tags": ["writing", "paper", "focus"],
+    },
+    {
+        "id": "technology",
+        "patterns": [
+            r"\b(code|debug|build|fix|ship|deploy|setup|install|configure|update|refactor|script)\b",
+        ],
+        "literal": "a friendly laptop radiating upgrade sparks and neat glowing circuitry",
+        "metaphor": "gears of light clicking smoothly into place with an upward burst",
+        "tags": ["technology", "build", "focus"],
+    },
+    {
+        "id": "organization",
+        "patterns": [
+            r"\b(clean|tidy|organize|organise|declutter|laundry|dishes|sort)\b",
+        ],
+        "literal": "objects snapping into colorful order with satisfying sparkles",
+        "metaphor": "chaos settling into calm symmetry under warm golden light",
+        "tags": ["organization", "home", "order"],
+    },
+    {
+        "id": "movement",
+        "patterns": [
+            r"\b(run|walk|workout|exercise|gym|stretch|bike)\b",
+        ],
+        "literal": "a bright path lighting up under energetic footsteps",
+        "metaphor": "a trail of light unfurling forward with steady momentum",
+        "tags": ["movement", "outdoors", "health"],
+    },
+    {
+        "id": "food",
+        "patterns": [
+            r"\b(cook|meal|dinner|lunch|breakfast|grocery|groceries|shop)\b",
+        ],
+        "literal": "fresh ingredients and grocery shapes leaping upward in a burst of color",
+        "metaphor": "a welcoming table glow building into a festive burst",
+        "tags": ["food", "home", "care"],
+    },
+    {
+        "id": "admin",
+        "patterns": [
+            r"\b(pay|bill|budget|tax|invoice|insurance|form|paperwork)\b",
+        ],
+        "literal": "a neat stack of forms resolving into golden confetti",
+        "metaphor": "heavy blocks lifting into crisp floating ribbons of light",
+        "tags": ["admin", "paper", "relief"],
+    },
+]
+
+SENSITIVE_PATTERNS = [
+    (r"\b(therapy|therapist|counseling|counselling|psychiatry|psychiatrist|trauma|grief|breakup|funeral)\b", "personal"),
+    (r"\b(medical|doctor|hospital|clinic|prescription|medication|meds|diagnosis|lab|surgery|procedure|dentist|dental)\b", "medical"),
+    (r"\b(tax|bank|credit|debt|loan|lawsuit|lawyer|court|insurance appeal|claim)\b", "financial_or_legal"),
+]
+
+GENERIC_TITLES = {
+    "task",
+    "tasks",
+    "todo",
+    "to do",
+    "work",
+    "stuff",
+    "things",
+    "errands",
+    "chores",
+    "misc",
+    "miscellaneous",
+}
+
+WORK_TYPE_GUIDANCE = {
+    "focus": "Favor a clean, structured composition with one strong focal point.",
+    "creative": "Favor inventive motion and surprising details.",
+    "social": "Favor warm, connected energy without depicting private people literally.",
+    "independent": "Favor self-directed momentum and satisfying completion.",
+}
+
+ENERGY_GUIDANCE = {
+    "low": "Keep the mood gentle, reassuring, and non-overwhelming.",
+    "medium": "Keep the energy balanced and confident.",
+    "high": "Use punchier motion and stronger contrast.",
+}
+
+HUMOR_GUIDANCE = {
+    "subtle": "Keep the whimsy elegant and restrained.",
+    "playful": "Add lighthearted celebratory charm.",
+    "maximal": "Lean into exuberant, surprising celebratory details.",
+}
+
+HUMOR_GUIDANCE_KEYS = set(HUMOR_GUIDANCE)
+
+
+def slugify(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+
+
+def listify(value):
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item).strip()]
+    return []
+
+
+def normalize_text_list(values):
+    normalized = []
+    for value in values:
+        text = re.sub(r"\s+", " ", str(value).strip().lower())
+        if text:
+            normalized.append(text)
+    return normalized
+
+
+def term_variants(term: str):
+    variants = {term}
+    if term.endswith("s") and len(term) > 3:
+        variants.add(term[:-1])
+    else:
+        variants.add(f"{term}s")
+    return [variant for variant in variants if variant]
+
+
+def load_reward_preferences(path: Path):
+    if not path.is_file():
+        return {
+            "styles": [],
+            "palettes": [],
+            "subjects": [],
+            "avoid": [],
+            "humor_level": "playful",
+        }
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {
+            "styles": [],
+            "palettes": [],
+            "subjects": [],
+            "avoid": [],
+            "humor_level": "playful",
+        }
+
+    reward_prefs = ((payload.get("user_preferences") or {}).get("rewards")) or {}
+    if not isinstance(reward_prefs, dict):
+        reward_prefs = {}
+
+    humor = str(reward_prefs.get("humor_level") or "playful").strip().lower()
+    if humor in {"low", "minimal"}:
+        humor = "subtle"
+    elif humor in {"high", "loud"}:
+        humor = "maximal"
+    elif humor not in HUMOR_GUIDANCE_KEYS:
+        humor = "playful"
+
+    return {
+        "styles": normalize_text_list(listify(reward_prefs.get("preferred_styles") or reward_prefs.get("style"))),
+        "palettes": normalize_text_list(listify(reward_prefs.get("preferred_palettes") or reward_prefs.get("palette"))),
+        "subjects": normalize_text_list(listify(reward_prefs.get("favorite_subjects") or reward_prefs.get("subjects"))),
+        "avoid": normalize_text_list(listify(reward_prefs.get("avoid"))),
+        "humor_level": humor,
+    }
+
+
+def load_feedback(path: Path):
+    feedback = {
+        "theme_family": {},
+        "style": {},
+        "palette": {},
+        "theme_tag": {},
+    }
+
+    if not path.is_file():
+        return feedback
+
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return feedback
+
+    recent_lines = [line for line in lines if line.strip()][-50:]
+    for line in recent_lines:
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        score = {
+            "positive": 2.0,
+            "neutral": 0.0,
+            "negative": -2.0,
+        }.get(str(entry.get("reaction", "")).lower())
+        if score is None:
+            continue
+
+        family = slugify(str(entry.get("theme_family") or ""))
+        if family:
+            feedback["theme_family"][family] = feedback["theme_family"].get(family, 0.0) + score
+
+        style = slugify(str(entry.get("style") or ""))
+        if style:
+            feedback["style"][style] = feedback["style"].get(style, 0.0) + score
+
+        palette = slugify(str(entry.get("palette") or ""))
+        if palette:
+            feedback["palette"][palette] = feedback["palette"].get(palette, 0.0) + score
+
+        for tag in entry.get("theme_tags", []):
+            tag_key = slugify(str(tag))
+            if tag_key:
+                feedback["theme_tag"][tag_key] = feedback["theme_tag"].get(tag_key, 0.0) + score
+
+    return feedback
+
+
+def find_task_profile(title: str):
+    lowered = title.lower()
+    for profile in TASK_PROFILES:
+        for pattern in profile["patterns"]:
+            if re.search(pattern, lowered):
+                return profile
+    return {
+        "id": "general",
+        "literal": "a compact burst of progress and confetti radiating from a finished checkmark-shaped glow",
+        "metaphor": "a spark of momentum widening into a bright, satisfying celebration",
+        "tags": ["general", "progress"],
+    }
+
+
+def detect_sensitive_reason(title: str):
+    lowered = title.lower()
+    for pattern, reason in SENSITIVE_PATTERNS:
+        if re.search(pattern, lowered):
+            return reason
+    return ""
+
+
+def is_vague_title(title: str) -> bool:
+    lowered = title.lower().strip()
+    if lowered in GENERIC_TITLES:
+        return True
+    words = re.findall(r"[a-z0-9']+", lowered)
+    if not words:
+        return True
+    if len(words) <= 2 and all(word in GENERIC_TITLES for word in words):
+        return True
+    return False
+
+
+def pick_with_weights(options, scorer):
+    weights = []
+    for option in options:
+        weight = scorer(option)
+        weights.append(max(weight, 0.1))
+    return random.choices(options, weights=weights, k=1)[0]
+
+
+def option_text(option):
+    parts = [
+        option.get("id", ""),
+        option.get("family", ""),
+        option.get("name", ""),
+        option.get("scene", ""),
+        " ".join(option.get("tags", [])),
+    ]
+    return " ".join(parts).lower()
+
+
+def preference_score(option, preferred_terms, weight):
+    joined = option_text(option)
+    score = 0.0
+    for term in preferred_terms:
+        for variant in term_variants(term):
+            if variant and variant in joined:
+                score += weight
+                break
+    return score
+
+
+def avoidance_penalty(option, avoid_terms, weight):
+    joined = option_text(option)
+    penalty = 0.0
+    for term in avoid_terms:
+        for variant in term_variants(term):
+            if variant and variant in joined:
+                penalty += weight
+                break
+    return penalty
+
+
+def build_streak_detail(streak: int) -> str:
+    if streak >= 5:
+        return "Add a trail of five glowing orbs to signal a hot streak."
+    if streak >= 3:
+        return "Add three small orbiting stars to hint at momentum."
+    return ""
+
+
+def build_task_mode(task_title: str, sensitive_reason: str):
+    if sensitive_reason:
+        return "metaphorical"
+    if is_vague_title(task_title):
+        return "abstract"
+    return "literal"
+
+
+def build_task_motif(profile, task_mode: str):
+    if task_mode == "literal":
+        return profile["literal"]
+    if task_mode == "metaphorical":
+        return profile["metaphor"]
+    return "a clean burst of forward motion turning into a satisfying celebration"
+
+
+def theme_score(option, prefs, feedback, task_mode):
+    score = 1.0
+    score += preference_score(option, prefs["subjects"], 1.2)
+    score -= avoidance_penalty(option, prefs["avoid"], 1.5)
+    score += feedback["theme_family"].get(slugify(option.get("family", "")), 0.0) * 0.35
+    for tag in option.get("tags", []):
+        score += feedback["theme_tag"].get(slugify(tag), 0.0) * 0.12
+    if task_mode == "metaphorical":
+        if "playful" in option.get("tags", []):
+            score -= 0.25
+        if any(tag in option.get("tags", []) for tag in ("abstract", "light", "growth", "majestic")):
+            score += 0.45
+    return score
+
+
+def style_score(option, prefs, feedback, task_mode):
+    score = 1.0
+    score += preference_score(option, prefs["styles"], 1.3)
+    score -= avoidance_penalty(option, prefs["avoid"], 1.2)
+    score += feedback["style"].get(slugify(option["name"]), 0.0) * 0.4
+    if task_mode == "metaphorical" and "playful" in option.get("tags", []):
+        score -= 0.15
+    return score
+
+
+def palette_score(option, prefs, feedback):
+    score = 1.0
+    score += preference_score(option, prefs["palettes"], 1.3)
+    score += preference_score(option, prefs["subjects"], 0.4)
+    score -= avoidance_penalty(option, prefs["avoid"], 1.1)
+    score += feedback["palette"].get(slugify(option["name"]), 0.0) * 0.4
+    return score
+
+
+reward_preferences = load_reward_preferences(STATE_FILE)
+feedback = load_feedback(FEEDBACK_FILE)
+task_profile = find_task_profile(TASK_TITLE)
+sensitive_reason = detect_sensitive_reason(TASK_TITLE)
+task_mode = build_task_mode(TASK_TITLE, sensitive_reason)
+task_motif = build_task_motif(task_profile, task_mode)
+
+theme = pick_with_weights(
+    THEMES[INTENSITY],
+    lambda option: theme_score(option, reward_preferences, feedback, task_mode),
+)
+style = pick_with_weights(
+    STYLE_OPTIONS,
+    lambda option: style_score(option, reward_preferences, feedback, task_mode),
+)
+palette = pick_with_weights(
+    PALETTE_OPTIONS,
+    lambda option: palette_score(option, reward_preferences, feedback),
+)
+
+humor_level = reward_preferences["humor_level"]
+if sensitive_reason and humor_level == "maximal":
+    humor_level = "playful"
+
+prompt_parts = [
+    "Create a square celebratory reward image for a completed task.",
+    f"Core scene: {theme['scene']}.",
+    f"Blend in task relevance with {task_motif}.",
+]
+
+if sensitive_reason:
+    prompt_parts.append(
+        "Keep the celebration metaphorical and non-specific. Do not depict private medical, legal, financial, or relationship details literally."
+    )
+elif task_mode == "abstract":
+    prompt_parts.append(
+        "The task title is vague, so favor a universally satisfying sense of progress over literal objects."
+    )
+
+prompt_parts.extend(
+    [
+        f"Style: {style['name']}.",
+        f"Palette: {palette['name']}.",
+        WORK_TYPE_GUIDANCE.get(WORK_TYPE, ""),
+        ENERGY_GUIDANCE.get(ENERGY_LEVEL, ""),
+        HUMOR_GUIDANCE[humor_level],
+        build_streak_detail(STREAK),
+        "Keep the composition uplifting, polished, and easy to read at a glance.",
+        "No text, no letters, no numbers, no UI, no watermarks.",
+    ]
+)
+
+prompt = " ".join(part for part in prompt_parts if part)
+
+context = {
+    "reward_id": REWARD_ID,
+    "prompt_version": 2,
+    "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+    "intensity": INTENSITY,
+    "task_title": TASK_TITLE,
+    "streak": STREAK,
+    "task_mode": task_mode,
+    "task_profile": task_profile["id"],
+    "task_motif": task_motif,
+    "task_tags": list(dict.fromkeys(task_profile["tags"] + ([WORK_TYPE] if WORK_TYPE else []) + ([ENERGY_LEVEL] if ENERGY_LEVEL else []))),
+    "sensitive_reason": sensitive_reason or None,
+    "theme_id": theme["id"],
+    "theme_family": theme["family"],
+    "theme_tags": theme["tags"],
+    "style": style["name"],
+    "palette": palette["name"],
+    "humor_level": humor_level,
+    "work_type": WORK_TYPE or None,
+    "energy_level": ENERGY_LEVEL or None,
+    "feedback_active": FEEDBACK_FILE.is_file(),
+    "preferences_active": STATE_FILE.is_file() and bool(
+        reward_preferences["styles"]
+        or reward_preferences["palettes"]
+        or reward_preferences["subjects"]
+        or reward_preferences["avoid"]
+        or reward_preferences["humor_level"] != "playful"
+    ),
+    "prompt": prompt,
+}
+
+print(json.dumps(context, ensure_ascii=True))
+PY
+}
+
+PROMPT_CONTEXT_JSON="$(build_reward_context)"
+PROMPT="$(printf '%s' "$PROMPT_CONTEXT_JSON" | python3 -c 'import json, sys; print(json.load(sys.stdin)["prompt"])')"
+
 if [ "$INTENSITY" = "epic" ]; then
     QUALITY="high"
 else
     QUALITY="auto"
 fi
 
-# Generate the image — pass variables via environment to avoid shell injection
-# Temporarily allow failure so we can catch network/curl errors
 set +e
-RESPONSE=$(
+RESPONSE="$(
     PROMPT="$PROMPT" QUALITY="$QUALITY" \
     python3 -c "
 import json, os
@@ -166,52 +756,75 @@ print(payload)
     -H "Authorization: Bearer $OPENAI_API_KEY" \
     -H "Content-Type: application/json" \
     -d @-
-)
+)"
 CURL_EXIT=$?
 set -e
 
-if [ $CURL_EXIT -ne 0 ] || [ -z "$RESPONSE" ]; then
+if [ "$CURL_EXIT" -ne 0 ] || [ -z "$RESPONSE" ]; then
     suggest_offline_reward "network error or API unreachable"
 fi
 
-# Check for errors
-ERROR=$(echo "$RESPONSE" | python3 -c "
+ERROR="$(echo "$RESPONSE" | python3 -c "
 import json, sys
 data = json.load(sys.stdin)
 if 'error' in data:
     print(data['error']['message'])
-" 2>/dev/null || true)
+" 2>/dev/null || true)"
 
 if [ -n "$ERROR" ]; then
     suggest_offline_reward "API error: $ERROR"
 fi
 
-# Extract and save the image (gpt-image-1 returns b64_json by default)
 set +e
 OUTPUT_PATH="$OUTPUT" python3 -c "
-import json, sys, base64, os
+import base64
+import json
+import os
+import sys
+
 data = json.load(sys.stdin)
 result = data['data'][0]
-out = os.environ['OUTPUT_PATH']
+output_path = os.environ['OUTPUT_PATH']
+
 if 'b64_json' in result:
-    img_data = base64.b64decode(result['b64_json'])
-    with open(out, 'wb') as f:
-        f.write(img_data)
+    image_data = base64.b64decode(result['b64_json'])
+    with open(output_path, 'wb') as handle:
+        handle.write(image_data)
 elif 'url' in result:
     import urllib.request
-    urllib.request.urlretrieve(result['url'], out)
+    urllib.request.urlretrieve(result['url'], output_path)
 " <<< "$RESPONSE"
 EXTRACT_EXIT=$?
 set -e
 
-if [ $EXTRACT_EXIT -ne 0 ] || [ ! -s "$OUTPUT" ]; then
+if [ "$EXTRACT_EXIT" -ne 0 ] || [ ! -s "$OUTPUT" ]; then
     suggest_offline_reward "failed to decode image from API response"
 fi
 
-# Copy to archive
 cp "$OUTPUT" "$ARCHIVE_FILE"
 
-# Write metadata for the weekly recap (tab-delimited to avoid issues with | in titles)
-printf '%s\t%s\t%s\t%s\n' "$TIMESTAMP" "$INTENSITY" "$TASK_TITLE" "$ARCHIVE_FILE" >> "$ARCHIVE_DIR/manifest.log"
+printf '%s\t%s\t%s\t%s\n' "$TIMESTAMP" "$INTENSITY" "$TASK_TITLE" "$ARCHIVE_FILE" >> "$MANIFEST_FILE"
+
+MANIFEST_RECORD="$(
+    CONTEXT_JSON="$PROMPT_CONTEXT_JSON" \
+    TIMESTAMP="$TIMESTAMP" \
+    ARCHIVE_FILE="$ARCHIVE_FILE" \
+    OUTPUT_FILE="$OUTPUT" \
+    python3 <<'PY'
+import json
+import os
+
+record = json.loads(os.environ["CONTEXT_JSON"])
+record.update(
+    {
+        "timestamp": int(os.environ["TIMESTAMP"]),
+        "archive_file": os.environ["ARCHIVE_FILE"],
+        "output_file": os.environ["OUTPUT_FILE"],
+    }
+)
+print(json.dumps(record, ensure_ascii=True))
+PY
+)"
+printf '%s\n' "$MANIFEST_RECORD" >> "$MANIFEST_JSONL"
 
 echo "$OUTPUT"

--- a/scripts/log-reward-feedback.sh
+++ b/scripts/log-reward-feedback.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Record user feedback for a generated reward image.
+# Usage: ./scripts/log-reward-feedback.sh <reward_id|latest> <positive|neutral|negative> [note...]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ARCHIVE_DIR="$SCRIPT_DIR/../rewards"
+MANIFEST_JSONL="$ARCHIVE_DIR/manifest.jsonl"
+FEEDBACK_JSONL="$ARCHIVE_DIR/feedback.jsonl"
+
+TARGET="${1:-}"
+REACTION="${2:-}"
+
+usage() {
+    cat <<'EOF' >&2
+Usage: ./scripts/log-reward-feedback.sh <reward_id|latest> <positive|neutral|negative> [note...]
+EOF
+    exit 1
+}
+
+[ -n "$TARGET" ] || usage
+[ -n "$REACTION" ] || usage
+
+case "$REACTION" in
+    positive|neutral|negative)
+        ;;
+    *)
+        echo "Unsupported reaction: $REACTION" >&2
+        usage
+        ;;
+esac
+
+shift 2
+
+NOTE="$*"
+
+if [ ! -f "$MANIFEST_JSONL" ]; then
+    echo "No reward manifest found at $MANIFEST_JSONL" >&2
+    exit 1
+fi
+
+FEEDBACK_ENTRY="$(
+    TARGET="$TARGET" \
+    REACTION="$REACTION" \
+    NOTE="$NOTE" \
+    MANIFEST_JSONL="$MANIFEST_JSONL" \
+    python3 <<'PY'
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+manifest_path = Path(os.environ["MANIFEST_JSONL"])
+target = os.environ["TARGET"]
+reaction = os.environ["REACTION"]
+note = os.environ["NOTE"].strip()
+
+entries = []
+for line in manifest_path.read_text(encoding="utf-8").splitlines():
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        entries.append(json.loads(line))
+    except json.JSONDecodeError:
+        continue
+
+if not entries:
+    print("Reward manifest is empty", file=sys.stderr)
+    raise SystemExit(1)
+
+if target == "latest":
+    selected = entries[-1]
+else:
+    selected = next((entry for entry in entries if entry.get("reward_id") == target), None)
+
+if not selected:
+    print(f"Reward not found: {target}", file=sys.stderr)
+    raise SystemExit(1)
+
+payload = {
+    "recorded_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+    "reward_id": selected.get("reward_id"),
+    "reaction": reaction,
+    "note": note or None,
+    "theme_family": selected.get("theme_family"),
+    "theme_tags": selected.get("theme_tags", []),
+    "style": selected.get("style"),
+    "palette": selected.get("palette"),
+    "task_mode": selected.get("task_mode"),
+    "task_profile": selected.get("task_profile"),
+}
+
+print(json.dumps(payload, ensure_ascii=True))
+PY
+)"
+
+mkdir -p "$ARCHIVE_DIR"
+printf '%s\n' "$FEEDBACK_ENTRY" >> "$FEEDBACK_JSONL"
+
+RECORDED_REWARD_ID="$(printf '%s' "$FEEDBACK_ENTRY" | python3 -c 'import json, sys; print(json.load(sys.stdin)["reward_id"])')"
+echo "Recorded $REACTION feedback for reward $RECORDED_REWARD_ID"


### PR DESCRIPTION
Resolves #512

## Summary
- make `generate-reward-image.sh` build task-aware prompts instead of ignoring the task title
- load optional reward preferences from `state.json.user_preferences.rewards` and use them to weight theme/style/palette selection
- add `scripts/log-reward-feedback.sh` plus `manifest.jsonl`/`feedback.jsonl` metadata so future rewards can learn from reactions
- document the new prompt pipeline, preference schema, and feedback loop in `docs/reward-system.md`

## Test Plan
- `shellcheck scripts/*.sh`
- `yamllint .github/workflows/*.yml`
- `scripts/check-doc-links.sh`
- smoke test `scripts/generate-reward-image.sh` with a stubbed `curl` response to verify `manifest.jsonl` output and `scripts/log-reward-feedback.sh` writes `feedback.jsonl`

Generated with Codex

Author-Session: codex/25166501295