### PR TITLE
Guard disabled OpenClaw web tool defaults

### DIFF
--- a/scripts/validate-openclaw-config.sh
+++ b/scripts/validate-openclaw-config.sh
@@ -58,6 +58,12 @@ if grep -q '{{[A-Z0-9_]\+}}' "$config_path"; then
   exit 1
 fi
 
+echo "=== Checking default web tools are disabled ==="
+jq -e '
+  .tools.web.search.enabled == false
+  and .tools.web.fetch.enabled == false
+' "$config_path" >/dev/null
+
 export OPENCLAW_CONFIG_PATH="$config_path"
 export OPENCLAW_STATE_DIR="$state_dir"
 

--- a/setup/README.md
+++ b/setup/README.md
@@ -74,6 +74,13 @@
    `agents.defaults.envelopeTimezone` is a required first-setup field. Set it to
    the same IANA timezone identifier from `USER.md`.
 
+   The template disables OpenClaw web search and fetch tools by default:
+   `tools.web.search.enabled: false` and `tools.web.fetch.enabled: false`.
+   Leave them disabled for routine installs to keep every agent turn's system
+   prompt small, especially for local models and cron sessions. Instances that
+   truly need web access can opt in by setting either flag to `true` in the live
+   `~/.openclaw/openclaw.json`.
+
    Example:
    ```json
    {


### PR DESCRIPTION
Resolves #545

## Summary
- Add an OpenClaw config smoke assertion that rendered defaults keep web search and fetch disabled.
- Document that web search/fetch are opt-in in the setup guide to keep routine agent turns and cron wakes smaller.

## Test Plan
- shellcheck scripts/*.sh
- yamllint .github/workflows/*.yml
- bash scripts/check-doc-links.sh
- jq -e .tools.web.search.enabled == false and .tools.web.fetch.enabled == false setup/openclaw.json.template >/dev/null
- bash -n scripts/validate-openclaw-config.sh
- git push pre-push hook suite (script/doc/workflow validation; OpenClaw smoke skipped because openclaw binary is not installed locally)

Generated with Codex

Author-Session: codex/25356903191