### PR TITLE
Validate reward image streak task descriptions

### DIFF
--- a/docs/reward-system.md
+++ b/docs/reward-system.md
@@ -249,17 +249,24 @@ flowchart TD
 
 ```bash
 # Generate a reward image
-./scripts/generate-reward-image.sh <intensity> [task_title] [streak_count]
+./scripts/generate-reward-image.sh <intensity> <streak_count> <task_description>...
 
 # Examples:
-./scripts/generate-reward-image.sh low "Call dentist" 0
-./scripts/generate-reward-image.sh medium "Review proposal" 2
-./scripts/generate-reward-image.sh epic "Complete Q4 report" 5
+./scripts/generate-reward-image.sh low 0 "Call dentist"
+./scripts/generate-reward-image.sh medium 2 "Review proposal" "Clean desk"
+./scripts/generate-reward-image.sh epic 5 "Draft report" "Send update" "Pay bill" "Book appointment" "Fold laundry"
 
 # Optional context from the caller:
 REWARD_WORK_TYPE=focus REWARD_ENERGY_LEVEL=low \
-  ./scripts/generate-reward-image.sh medium "Review proposal" 2
+  ./scripts/generate-reward-image.sh medium 2 "Review proposal" "Clean desk"
 ```
+
+The script validates its reward inputs before generation:
+
+- `streak_count` must be a non-negative integer.
+- When `streak_count` is `N`, the caller must provide exactly `N` task descriptions.
+- For the first completion (`streak_count` `0`), the caller must provide exactly one task description.
+- Empty or generic placeholder descriptions such as `task` or `stuff` are rejected.
 
 Output: writes PNG to `/tmp/reward-<timestamp>.png` and prints the path.
 OpenClaw then stages attachment delivery through `~/.openclaw/media/outbound/`,
@@ -271,11 +278,11 @@ file.
 Reward prompts are built from four layers:
 
 1. **Intensity theme pool** - low/medium/high/epic still control the overall celebration scale
-2. **Task motif extraction** - task title becomes a safe visual motif (call, writing, setup, cleanup, etc.)
+2. **Task motif extraction** - validated task descriptions become safe visual motifs (call, writing, setup, cleanup, etc.)
 3. **Preference modifiers** - optional `state.json.user_preferences.rewards` values bias style, palette, and subject matter
 4. **Feedback weighting** - prior positive/negative reactions bias future theme-family, style, and palette selection
 
-Task titles are not copied blindly into the image prompt. The script first classifies the task and builds either:
+Task descriptions are not copied blindly into the image prompt. The script first validates the count against the streak, classifies the completed tasks, and builds either:
 
 - **Literal motifs** for ordinary tasks: "glowing phone and confetti" for calls, "pages turning into stars" for writing
 - **Metaphorical motifs** for sensitive tasks: therapy/medical/personal/legal/financial tasks use abstract or symbolic celebration instead of literal depictions

--- a/docs/reward-system.md
+++ b/docs/reward-system.md
@@ -252,7 +252,7 @@ flowchart TD
 ./scripts/generate-reward-image.sh <intensity> <streak_count> <task_description>...
 
 # Examples:
-./scripts/generate-reward-image.sh low 0 "Call dentist"
+./scripts/generate-reward-image.sh low 1 "Call dentist"
 ./scripts/generate-reward-image.sh medium 2 "Review proposal" "Clean desk"
 ./scripts/generate-reward-image.sh epic 5 "Draft report" "Send update" "Pay bill" "Book appointment" "Fold laundry"
 
@@ -263,10 +263,16 @@ REWARD_WORK_TYPE=focus REWARD_ENERGY_LEVEL=low \
 
 The script validates its reward inputs before generation:
 
-- `streak_count` must be a non-negative integer.
+- `streak_count` must be the positive, post-completion current streak length.
 - When `streak_count` is `N`, the caller must provide exactly `N` task descriptions.
-- For the first completion (`streak_count` `0`), the caller must provide exactly one task description.
-- Empty or generic placeholder descriptions such as `task` or `stuff` are rejected.
+- The first completion in a streak uses `streak_count` `1` and one task description.
+- Empty descriptions are rejected.
+
+Callers build the task-description list from the current completion session,
+ordered oldest to newest after the completed task has been counted. The list
+resets whenever the completion streak resets. If prior streak history is not
+available, callers must not invent descriptions or marker counts; they should
+start a fresh one-item streak list with the current completed task.
 
 Output: writes PNG to `/tmp/reward-<timestamp>.png` and prints the path.
 OpenClaw then stages attachment delivery through `~/.openclaw/media/outbound/`,
