### PR TITLE
auth: gate Signal ingress behind AUTHORIZED_PEERS allowlist

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -5,6 +5,8 @@ NOTION_DATABASE_ID=
 # Signal
 # E.164 phone number registered with signal-cli (required when ENABLE_LANGGRAPH_PATH=true)
 SIGNAL_ACCOUNT=
+# Comma-separated E.164 numbers allowed to send messages (required; empty or unset refuses startup)
+AUTHORIZED_PEERS=
 
 # Anthropic (primary LLM — required)
 ANTHROPIC_API_KEY=

--- a/app/ingress/signal_listener.py
+++ b/app/ingress/signal_listener.py
@@ -109,14 +109,7 @@ class SignalListener:
             peer, text = result
 
             if peer not in self._authorized_peers:
-                # Silent drop. Logging the peer prefix only — the full number
-                # would itself be useful intel for an attacker enumerating
-                # numbers via timing. No response means an attacker cannot
-                # confirm the bot is live by sending a message.
-                log.warning(
-                    "signal_listener.unauthorized_peer_dropped",
-                    peer_prefix=peer[:4] + "***",
-                )
+                log.warning("signal_listener.unauthorized_peer_dropped")
                 continue
 
             log.info("signal_listener.message_received", peer=peer[:4] + "***")

--- a/app/ingress/signal_listener.py
+++ b/app/ingress/signal_listener.py
@@ -3,10 +3,17 @@
 Consumes the signal-cli-rest-api WebSocket stream and routes each
 (peer, text) pair through the LangGraph pipeline.
 
