### PR TITLE
Migrate Codex reviewer defaults to gpt-5.5

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,4 +1,4 @@
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_provider = "litellm"
 
 [model_providers.litellm]

--- a/.devcontainer/configure-codex.sh
+++ b/.devcontainer/configure-codex.sh
@@ -15,7 +15,7 @@ mkdir -p "$HOME/.codex"
 # Allow the Codex model configuration to be overridden for different LiteLLM
 # backends without requiring code changes. These defaults reflect the current
 # shared LiteLLM proxy deployment used in CI.
-CODEX_MODEL_DEFAULT="gpt-5.4"
+CODEX_MODEL_DEFAULT="gpt-5.5"
 CODEX_MODEL_PROVIDER_DEFAULT="litellm"
 CODEX_MODEL_PROVIDER_NAME_DEFAULT="LiteLLM"
 CODEX_MODEL_BASE_URL_DEFAULT="https://llm.featherback-mermaid.ts.net/v1"

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -170,7 +170,7 @@ Canonical model list and tier mappings live in `setup/openclaw.json.template` (s
 - **Primary model (expensive tier):** Whatever `modelTiers.expensive` maps to for conversations and task management
 - **Heartbeat model (cheap tier):** Whatever `modelTiers.cheap` maps to for routine health checks
 - **Cron model (cheap tier):** Whatever `modelTiers.cheap` maps to for both isolated recurring cron work (reminder polling, workspace sync) and the per-reminder one-shot delivery cron
-- **Codex CLI model:** GPT-5.4, configured separately in `.codex/config.toml` via `.devcontainer/configure-codex.sh`; not served through the OpenClaw models array above.
+- **Codex CLI model:** GPT-5.5, configured separately in `.codex/config.toml` via `.devcontainer/configure-codex.sh`; not served through the OpenClaw models array above.
 
 **Our role:** No direct interaction with model selection. Prompts in `docs/ai-prompts/` model-agnostic. OpenClaw picks model from config.
 

--- a/setup/README.md
+++ b/setup/README.md
@@ -104,7 +104,7 @@
 | `GITHUB_PAT` | No | Personal access token used by repo maintenance scripts when `gh auth login` has not been run on the host |
 | `REMINDER_SIGNAL_FILE` | No | Optional reminder handoff filename in the repo root (defaults to `.reminder-signal`) |
 | `OPS_ALERT_SIGNAL_NUMBER` | Yes | Separate Signal recipient for heartbeat ops alerts (Notion failures, cron drift/expiry, dirty-pull recovery problems, malformed reminder handoffs) |
-| `CODEX_MODEL` | No | Overrides the Codex CLI model (defaults to `gpt-5.4` for the shared LiteLLM proxy) |
+| `CODEX_MODEL` | No | Overrides the Codex CLI model (defaults to `gpt-5.5` for the shared LiteLLM proxy) |
 
 Advanced overrides for self-hosted LiteLLM setups are also supported:
 


### PR DESCRIPTION
Resolves #521

## Summary
- switch the shared Codex CLI defaults in `.devcontainer/configure-codex.sh` and `.codex/config.toml` from `gpt-5.4` to `gpt-5.5`
- update `setup/README.md` to document the new default model for the shared LiteLLM proxy
- verify there are no remaining `gpt-5.4` hits in the affected Codex reviewer paths

## Test Plan
- `git grep -n "gpt-5\\.4" -- .codex .devcontainer setup .github/workflows .github/actions || true`
- `shellcheck scripts/*.sh`
- `yamllint .github/workflows/*.yml`
- verify local docs links referenced from `docs/architecture.md` resolve and `setup/README.md` introduces no markdown links to break

Generated with Codex

Author-Session: codex/25239975499