### PR TITLE
Align OpenClaw config prompt baseline

### DIFF
--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -46,6 +46,31 @@ Canonical setup path:
 - Copy that same TZ identifier into `setup/openclaw.json.template` when creating
   `~/.openclaw/openclaw.json`
 
+## Canonical Config Baseline
+
+`setup/openclaw.json.template` is the standard prompt-footprint baseline for
+hide-my-list instances. New deployments should start from that template and
+replace only placeholder values such as LiteLLM URL, timezone, Signal account,
+gateway auth token, and control UI origin.
+
+Baseline config intentionally excludes optional OpenClaw features that add tools
+or prompt metadata:
+
+- root-level `auth.profiles`, including `openai:default`
+- `channels.signal.defaultTo`
+- `agents.defaults.model.fallbacks`
+- `agents.defaults.maxConcurrent` and `agents.defaults.subagents`
+- `messages.*`
+- `commands.*`
+- `skills.install.*`
+- web search/fetch tools, which stay disabled by default
+
+Instances that need one of those features can opt in by editing their live
+`~/.openclaw/openclaw.json`, but that is an explicit local divergence from the
+standard footprint. Reward image generation is script-driven through
+`OPENAI_API_KEY` in `.env`; it does not require OpenClaw's `image_generate` tool
+or an `openai:default` auth profile.
+
 ## Heartbeat
 
 Production heartbeat = durable cron job `heartbeat` defined in `setup/cron/heartbeat.md`. The built-in OpenClaw heartbeat block remains in `openclaw.json` only to keep the disabled setting explicit:
@@ -180,6 +205,7 @@ OpenClaw supports multiple model providers. We route through LiteLLM proxy on Ta
 Canonical model list lives in `setup/openclaw.json.template`; repo-only tier mappings live in `setup/model-tiers.json` so the generated `openclaw.json` stays valid against OpenClaw's schema. `scripts/validate-model-refs.sh` enforces that every `litellm/<id>` reference in classifier-listed spec files resolves against the template model list, that tier mappings are consistent with agent config where tiers still apply, that `agents.defaults.heartbeat.model` points at a configured model, and that cheap-tier cron specs plus sibling docs stay aligned with the cheap tier contract.
 
 - **Primary model (expensive tier):** Whatever `setup/model-tiers.json` maps `expensive` to for conversations and task management
+- **Medium model:** Present in the template model list for explicit live-config fallback opt-in, but not wired into `agents.defaults.model.fallbacks` in the canonical baseline
 - **Built-in heartbeat model:** disabled with `every: "0s"`; retained only as a configured fallback for stale live configs
 - **Routine recurring cron model (cheap tier):** Whatever `setup/model-tiers.json` maps `cheap` to for isolated recurring cron work (`heartbeat`, reminder polling, workspace sync)
 - **Janitor model:** `litellm/claude-opus-4-6`, configured directly and decoupled from the cheap tier for the weekly deep audit

--- a/scripts/validate-model-refs.sh
+++ b/scripts/validate-model-refs.sh
@@ -6,9 +6,9 @@
 #      file registered by review-classify's is_spec_md() must resolve in
 #      setup/openclaw.json.template's models array.
 #   2) Tier-config consistency: setup/model-tiers.json must match
-#      agents.defaults where tiers still apply (expensive=primary,
-#      medium=fallback), and the disabled built-in heartbeat block must remain
-#      internally valid.
+#      agents.defaults where tiers still apply (expensive=primary), optional
+#      prompt-surface knobs must stay out of the baseline template, and the
+#      disabled built-in heartbeat block must remain internally valid.
 #   3) Cron-tier agreement: routine cron spec files must use the cheap-tier
 #      model from setup/model-tiers.json, janitor must stay on a configured
 #      decoupled model, and sibling docs' cron-contract sections must point
@@ -121,6 +121,7 @@ done
 # --- Invariant 2: tier-config consistency --------------------------------
 
 tier_errors=()
+baseline_errors=()
 
 # Check that each tier model exists in the models array
 for tier_name in expensive medium cheap; do
@@ -136,13 +137,24 @@ if [[ "$primary_model" != "litellm/$tier_expensive" ]]; then
   tier_errors+=("agents.defaults.model.primary = $primary_model, expected litellm/$tier_expensive (expensive tier)")
 fi
 
