### PR TITLE
Tighten reward output boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,17 @@ Personalize prep using user preferences (beverage, comfort spot, rituals).
 | NEED_HELP | `docs/ai-prompts/breakdown.md` + `docs/ai-prompts/shared.md` — confidence detection, response levels, base prompt |
 | CHECK_IN | `docs/ai-prompts/check-in.md` + `docs/ai-prompts/shared.md` — timing, shame-safe templates, base prompt |
 
+### COMPLETE Output Boundary
+
+Reward generation is multi-step, but the conversation must not be.
+
+During COMPLETE handling:
+- Do all Notion updates, state updates, reward scoring, and image generation silently.
+- Do not send progress narration such as score math, streak calculations, tool plans, script commands, image-generation status, or state-update notes.
+- If a reward image is generated, send exactly one final user-visible reward reply containing celebration text plus one `MEDIA:<absolute-path>` line.
+- If image generation falls back to `.txt`, read the suggestion and send one plain-text celebration/reward reply with no `MEDIA:` line.
+- If two or more tasks are completed in the same turn, batch the hidden work and still send only the final celebration output(s). Internal per-task calculations stay invisible.
+
 ## Safety
 
 - Don't show full task list. Core rule.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,7 @@ During COMPLETE handling:
 - Do not send progress narration such as score math, streak calculations, tool plans, script commands, image-generation status, or state-update notes.
 - If a reward image is generated, send exactly one final user-visible reward reply containing celebration text plus one `MEDIA:<absolute-path>` line.
 - If image generation falls back to `.txt`, read the suggestion and send one plain-text celebration/reward reply with no `MEDIA:` line.
-- If two or more tasks are completed in the same turn, batch the hidden work and still send only the final celebration output(s). Internal per-task calculations stay invisible.
+- If two or more tasks are completed in the same user turn, batch hidden work into one turn-scoped reward: one combined celebration reply, at most one `MEDIA:` line, and no visible per-task calculations.
 
 ## Safety
 

--- a/docs/ai-prompts/shared.md
+++ b/docs/ai-prompts/shared.md
@@ -97,7 +97,7 @@ Rules:
 - Never mention reminder infrastructure like cron jobs, polling, handoff files, Notion writes, tool calls, or whether something will trigger automatically unless the user explicitly asks.
 - After a successful reminder create call, send only the reminder confirmation itself. No appended caveats, diagnostics, or self-evaluation.
 - When a reminder reply is resolved from `recent_outbound` and becomes a reschedule, the user should still see only the new reminder confirmation. Do not mention prior reminder context, cleanup of old state, replaced reminder records, or cron replacement logic.
-- During COMPLETE/reward handling, the only visible reward-phase content is the final celebration copy and optional rendered attachment markup described in `docs/reward-system.md`. Never expose reward score calculations, streak math, `state.json` updates, Notion status updates, generation commands, generated file paths except the required `MEDIA:` attachment line, or fallback diagnostics.
+- During COMPLETE/reward handling, the only visible reward-phase content is the final celebration copy and optional rendered attachment markup described in `docs/reward-system.md`. A user turn that completes multiple tasks still gets one turn-scoped reward reply with at most one attachment. Never expose reward score calculations, streak math, `state.json` updates, Notion status updates, generation commands, generated file paths except the required `MEDIA:` attachment line, or fallback diagnostics.
 - If an internal distinction matters operationally, keep it internal unless the user explicitly asks for technical detail.
 
 

--- a/docs/ai-prompts/shared.md
+++ b/docs/ai-prompts/shared.md
@@ -93,9 +93,11 @@ Everything the user sees should read like direct conversation, not system narrat
 
 Rules:
 - Never expose internal reasoning, chain-of-thought, hidden compliance checks, or tool-status narration.
+- Multi-step flows must stay silent until the user-facing result is ready. Do not send interim messages while running tools, updating state, calculating scores, or preparing attachments.
 - Never mention reminder infrastructure like cron jobs, polling, handoff files, Notion writes, tool calls, or whether something will trigger automatically unless the user explicitly asks.
 - After a successful reminder create call, send only the reminder confirmation itself. No appended caveats, diagnostics, or self-evaluation.
 - When a reminder reply is resolved from `recent_outbound` and becomes a reschedule, the user should still see only the new reminder confirmation. Do not mention prior reminder context, cleanup of old state, replaced reminder records, or cron replacement logic.
+- During COMPLETE/reward handling, the only visible reward-phase content is the final celebration copy and optional rendered attachment markup described in `docs/reward-system.md`. Never expose reward score calculations, streak math, `state.json` updates, Notion status updates, generation commands, generated file paths except the required `MEDIA:` attachment line, or fallback diagnostics.
 - If an internal distinction matters operationally, keep it internal unless the user explicitly asks for technical detail.
 
 

