### PR TITLE
Replace cheap-tier model with qwen2.5

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -5,7 +5,7 @@
 - **OpenClaw** installed and configured (`openclaw setup`)
 - **Notion** database created with the schema from `docs/notion-schema.md`
 - **Signal** account configured if Signal will be one of the interactive messaging surfaces
-- **LiteLLM proxy** for the default model routing (`gemma4-small` cheap tier plus Anthropic-backed medium/expensive tiers)
+- **LiteLLM proxy** for the default model routing (`qwen2.5` cheap tier plus Anthropic-backed medium/expensive tiers)
 
 ## Quick Start
 
@@ -138,7 +138,7 @@ Model assignments use a tier system defined in `setup/openclaw.json.template` un
 |------|------|---------|
 | `expensive` | Primary interactive agent | `claude-opus-4-6` |
 | `medium` | Fallback | `claude-sonnet-4-6` |
-| `cheap` | Heartbeat, isolated cron jobs | `gemma4-small` |
+| `cheap` | Heartbeat, isolated cron jobs | `qwen2.5` |
 
 Default setup assumes LiteLLM fronts every configured model. If you want a direct Anthropic-only install, that is a custom setup: remap `modelTiers.cheap` to an Anthropic model you can access, then update the cron `model:` lines and agent defaults to match before first run.
 

--- a/setup/cron/heartbeat-check.md
+++ b/setup/cron/heartbeat-check.md
@@ -7,7 +7,7 @@ Heartbeat = built-in OpenClaw feature, not a cron job. Configured in `openclaw.j
 ```json
 "heartbeat": {
   "every": "60m",
-  "model": "litellm/gemma4-small",  // must match modelTiers.cheap
+  "model": "litellm/qwen2.5",  // must match modelTiers.cheap
   "lightContext": true,              // bootstrap = HEARTBEAT.md only
   "isolatedSession": true            // skip prior conversation transcript
 }

--- a/setup/cron/pull-main.md
+++ b/setup/cron/pull-main.md
@@ -10,7 +10,7 @@ CronCreate:
   durable: true
   name: "pull-main"
   sessionTarget: isolated
-  model: litellm/gemma4-small  # must match modelTiers.cheap
+  model: litellm/qwen2.5  # must match modelTiers.cheap
   payload:
     kind: agentTurn
     lightContext: true  # empty bootstrap — cron prompt is self-contained

--- a/setup/cron/reminder-check.md
+++ b/setup/cron/reminder-check.md
@@ -10,7 +10,7 @@ CronCreate:
   durable: true
   name: "reminder-check"
   sessionTarget: isolated
-  model: litellm/gemma4-small  # must match modelTiers.cheap
+  model: litellm/qwen2.5  # must match modelTiers.cheap
   payload:
     kind: agentTurn
     lightContext: true  # empty bootstrap — cron prompt is self-contained

--- a/setup/cron/reminder-delivery.md
+++ b/setup/cron/reminder-delivery.md
@@ -21,7 +21,7 @@ CronCreate:
     kind: "at"
     at: "<remind_at ISO 8601 with timezone>"
   sessionTarget: main
-  model: litellm/gemma4-small  # must match modelTiers.cheap
+  model: litellm/qwen2.5  # must match modelTiers.cheap
   payload:
     kind: agentTurn
     lightContext: false  # bootstrap loaded — agent needs SOUL.md tone, AGENTS.md state.json conventions

--- a/setup/openclaw.json.template
+++ b/setup/openclaw.json.template
@@ -47,8 +47,8 @@
             "maxTokens": 4096
           },
           {
-            "id": "gemma4-small",
-            "name": "Gemma 4 Small",
+            "id": "qwen2.5",
+            "name": "Qwen 2.5",
             "reasoning": false,
             "input": ["text"],
             "contextWindow": 200000,
@@ -69,7 +69,7 @@
   "modelTiers": {
     "expensive": "claude-opus-4-6",
     "medium": "claude-sonnet-4-6",
-    "cheap": "gemma4-small"
+    "cheap": "qwen2.5"
   },
   "agents": {
     "defaults": {
@@ -86,7 +86,7 @@
       },
       "heartbeat": {
         "every": "60m",
-        "model": "litellm/gemma4-small",
+        "model": "litellm/qwen2.5",
         "lightContext": true,
         "isolatedSession": true
       },


### PR DESCRIPTION
Resolves #517

## Summary
- replace the cheap-tier LiteLLM model entry in `setup/openclaw.json.template` from `gemma4-small` to `qwen2.5`
- update `modelTiers.cheap`, `agents.defaults.heartbeat.model`, and all four cron/heartbeat specs to reference `litellm/qwen2.5`
- refresh `setup/README.md` so setup docs match the new cheap-tier model

## Test Plan
- `grep -RIn --exclude-dir=.git "gemma4-small" setup scripts docs || true`
- `scripts/validate-model-refs.sh`
- `shellcheck scripts/*.sh`
- `yamllint .github/workflows/*.yml`
- `scripts/check-doc-links.sh`

Generated with Codex

Author-Session: codex/25237887551