+Authorization: AUTHORIZED_PEERS is a comma-separated env var of allowed
+E.164 numbers. Messages from any other peer are silently dropped — no
+reply is sent so the channel reveals no signal-cli liveness to an
+attacker who happened to discover the bot's number. An empty or unset
+AUTHORIZED_PEERS refuses startup; the fail-safe default is closed.
+
 This module is one of three authorised sites for httpx.AsyncClient usage.
 """
 from __future__ import annotations
 
+import os
 from typing import Any
 
 import structlog
@@ -14,6 +21,25 @@ import structlog
 from app.tools.signal_client import receive_messages
 
 log = structlog.get_logger(__name__)
+
+
+def _load_authorized_peers() -> frozenset[str]:
+    """Read AUTHORIZED_PEERS env var; return the frozenset of E.164 strings.
+
+    Raises RuntimeError if the env var is missing or yields no usable peers
+    after parsing — open ingress against single-tenant Notion data is not a
+    default we'll ship.
+    """
+    raw = os.environ.get("AUTHORIZED_PEERS", "")
+    peers = frozenset(p.strip() for p in raw.split(",") if p.strip())
+    if not peers:
+        raise RuntimeError(
+            "AUTHORIZED_PEERS is empty or unset. Refusing to start: any peer "
+            "that knows the signal-cli account number could otherwise read "
+            "tasks from the single-tenant Notion database. Set "
+            "AUTHORIZED_PEERS to a comma-separated list of E.164 numbers."
+        )
+    return peers
 
 
 def _extract_peer_and_text(envelope: dict[str, Any]) -> tuple[str, str] | None:
@@ -45,10 +71,17 @@ class SignalListener:
         base_url: str | None = None,
         account: str | None = None,
         graph: Any = None,
+        authorized_peers: frozenset[str] | None = None,
     ) -> None:
         self._base_url = base_url
         self._account = account
         self._graph = graph  # injected in tests; built lazily in production
+        # Eagerly load on construction so a misconfiguration fails fast at
+        # startup instead of at the first inbound message.
+        self._authorized_peers = (
+            authorized_peers if authorized_peers is not None
+            else _load_authorized_peers()
+        )
 
     def _get_graph(self) -> Any:
         if self._graph is not None:
@@ -60,7 +93,10 @@ class SignalListener:
     async def run(self) -> None:
         """Main loop: consume WebSocket, route each message to the graph."""
         graph = self._get_graph()
-        log.info("signal_listener.started")
+        log.info(
+            "signal_listener.started",
+            authorized_peer_count=len(self._authorized_peers),
+        )
 
         async for envelope in receive_messages(
             base_url=self._base_url,
@@ -71,6 +107,18 @@ class SignalListener:
                 continue
 
             peer, text = result
+
+            if peer not in self._authorized_peers:
+                # Silent drop. Logging the peer prefix only — the full number
+                # would itself be useful intel for an attacker enumerating
+                # numbers via timing. No response means an attacker cannot
+                # confirm the bot is live by sending a message.
+                log.warning(
+                    "signal_listener.unauthorized_peer_dropped",
+                    peer_prefix=peer[:4] + "***",
+                )
+                continue
+
             log.info("signal_listener.message_received", peer=peer[:4] + "***")
 
             try:

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -29,6 +29,10 @@ services:
       # SIGNAL_ACCOUNT: E.164 phone number registered with signal-cli (required when
       # ENABLE_LANGGRAPH_PATH=true; set in the operator's .env file).
       - SIGNAL_ACCOUNT=${SIGNAL_ACCOUNT:-}
+      # AUTHORIZED_PEERS: comma-separated E.164 numbers permitted to message the
+      # bot. Notion is single-tenant; any inbound peer can read all tasks unless
+      # gated here. Empty/unset = refuse to start (fail-safe closed default).
+      - AUTHORIZED_PEERS=${AUTHORIZED_PEERS:-}
       - ENABLE_LANGGRAPH_PATH=${ENABLE_LANGGRAPH_PATH:-true}
       # LangSmith guard: requires explicit opt-in with ALLOW_PRIVATE_TRACE_EXPORT=true
       - LANGSMITH_TRACING=${LANGSMITH_TRACING:-false}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -143,6 +143,7 @@ model IDs. No LiteLLM proxy — LangChain provider adapters directly.
 | `DATABASE_URL` | Postgres connection string |
 | `SIGNAL_CLI_URL` | signal-cli REST API base URL |
 | `SIGNAL_ACCOUNT` | E.164 Signal account number |
+| `AUTHORIZED_PEERS` | Comma-separated E.164 allowed inbound peers; empty or unset refuses startup |
 | `USER_TZ` | User's IANA timezone (default `America/Chicago`) |
 | `ENABLE_LANGGRAPH_PATH` | Activates the Python path (default `true` post-cutover) |
 

--- a/docs/python-rewrite/rollback.md
+++ b/docs/python-rewrite/rollback.md
@@ -124,6 +124,15 @@ into Postgres.
 
 ### 2.3 Start the Python stack
 
+Before starting, ensure `AUTHORIZED_PEERS` is set in `.env`:
+
+```bash
+# In .env — set to the E.164 number(s) allowed to send inbound messages
+AUTHORIZED_PEERS=<E.164_peer>
+```
+
+The app refuses to start if `AUTHORIZED_PEERS` is empty or unset.
+
 ```bash
 cd <repo_root>
 docker compose -f docker/compose.yaml up -d
@@ -154,9 +163,11 @@ stack's behavior.
 Run after `docker compose up -d` in Section 2.3. Operator executes manually.
 Not a CI step.
 
-1. **Signal round-trip:** Send "I have 30 minutes" via Signal. Expect a
-   GET_TASK task suggestion within 5 seconds. Check `docker compose logs -f app`
-   for the graph invocation.
+1. **Signal round-trip:** Send "I have 30 minutes" via Signal **from the peer
+   listed in `AUTHORIZED_PEERS`**. Expect a GET_TASK task suggestion within
+   5 seconds. Check `docker compose logs -f app` for the graph invocation.
+   Messages from peers not in `AUTHORIZED_PEERS` are silently dropped (no
+   reply); check logs for `signal_listener.unauthorized_peer_dropped`.
 
 2. **Reminder outbox:** Send "remind me to test in 2 minutes". Query
    `reminder_outbox` for a `pending` row:

--- a/setup/README.md
+++ b/setup/README.md
@@ -51,6 +51,7 @@ signal-cli volume management or registration carry-over. The `signal-cli` servic
 | `NOTION_API_KEY` | Yes | Notion integration API key |
 | `NOTION_DATABASE_ID` | Yes | ID of the tasks database |
 | `SIGNAL_ACCOUNT` | Yes | E.164 phone number registered with signal-cli |
+| `AUTHORIZED_PEERS` | Yes | Comma-separated E.164 numbers allowed to send inbound messages; empty or unset refuses startup |
 | `ANTHROPIC_API_KEY` | Yes | Primary LLM (Claude via langchain-anthropic) |
 | `DATABASE_URL` | Compose-managed | Postgres DSN; hardcoded in `docker/compose.yaml` for the compose network. Override only for non-compose runs. |
 | `SIGNAL_CLI_URL` | Compose-managed | WebSocket URL of the signal-cli bridge; hardcoded in `docker/compose.yaml`. Override only for non-compose runs. |

--- a/tests/unit/test_signal_listener_auth.py
+++ b/tests/unit/test_signal_listener_auth.py
@@ -1,0 +1,138 @@
+"""Tests for the AUTHORIZED_PEERS allowlist in app.ingress.signal_listener.
+
+Notion is single-tenant; the listener must drop messages from any peer
+not in AUTHORIZED_PEERS before the graph is invoked. The listener must
+refuse to start when AUTHORIZED_PEERS is unset or empty (fail-safe
+closed default).
+"""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+def _envelope(source: str, message: str) -> dict[str, Any]:
+    """Build a minimal signal-cli envelope for tests."""
+    return {
+        "envelope": {
+            "source": source,
+            "dataMessage": {"message": message},
+        }
+    }
+
+
+async def _async_gen(envelopes: list[dict[str, Any]]):
+    for env in envelopes:
+        yield env
+
+
+def test_load_authorized_peers_empty_refuses(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty/unset AUTHORIZED_PEERS must raise — open ingress is not a default."""
+    monkeypatch.delenv("AUTHORIZED_PEERS", raising=False)
+    from app.ingress.signal_listener import _load_authorized_peers
+
+    with pytest.raises(RuntimeError, match="AUTHORIZED_PEERS is empty"):
+        _load_authorized_peers()
+
+
+def test_load_authorized_peers_whitespace_only_refuses(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A blank-string AUTHORIZED_PEERS must also refuse."""
+    monkeypatch.setenv("AUTHORIZED_PEERS", "  , , ")
+    from app.ingress.signal_listener import _load_authorized_peers
+
+    with pytest.raises(RuntimeError, match="AUTHORIZED_PEERS is empty"):
+        _load_authorized_peers()
+
+
+def test_load_authorized_peers_parses_comma_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Comma-separated list parses into a frozenset with whitespace trimmed."""
+    monkeypatch.setenv("AUTHORIZED_PEERS", " +15551234567 , +15559876543 ")
+    from app.ingress.signal_listener import _load_authorized_peers
+
+    peers = _load_authorized_peers()
+    assert peers == frozenset({"+15551234567", "+15559876543"})
+
+
+def test_listener_construct_fails_without_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Listener construction reads env on init — fail-fast at startup."""
+    monkeypatch.delenv("AUTHORIZED_PEERS", raising=False)
+    from app.ingress.signal_listener import SignalListener
+
+    with pytest.raises(RuntimeError, match="AUTHORIZED_PEERS is empty"):
+        SignalListener(graph=object())
+
+
+@pytest.mark.asyncio
+async def test_authorized_peer_invokes_graph() -> None:
+    """A peer in AUTHORIZED_PEERS reaches the graph."""
+    from app.ingress.signal_listener import SignalListener
+
+    graph = AsyncMock()
+    listener = SignalListener(
+        graph=graph,
+        authorized_peers=frozenset({"+15551234567"}),
+    )
+
+    envelopes = [_envelope("+15551234567", "hello")]
+    with patch(
+        "app.ingress.signal_listener.receive_messages",
+        return_value=_async_gen(envelopes),
+    ):
+        await listener.run()
+
+    graph.ainvoke.assert_awaited_once()
+    args, kwargs = graph.ainvoke.await_args
+    assert args[0]["peer"] == "+15551234567"
+    assert args[0]["incoming"] == "hello"
+    assert kwargs["config"]["configurable"]["thread_id"] == "+15551234567"
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_peer_silently_dropped() -> None:
+    """A peer NOT in AUTHORIZED_PEERS is dropped before the graph is invoked."""
+    from app.ingress.signal_listener import SignalListener
+
+    graph = AsyncMock()
+    listener = SignalListener(
+        graph=graph,
+        authorized_peers=frozenset({"+15551234567"}),
+    )
+
+    envelopes = [_envelope("+19990001111", "hello from attacker")]
+    with patch(
+        "app.ingress.signal_listener.receive_messages",
+        return_value=_async_gen(envelopes),
+    ):
+        await listener.run()
+
+    # Graph never reached — the silent drop must happen before invocation.
+    graph.ainvoke.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_mixed_stream_only_authorized_reaches_graph() -> None:
+    """Among interleaved peers, only the authorized one reaches the graph."""
+    from app.ingress.signal_listener import SignalListener
+
+    graph = AsyncMock()
+    listener = SignalListener(
+        graph=graph,
+        authorized_peers=frozenset({"+15551234567"}),
+    )
+
+    envelopes = [
+        _envelope("+19990001111", "attacker probing"),
+        _envelope("+15551234567", "legit message"),
+        _envelope("+19990002222", "another attacker"),
+    ]
+    with patch(
+        "app.ingress.signal_listener.receive_messages",
+        return_value=_async_gen(envelopes),
+    ):
+        await listener.run()
+
+    assert graph.ainvoke.await_count == 1
+    args, _ = graph.ainvoke.await_args
+    assert args[0]["peer"] == "+15551234567"


### PR DESCRIPTION
## Summary

- Closes the security gap from Phase D: any peer who learned the bot's Signal number could send "I have 30 min" and receive a real task from the owner's single-tenant Notion DB.
- Adds `AUTHORIZED_PEERS` env var (comma-separated E.164). Listener checks each inbound peer before invoking the graph; non-allowed peers are silently dropped (no reply, so the attacker gets no liveness signal).
- Empty / whitespace-only `AUTHORIZED_PEERS` refuses to start — fail-safe closed default.

## Files

- `app/ingress/signal_listener.py` — `_load_authorized_peers()` + allowlist check in `SignalListener.run()`
- `docker/compose.yaml` — passes `AUTHORIZED_PEERS` env through with documented empty default
- `tests/unit/test_signal_listener_auth.py` — 7 wire-level tests

## Operator action after merge

Set in `.env`:
```
AUTHORIZED_PEERS=+15551234567
```
(your registered Signal phone number; comma-separate for multiple). Without this set, the app refuses to start.

## Test plan

- [x] 92 unit tests pass; ruff + mypy clean
- [ ] After merge: smoke-test from disallowed phone — expect `signal_listener.unauthorized_peer_dropped` in logs, no reply
- [ ] After merge: smoke-test from authorized phone — expect `signal_listener.message_received` + normal graph processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)