@@ -369,16 +375,15 @@ Streak count modifies generated image:
 
 | Streak | Visual Enhancement |
 |--------|--------------------|
-| 0-2 | Base theme only |
-| 3-4 | Three orbiting stars added |
-| 5+ | Trail of five glowing orbs added |
+| 1 | One small glowing progress marker |
+| N > 1 | Exactly N small glowing progress markers, one per completed task in the current streak |
 
 #### Feedback Loop
 
 Generated rewards leave two metadata trails:
 
 - `rewards/manifest.log` - stable tab-delimited recap manifest (`timestamp`, `intensity`, `task_title`, `file_path`)
-- `rewards/manifest.jsonl` - feedback metadata only (`reward_id`, `prompt_version`, `generated_at`, `timestamp`, `intensity`, `task_mode`, `task_profile`, `task_tags`, `theme_id`, `theme_family`, `theme_tags`, `style`, `palette`, `archive_file`)
+- `rewards/manifest.jsonl` - feedback metadata only (`reward_id`, `prompt_version`, `generated_at`, `timestamp`, `intensity`, `task_mode`, `task_profile`, `task_profiles`, `task_tags`, `theme_id`, `theme_family`, `theme_tags`, `style`, `palette`, `archive_file`)
 
 The companion script `scripts/log-reward-feedback.sh` records lightweight reactions:
 

--- a/scripts/generate-reward-image.sh
+++ b/scripts/generate-reward-image.sh
@@ -2,8 +2,7 @@
 # Generate a celebratory reward image using OpenAI's image generation API.
 # Usage: ./generate-reward-image.sh <intensity> <streak_count> <task_description>...
 #
-# Provide exactly N task descriptions when streak_count is N. For a first
-# completion with streak_count 0, provide exactly one task description.
+# Provide exactly N task descriptions when streak_count is N.
 #
 # Optional context:
 #   REWARD_STATE_FILE=/path/to/state.json
@@ -24,11 +23,10 @@ Usage: ./scripts/generate-reward-image.sh <intensity> <streak_count> <task_descr
 
 Intensity: low, medium, high, epic
 
-Pass exactly N task descriptions when streak_count is N. For streak_count 0,
-pass exactly one task description for the completed task.
+Pass exactly N task descriptions when streak_count is N.
 
 Examples:
-  ./scripts/generate-reward-image.sh low 0 "Call dentist"
+  ./scripts/generate-reward-image.sh low 1 "Call dentist"
   ./scripts/generate-reward-image.sh medium 2 "Review proposal" "Clean desk"
   ./scripts/generate-reward-image.sh epic 5 "Draft report" "Send update" "Pay bill" "Book appointment" "Fold laundry"
 EOF
@@ -91,14 +89,14 @@ esac
 
 case "$STREAK" in
     ''|*[!0-9]*)
-        fail_usage "streak_count must be a non-negative integer"
+        fail_usage "streak_count must be a positive integer"
         ;;
 esac
 
 shift 2
 EXPECTED_TASK_COUNT="$STREAK"
 if [ "$EXPECTED_TASK_COUNT" -eq 0 ]; then
-    EXPECTED_TASK_COUNT=1
+    fail_usage "streak_count must be a positive integer"
 fi
 
 if [ "$#" -ne "$EXPECTED_TASK_COUNT" ]; then
@@ -117,29 +115,11 @@ import json
 import re
 import sys
 
-generic_titles = {
-    "a task",
-    "task",
-    "tasks",
-    "todo",
-    "to do",
-    "work",
-    "stuff",
-    "things",
-    "errands",
-    "chores",
-    "misc",
-    "miscellaneous",
-}
-
 normalized = []
 for raw in sys.argv[1:]:
     title = re.sub(r"\s+", " ", raw).strip()
     if not title:
         print("task descriptions must be non-empty", file=sys.stderr)
-        sys.exit(2)
-    if title.lower() in generic_titles:
-        print(f"task description is too generic: {title}", file=sys.stderr)
         sys.exit(2)
     normalized.append(title)
 