--- a/docs/reward-system.md
+++ b/docs/reward-system.md
@@ -298,6 +298,13 @@ assistant-authored reward turn passed to OpenClaw should contain only:
 1. Celebration text for the completion
 2. One `MEDIA:<absolute-path-to-image>` line
 
+Reward delivery is scoped to the user turn, not to each internal task update.
+If one user message completes multiple tasks, complete all hidden task/state
+work first, calculate the combined reward intensity, generate one representative
+image for the combined win, and send one final assistant-authored reward turn.
+That turn still contains exactly one celebration message and at most one
+`MEDIA:` line. Do not send one reward reply per task.
+
 OpenClaw consumes the `MEDIA:` line as attachment markup. End users should see
 only the celebration text plus the rendered image attachment — never the raw
 filesystem path or transport syntax.
@@ -313,13 +320,14 @@ Reward Delivery Checklist:
 
 - [ ] No interim user-visible messages were sent during reward scoring, state updates, Notion updates, or image generation
 - [ ] Visible user copy is celebration only — no orchestration notes, no "Now let me...", no tool narration
-- [ ] Exactly one `MEDIA:` line in the assistant-authored turn
+- [ ] At most one assistant-authored reward turn per user COMPLETE turn
+- [ ] Exactly one `MEDIA:` line in that turn when image generation returns `.png`; no `MEDIA:` line when using a `.txt` fallback
 - [ ] User sees rendered attachment, not raw `MEDIA:` syntax or filesystem path
 - [ ] No inline media tags such as `<media:image>` in the same reply
 - [ ] No second send of the same image via the `message` tool in the same turn
 - [ ] If the script returns a `.txt` fallback instead of `.png`, read the suggestion and send plain text only — no `MEDIA:` line
 - [ ] If the turn also includes an outing suggestion or other follow-up, send that as a separate plain-text message after the attachment-bearing reward reply
-- [ ] If multiple completions are handled in one user turn, per-task score math and tool work remain hidden; user-visible output is still only final celebration text plus each intended attachment/fallback
+- [ ] If multiple completions are handled in one user turn, per-task score math and tool work remain hidden; user-visible output is one combined celebration with one representative attachment/fallback at most
 
 #### Theme Pools by Intensity
 

--- a/docs/reward-system.md
+++ b/docs/reward-system.md
@@ -283,8 +283,17 @@ Task titles are not copied blindly into the image prompt. The script first class
 
 #### Reward Delivery Contract
 
-When `scripts/generate-reward-image.sh` returns a `.png`, the assistant-authored
-reward turn passed to OpenClaw should contain only:
+The COMPLETE reward phase has a strict visible-output boundary. All work before
+delivery is hidden implementation detail: status updates, `state.json` writes,
+reward scoring, streak math, channel selection, script invocations, fallback
+diagnostics, and image-generation progress must not be sent to the user.
+
+Do not narrate reward preparation. A COMPLETE turn must not contain visible text
+like "calculating the reward", "updating Notion", "generating an image", score
+breakdowns, shell commands, tool names, or progress updates before the reward.
+
+When `scripts/generate-reward-image.sh` returns a `.png`, the final
+assistant-authored reward turn passed to OpenClaw should contain only:
 
 1. Celebration text for the completion
 2. One `MEDIA:<absolute-path-to-image>` line
@@ -302,6 +311,7 @@ MEDIA:/absolute/path/to/image.png
 
 Reward Delivery Checklist:
 
+- [ ] No interim user-visible messages were sent during reward scoring, state updates, Notion updates, or image generation
 - [ ] Visible user copy is celebration only — no orchestration notes, no "Now let me...", no tool narration
 - [ ] Exactly one `MEDIA:` line in the assistant-authored turn
 - [ ] User sees rendered attachment, not raw `MEDIA:` syntax or filesystem path
@@ -309,6 +319,7 @@ Reward Delivery Checklist:
 - [ ] No second send of the same image via the `message` tool in the same turn
 - [ ] If the script returns a `.txt` fallback instead of `.png`, read the suggestion and send plain text only — no `MEDIA:` line
 - [ ] If the turn also includes an outing suggestion or other follow-up, send that as a separate plain-text message after the attachment-bearing reward reply
+- [ ] If multiple completions are handled in one user turn, per-task score math and tool work remain hidden; user-visible output is still only final celebration text plus each intended attachment/fallback
 
 #### Theme Pools by Intensity
 


### PR DESCRIPTION
Resolves #537

## Summary
- Clarified that COMPLETE reward preparation must stay silent until the final user-facing celebration is ready.
- Added explicit guardrails against leaking score math, streak calculations, tool/status narration, script commands, and state/Notion update details.
- Covered multi-completion reward handling so per-task internal work remains hidden.

## Test Plan
- shellcheck scripts/*.sh
- yamllint .github/workflows/*.yml
- scripts/check-doc-links.sh
- git diff --check
- commit/pre-push hooks: Mermaid lint/validation, script permission checks, model/spec/workflow validators, actionlint

Generated with Codex

Author-Session: codex/25299128458