### PR TITLE
chore: update AI CLI pins

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -38,8 +38,8 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
     && rm -rf /var/lib/apt/lists/*
 
 # Pin AI CLI versions so Dockerfile, post-create script, and updater workflow stay in sync
-ARG CLAUDE_CODE_VERSION=2.1.126
-ARG CODEX_CLI_VERSION=0.128.0
+ARG CLAUDE_CODE_VERSION=2.1.150
+ARG CODEX_CLI_VERSION=0.133.0
 
 # Install Node.js LTS (needed for Claude Code plugins and Mermaid validation)
 ARG NODE_VERSION=20

--- a/.github/ci/versions.env
+++ b/.github/ci/versions.env
@@ -3,8 +3,8 @@
 # Keep in sync with `.devcontainer/Dockerfile` via its own ARG lines
 # (or remove the devcontainer dependency on pins once it stops pulling
 # from GHCR for local-dev speedups).
-CLAUDE_CODE_VERSION=2.1.126
-CODEX_CLI_VERSION=0.128.0
+CLAUDE_CODE_VERSION=2.1.150
+CODEX_CLI_VERSION=0.133.0
 OPENCLAW_VERSION=2026.5.2
 ACTIONLINT_VERSION=1.7.7
 NODE_MAJOR=20


### PR DESCRIPTION
Automated weekly update of the pinned AI CLI versions.

Updated in `.github/ci/versions.env` as the CI pin source and
mirrored into `.devcontainer/Dockerfile`'s ARG defaults for
the devcontainer image build.

- **Claude Code:** 2.1.126 → 2.1.150
- **Codex:** 0.128.0 → 0.133.0

🤖 Generated automatically by the `update-ai-clis` workflow.