-# Check agents.defaults.model.fallbacks[0] matches medium tier
-fallback_model="$(grep -A2 '"fallbacks"' "$TEMPLATE" | grep -oE 'litellm/[A-Za-z0-9._-]+' | head -1)"
-if [[ -z "$fallback_model" ]]; then
-  tier_errors+=("agents.defaults.model.fallbacks not found in $TEMPLATE")
-elif [[ "$fallback_model" != "litellm/$tier_medium" ]]; then
-  tier_errors+=("agents.defaults.model.fallbacks[0] = $fallback_model, expected litellm/$tier_medium (medium tier)")
-fi
+reject_template_path() {
+  local jq_expr="$1"
+  local label="$2"
+
+  if jq -e "$jq_expr" "$TEMPLATE" >/dev/null; then
+    baseline_errors+=("$label must not be present in the canonical prompt-footprint baseline")
+  fi
+}
+
+# Check prompt-footprint baseline excludes optional tool/prompt-surface knobs.
+reject_template_path 'has("auth")' 'root auth profiles'
+reject_template_path '((.agents.defaults.model // {}) | has("fallbacks"))' 'agents.defaults.model.fallbacks'
+reject_template_path '((.agents.defaults // {}) | has("maxConcurrent"))' 'agents.defaults.maxConcurrent'
+reject_template_path '((.agents.defaults // {}) | has("subagents"))' 'agents.defaults.subagents'
+reject_template_path 'has("messages")' 'messages overrides'
+reject_template_path 'has("commands")' 'commands overrides'
+reject_template_path '((.skills // {}) | has("install"))' 'skills.install'
+reject_template_path '((.channels.signal // {}) | has("defaultTo"))' 'channels.signal.defaultTo'
 
 # Extract the heartbeat block so heartbeat-specific checks cannot be satisfied
 # by another `model` or `lightContext` key elsewhere in the template.