@@ -989,7 +969,6 @@ record = {
     "generated_at": context["generated_at"],
     "timestamp": int(os.environ["TIMESTAMP"]),
     "intensity": context["intensity"],
-    "task_titles": context["task_titles"],
     "task_mode": context["task_mode"],
     "task_profile": context["task_profile"],
     "task_profiles": context["task_profiles"],

--- a/scripts/generate-reward-image.sh
+++ b/scripts/generate-reward-image.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Generate a celebratory reward image using OpenAI's image generation API.
-# Usage: ./generate-reward-image.sh <intensity> [task_title] [streak_count]
+# Usage: ./generate-reward-image.sh <intensity> <streak_count> <task_description>...
+#
+# Provide exactly N task descriptions when streak_count is N. For a first
+# completion with streak_count 0, provide exactly one task description.
 #
 # Optional context:
 #   REWARD_STATE_FILE=/path/to/state.json
@@ -14,6 +17,28 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$SCRIPT_DIR/.."
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: ./scripts/generate-reward-image.sh <intensity> <streak_count> <task_description>...
+
+Intensity: low, medium, high, epic
+
+Pass exactly N task descriptions when streak_count is N. For streak_count 0,
+pass exactly one task description for the completed task.
+
+Examples:
+  ./scripts/generate-reward-image.sh low 0 "Call dentist"
+  ./scripts/generate-reward-image.sh medium 2 "Review proposal" "Clean desk"
+  ./scripts/generate-reward-image.sh epic 5 "Draft report" "Send update" "Pay bill" "Book appointment" "Fold laundry"
+EOF
+}
+
+fail_usage() {
+    echo "Error: $1" >&2
+    usage
+    exit 2
+}
 
 # --- Offline fallback rewards ---
 # When image generation is unavailable (API outage, missing key, network error),
@@ -50,13 +75,34 @@ suggest_offline_reward() {
     exit 0
 }
 
-# shellcheck source=scripts/load-env.sh
-if ! source "$SCRIPT_DIR/load-env.sh" OPENAI_API_KEY?; then
-    suggest_offline_reward "env file unavailable"
+INTENSITY="${1:-}"
+STREAK="${2:-}"
+
+[ -n "$INTENSITY" ] || fail_usage "missing intensity"
+[ -n "$STREAK" ] || fail_usage "missing streak_count"
+
+case "$INTENSITY" in
+    low|medium|high|epic)
+        ;;
+    *)
+        fail_usage "unknown intensity: $INTENSITY"
+        ;;
+esac
+
+case "$STREAK" in
+    ''|*[!0-9]*)
+        fail_usage "streak_count must be a non-negative integer"
+        ;;
+esac
+
+shift 2
+EXPECTED_TASK_COUNT="$STREAK"
+if [ "$EXPECTED_TASK_COUNT" -eq 0 ]; then
+    EXPECTED_TASK_COUNT=1
 fi
 
-if [ -z "${OPENAI_API_KEY:-}" ]; then
-    suggest_offline_reward "OPENAI_API_KEY not set"
+if [ "$#" -ne "$EXPECTED_TASK_COUNT" ]; then
+    fail_usage "streak_count $STREAK requires $EXPECTED_TASK_COUNT task description(s), got $#"
 fi
 
 for cmd in python3 curl; do
@@ -65,32 +111,64 @@ for cmd in python3 curl; do
     fi
 done
 
-INTENSITY="${1:-medium}"
-TASK_TITLE_RAW="${2:-a task}"
-STREAK="${3:-0}"
+TASK_TITLES_JSON="$(
+    python3 - "$@" <<'PY'
+import json
+import re
+import sys
+
+generic_titles = {
+    "a task",
+    "task",
+    "tasks",
+    "todo",
+    "to do",
+    "work",
+    "stuff",
+    "things",
+    "errands",
+    "chores",
+    "misc",
+    "miscellaneous",
+}
+
+normalized = []
+for raw in sys.argv[1:]:
+    title = re.sub(r"\s+", " ", raw).strip()
+    if not title:
+        print("task descriptions must be non-empty", file=sys.stderr)
+        sys.exit(2)
+    if title.lower() in generic_titles:
+        print(f"task description is too generic: {title}", file=sys.stderr)
+        sys.exit(2)
+    normalized.append(title)
+
+print(json.dumps(normalized, ensure_ascii=True))
+PY
+)" || exit 2
+
 TIMESTAMP="$(date +%s)"
 DATE_STR="$(date +%Y-%m-%d)"
 TIME_STR="$(date +%H%M%S)"
 REWARD_ID="${DATE_STR}_${TIME_STR}_${INTENSITY}_$RANDOM"
 STATE_FILE="${REWARD_STATE_FILE:-$REPO_ROOT/state.json}"