@@ -324,6 +336,10 @@ if (( ${#tier_errors[@]} > 0 )); then
   all_errors+=("Tier-config consistency errors:")
   for t in "${tier_errors[@]}"; do all_errors+=("  - $t"); done
 fi
+if (( ${#baseline_errors[@]} > 0 )); then
+  all_errors+=("Prompt-footprint baseline errors:")
+  for b in "${baseline_errors[@]}"; do all_errors+=("  - $b"); done
+fi
 if (( ${#cron_errors[@]} > 0 )); then
   all_errors+=("Cron-tier agreement errors:")
   for c in "${cron_errors[@]}"; do all_errors+=("  - $c"); done
@@ -333,8 +349,8 @@ if (( ${#all_errors[@]} > 0 )); then
   echo "ERROR: model reference validation failed:" >&2
   for e in "${all_errors[@]}"; do echo "$e" >&2; done
   echo "" >&2
-  echo "Fix: update $TIER_MAP, ensure routine cheap-tier cron specs/docs match, keep janitor on a configured decoupled model, and keep built-in heartbeat disabled." >&2
+  echo "Fix: update $TIER_MAP, ensure routine cheap-tier cron specs/docs match, keep janitor on a configured decoupled model, keep built-in heartbeat disabled, and keep optional prompt-surface knobs out of the template baseline." >&2
   exit 1
 fi
 
-echo "Model references consistent: template membership OK; tier-config OK (expensive=$tier_expensive, medium=$tier_medium, cheap=$tier_cheap, built-in heartbeat every=$heartbeat_every); routine cheap-tier cron specs use $expected_cron_ref; decoupled cron specs reference configured models"
+echo "Model references consistent: template membership OK; tier-config OK (expensive=$tier_expensive, medium=$tier_medium, cheap=$tier_cheap, built-in heartbeat every=$heartbeat_every); prompt-footprint baseline OK; routine cheap-tier cron specs use $expected_cron_ref; decoupled cron specs reference configured models"

--- a/scripts/validate-openclaw-config.sh
+++ b/scripts/validate-openclaw-config.sh
@@ -64,6 +64,18 @@ jq -e '
   and .tools.web.fetch.enabled == false
 ' "$config_path" >/dev/null
 
+echo "=== Checking prompt-footprint baseline excludes optional extras ==="
+jq -e '
+  (has("auth") | not)
+  and ((.agents.defaults.model // {}) | has("fallbacks") | not)
+  and ((.agents.defaults // {}) | has("maxConcurrent") | not)
+  and ((.agents.defaults // {}) | has("subagents") | not)
+  and (has("messages") | not)
+  and (has("commands") | not)
+  and ((.skills // {}) | has("install") | not)
+  and ((.channels.signal // {}) | has("defaultTo") | not)
+' "$config_path" >/dev/null
+
 export OPENCLAW_CONFIG_PATH="$config_path"
 export OPENCLAW_STATE_DIR="$state_dir"
 

--- a/setup/README.md
+++ b/setup/README.md
@@ -81,6 +81,17 @@
    truly need web access can opt in by setting either flag to `true` in the live
    `~/.openclaw/openclaw.json`.
 
+   The template is also the canonical prompt-footprint baseline for
+   hide-my-list instances. Keep optional prompt/tool-surface features out of the
+   baseline unless an instance deliberately opts in in its live config:
+   root-level `auth.profiles` such as `openai:default`, `channels.signal.defaultTo`,
+   `agents.defaults.model.fallbacks`, `agents.defaults.maxConcurrent`,
+   `agents.defaults.subagents`, `messages.*`, `commands.*`, and
+   `skills.install.*`. This keeps new deployments at the same system prompt size
+   instead of silently exposing extra tools or prompt metadata. Reward image
+   generation uses `OPENAI_API_KEY` from `.env`; it does not require an OpenClaw
+   `openai:default` auth profile.
+
    Example:
    ```json
    {
@@ -153,7 +164,7 @@ Model assignments use a tier system defined in `setup/model-tiers.json`. That fi
 | Tier | Role | Default |
 |------|------|---------|
 | `expensive` | Primary interactive agent | `claude-opus-4-6` |
-| `medium` | Fallback | `claude-sonnet-4-6` |
+| `medium` | Available model for explicit fallback opt-in | `claude-sonnet-4-6` |
 | `cheap` | Isolated routine recurring cron jobs (`heartbeat`, `reminder-check`, `reminder-delivery-sweep`, `pull-main`) | `qwen2.5` |
 | Decoupled direct model | One-shot reminder delivery; multi-step user-facing state mutation | `claude-haiku-4-5` |
 | Decoupled janitor model | Weekly deep audit | `claude-opus-4-6` |
@@ -164,7 +175,7 @@ To remap tiers to your available models:
 
 1. Add your models to the `models[]` array in `setup/openclaw.json.template`
 2. Edit `setup/model-tiers.json` values to point at your model IDs
-3. Update `agents.defaults` in `setup/openclaw.json.template` to match: `model.primary` = `litellm/<expensive>`, `model.fallbacks` = `[litellm/<medium>]`, and keep the built-in `heartbeat.every` disabled (`"0s"`)
+3. Update `agents.defaults` in `setup/openclaw.json.template` to match: `model.primary` = `litellm/<expensive>`, and keep the built-in `heartbeat.every` disabled (`"0s"`). Do not add `model.fallbacks` to the template baseline; live instances can opt in explicitly if they accept the extra prompt metadata.
 4. Update `model:` lines in `setup/cron/heartbeat.md`, `setup/cron/reminder-check.md`, `setup/cron/reminder-delivery-sweep.md`, and `setup/cron/pull-main.md` to `litellm/<cheap>`. Leave `setup/cron/janitor.md` on its explicit Opus model unless you are intentionally changing the weekly deep-audit model.
 5. Run `bash scripts/validate-model-refs.sh` — catches drift between tiers, agent config, cron specs, and documented defaults
 

--- a/setup/openclaw.json.template
+++ b/setup/openclaw.json.template
@@ -3,18 +3,6 @@
     "lastTouchedVersion": "{{OPENCLAW_VERSION}}",
     "lastTouchedAt": "{{SETUP_DATE}}"
   },
-  "auth": {
-    "profiles": {
-      "anthropic:default": {
-        "provider": "anthropic",
-        "mode": "token"
-      },
-      "openai:default": {
-        "provider": "openai",
-        "mode": "api_key"
-      }
-    }
-  },
   "models": {
     "providers": {
       "litellm": {
@@ -69,10 +57,7 @@
   "agents": {
     "defaults": {
       "model": {
-        "primary": "litellm/claude-opus-4-6",
-        "fallbacks": [
-          "litellm/claude-sonnet-4-6"
-        ]
+        "primary": "litellm/claude-opus-4-6"
       },
       "workspace": "{{OPENCLAW_HOME}}/workspace",
       "envelopeTimezone": "{{TZ_IDENTIFIER}}",
@@ -83,10 +68,6 @@
         "every": "0s",
         "model": "litellm/claude-haiku-4-5",
         "lightContext": true
-      },
-      "maxConcurrent": 4,
-      "subagents": {
-        "maxConcurrent": 8
       }
     }
   },
@@ -99,15 +80,6 @@
         "enabled": false
       }
     }
-  },
-  "messages": {
-    "ackReactionScope": "group-mentions"
-  },
-  "commands": {
-    "native": "auto",
-    "nativeSkills": "auto",
-    "restart": true,
-    "ownerDisplay": "raw"
   },
   "session": {
     "dmScope": "per-channel-peer"
@@ -146,11 +118,6 @@
         "reminders.add",
         "sms.send"
       ]
-    }
-  },
-  "skills": {
-    "install": {
-      "nodeManager": "npm"
     }
   },
   "plugins": {


### PR DESCRIPTION
Resolves #548

## Summary
- Removed optional prompt/tool-surface knobs from the canonical OpenClaw config template so new hide-my-list instances start with a minimal consistent footprint.
- Documented the standard baseline and explicit opt-in path for local extras like OpenAI auth, command/native-skill controls, model fallbacks, and Signal default targets.
- Extended config/model validation to reject reintroducing drift-prone optional keys into the template baseline.

## Test Plan
- shellcheck scripts/*.sh
- yamllint .github/workflows/*.yml
- bash scripts/validate-model-refs.sh
- bash scripts/check-doc-links.sh
- pre-push hook suite during git push (OpenClaw smoke skipped because openclaw is not installed in this container)

Generated with Codex

Author-Session: codex/25357627281