+TASK_TITLE="$(TASK_TITLES_JSON="$TASK_TITLES_JSON" python3 <<'PY'
+import json
+import os
 
-case "$INTENSITY" in
-    low|medium|high|epic)
-        ;;
-    *)
-        echo "Unknown intensity: $INTENSITY" >&2
-        exit 1
-        ;;
-esac
+print("; ".join(json.loads(os.environ["TASK_TITLES_JSON"])))
+PY
+)"
 
-case "$STREAK" in
-    ''|*[!0-9]*)
-        STREAK=0
-        ;;
-esac
+# shellcheck source=scripts/load-env.sh
+# shellcheck disable=SC1091
+if ! source "$SCRIPT_DIR/load-env.sh" OPENAI_API_KEY?; then
+    suggest_offline_reward "env file unavailable"
+fi
 
-TASK_TITLE="$(printf '%s' "$TASK_TITLE_RAW" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')"
-[ -n "$TASK_TITLE" ] || TASK_TITLE="a task"
+if [ -z "${OPENAI_API_KEY:-}" ]; then
+    suggest_offline_reward "OPENAI_API_KEY not set"
+fi
 
 ARCHIVE_DIR="$REPO_ROOT/rewards"
 MANIFEST_FILE="$ARCHIVE_DIR/manifest.log"
@@ -104,6 +182,7 @@ ARCHIVE_FILE="${ARCHIVE_DIR}/${DATE_STR}_${TIME_STR}_${INTENSITY}.png"
 build_reward_context() {
     INTENSITY="$INTENSITY" \
     TASK_TITLE="$TASK_TITLE" \
+    TASK_TITLES_JSON="$TASK_TITLES_JSON" \
     STREAK="$STREAK" \
     REWARD_ID="$REWARD_ID" \
     STATE_FILE="$STATE_FILE" \
@@ -121,6 +200,7 @@ from pathlib import Path
 
 INTENSITY = os.environ["INTENSITY"]
 TASK_TITLE = " ".join(os.environ["TASK_TITLE"].split())
+TASK_TITLES = json.loads(os.environ["TASK_TITLES_JSON"])
 STREAK = int(os.environ.get("STREAK", "0") or 0)
 REWARD_ID = os.environ["REWARD_ID"]
 STATE_FILE = Path(os.environ["STATE_FILE"])
@@ -361,6 +441,7 @@ SENSITIVE_PATTERNS = [
 ]
 
 GENERIC_TITLES = {
+    "a task",
     "task",
     "tasks",
     "todo",
@@ -566,11 +647,23 @@ def find_task_profile(title: str):
     }
 
 
-def detect_sensitive_reason(title: str):
-    lowered = title.lower()
-    for pattern, reason in SENSITIVE_PATTERNS:
-        if re.search(pattern, lowered):
-            return reason
+def find_task_profiles(titles):
+    profiles = []
+    seen = set()
+    for title in titles:
+        profile = find_task_profile(title)
+        if profile["id"] not in seen:
+            profiles.append(profile)
+            seen.add(profile["id"])
+    return profiles
+
+
+def detect_sensitive_reason(titles):
+    for title in titles:
+        lowered = title.lower()
+        for pattern, reason in SENSITIVE_PATTERNS:
+            if re.search(pattern, lowered):
+                return reason
     return ""
 
 
@@ -628,26 +721,26 @@ def avoidance_penalty(option, avoid_terms, weight):
 
 
 def build_streak_detail(streak: int) -> str:
-    if streak >= 5:
-        return "Add a trail of five glowing orbs to signal a hot streak."
-    if streak >= 3:
-        return "Add three small orbiting stars to hint at momentum."
+    if streak > 0:
+        return f"Add exactly {streak} small glowing progress markers, one for each completed task in this streak."
     return ""
 
 
-def build_task_mode(task_title: str, sensitive_reason: str):
+def build_task_mode(task_titles, sensitive_reason: str):
     if sensitive_reason:
         return "metaphorical"
-    if is_vague_title(task_title):
+    if any(is_vague_title(title) for title in task_titles):
         return "abstract"
     return "literal"
 
 
-def build_task_motif(profile, task_mode: str):
+def build_task_motif(profiles, task_mode: str):
     if task_mode == "literal":
-        return profile["literal"]
+        motifs = [profile["literal"] for profile in profiles[:3]]
+        return "; ".join(motifs)
     if task_mode == "metaphorical":
-        return profile["metaphor"]
+        motifs = [profile["metaphor"] for profile in profiles[:3]]
+        return "; ".join(motifs)
     return "a clean burst of forward motion turning into a satisfying celebration"
 
 
@@ -701,10 +794,18 @@ def sensitive_palette_candidates():
 
 reward_preferences = load_reward_preferences(STATE_FILE)
 feedback = load_feedback(FEEDBACK_FILE)
-task_profile = find_task_profile(TASK_TITLE)
-sensitive_reason = detect_sensitive_reason(TASK_TITLE)
-task_mode = build_task_mode(TASK_TITLE, sensitive_reason)
-task_motif = build_task_motif(task_profile, task_mode)
+task_profiles = find_task_profiles(TASK_TITLES)
+sensitive_reason = detect_sensitive_reason(TASK_TITLES)
+task_mode = build_task_mode(TASK_TITLES, sensitive_reason)
+task_motif = build_task_motif(task_profiles, task_mode)
+task_profile_ids = [profile["id"] for profile in task_profiles]
+task_tags = []
+for profile in task_profiles:
+    task_tags.extend(profile["tags"])
+if WORK_TYPE:
+    task_tags.append(WORK_TYPE)
+if ENERGY_LEVEL:
+    task_tags.append(ENERGY_LEVEL)
 
 theme_options = THEMES[INTENSITY]
 style_options = STYLE_OPTIONS
@@ -734,7 +835,7 @@ if sensitive_reason:
 prompt_parts = [
     "Create a square celebratory reward image for a completed task.",
     f"Core scene: {theme['scene']}.",
-    f"Blend in task relevance with {task_motif}.",
+    f"Blend in motifs from the validated completed tasks: {task_motif}.",
 ]
 
 if sensitive_reason:
@@ -767,11 +868,13 @@ context = {
     "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
     "intensity": INTENSITY,
     "task_title": TASK_TITLE,
+    "task_titles": TASK_TITLES,
     "streak": STREAK,
     "task_mode": task_mode,
-    "task_profile": task_profile["id"],
+    "task_profile": ",".join(task_profile_ids),
+    "task_profiles": task_profile_ids,
     "task_motif": task_motif,
-    "task_tags": list(dict.fromkeys(task_profile["tags"] + ([WORK_TYPE] if WORK_TYPE else []) + ([ENERGY_LEVEL] if ENERGY_LEVEL else []))),
+    "task_tags": list(dict.fromkeys(task_tags)),
     "sensitive_reason": sensitive_reason or None,
     "theme_id": theme["id"],
     "theme_family": theme["family"],
@@ -886,8 +989,10 @@ record = {
     "generated_at": context["generated_at"],
     "timestamp": int(os.environ["TIMESTAMP"]),
     "intensity": context["intensity"],
+    "task_titles": context["task_titles"],
     "task_mode": context["task_mode"],
     "task_profile": context["task_profile"],
+    "task_profiles": context["task_profiles"],
     "task_tags": context["task_tags"],
     "theme_id": context["theme_id"],
     "theme_family": context["theme_family"],


### PR DESCRIPTION
Resolves #541

## Summary
Require reward image callers to pass a positive post-completion streak count plus exactly one task description per streak completion. The image prompt now blends motifs from all validated task descriptions and uses an exact streak marker count.

## Test Plan
- shellcheck scripts/*.sh
- yamllint .github/workflows/*.yml
- ./scripts/check-doc-links.sh
- ./scripts/generate-reward-image.sh medium 2 "Review proposal" exits 2
- ./scripts/generate-reward-image.sh medium 1 "" exits 2
- ./scripts/generate-reward-image.sh low 1 "Call dentist" reaches reward fallback/image path

Generated with Codex

Author-Session: codex/25299978916