### PR TITLE
feat: deliver generated reward images via Signal attachments

### DIFF
--- a/DEV-AGENTS.md
+++ b/DEV-AGENTS.md
@@ -69,6 +69,7 @@ The Python/LangGraph application. Safe to edit via PRs.
 - `migrations/0002_reward_manifests.sql` — Reward manifests table
 - `migrations/0003_ops_alerts.sql` — Ops alerts table
 - `migrations/0004_user_prefs.sql` — User preferences table
+- `migrations/0005_reward_feedback_columns.sql` — Adds `feedback_emoji` and `feedback_at` columns to `reward_manifests`
 - `tests/unit/` — Unit tests (no DATABASE_URL required)
 - `tests/integration/` — Integration tests (require DATABASE_URL)
 - `tests/spike/` — Durability spike tests

--- a/app/graph/nodes/complete.py
+++ b/app/graph/nodes/complete.py
@@ -44,12 +44,12 @@ async def complete_node(state: State) -> dict[str, Any]:
         active_task = state.get("active_task")
         if not active_task:
             # No active task — may be a reminder completion via recent_outbound
-            draft = {
+            no_task_draft: OutboundDraft = {
                 "recipient": peer,
                 "body": "Done! Nice work. Want another task?",
                 "notion_page_id": None,
             }
-            return {"pending_outbound": [draft], "conversation_state": "idle"}
+            return {"pending_outbound": [no_task_draft], "conversation_state": "idle"}
 
         page_id = active_task.get("page_id", "")
         task_title = active_task.get("title", "task")
@@ -62,8 +62,8 @@ async def complete_node(state: State) -> dict[str, Any]:
         streak = state.get("streak", 0) + 1
         tasks_today = state.get("tasks_completed_today", 0) + 1
 
-        # Get reward message (PR-B5 implements full reward; basic celebration for now)
-        reward_body = await maybe_reward(
+        # Get reward result — text celebration + optional image path
+        reward_result = await maybe_reward(
             peer=peer,
             task_title=task_title,
             notion_page_id=page_id,
@@ -72,15 +72,19 @@ async def complete_node(state: State) -> dict[str, Any]:
             energy_required=active_task.get("energy_required", ""),
         )
 
-        draft = {
+        reward_draft: OutboundDraft = {
             "recipient": peer,
-            "body": reward_body,
+            "body": reward_result["text"],
             "notion_page_id": page_id,
         }
+        # Attach image if one was generated.
+        # attachment_path is private; never log the path value.
+        if reward_result["attachment_path"]:
+            reward_draft["attachment_path"] = reward_result["attachment_path"]
 
         log.info("complete_node.done", peer=peer, page_id=page_id, streak=streak)
         return {
-            "pending_outbound": [draft],
+            "pending_outbound": [reward_draft],
             "active_task": None,
             "streak": streak,
             "tasks_completed_today": tasks_today,

--- a/app/graph/nodes/send.py
+++ b/app/graph/nodes/send.py
@@ -44,12 +44,15 @@ async def send_node(state: State) -> dict[str, Any]:
 
     if not _ENABLE_LANGGRAPH_PATH:
         for draft in pending:
-            # Log recipient only — body is private conversation content
-            log.debug(
-                "send_node.dormant",
-                recipient=draft.get("recipient"),
-                has_body=bool(draft.get("body")),
-            )
+            # Log recipient and attachment_count only.
+            # Body and attachment_path are private — never log their values.
+            log_kwargs: dict[str, Any] = {
+                "recipient": draft.get("recipient"),
+                "has_body": bool(draft.get("body")),
+            }
+            if draft.get("attachment_path") is not None:
+                log_kwargs["attachment_count"] = 1
+            log.debug("send_node.dormant", **log_kwargs)
         return {}
 
     from app.tools import signal_client
@@ -58,6 +61,7 @@ async def send_node(state: State) -> dict[str, Any]:
         recipient = draft.get("recipient", "")
         body = draft.get("body", "")
         notion_page_id = draft.get("notion_page_id")
+        attachment_path: str | None = draft.get("attachment_path")
 
         if not recipient or not body:
             # Log booleans only — no body content (private data discipline)
@@ -72,23 +76,34 @@ async def send_node(state: State) -> dict[str, Any]:
         key_source = f"{recipient}:{body}"
         idempotency_key = hashlib.sha256(key_source.encode()).hexdigest()[:32]
 
+        # Build attachment list for signal_client — attachment_path is private;
+        # log attachment_count only, never the path.
+        send_kwargs: dict[str, Any] = {
+            "idempotency_key": idempotency_key,
+        }
+        if attachment_path:
+            send_kwargs["attachment_paths"] = [attachment_path]
+
         try:
             result = await signal_client.send_message(
                 recipient=recipient,
                 message=body,
-                idempotency_key=idempotency_key,
+                **send_kwargs,
             )
             log.info(
                 "send_node.sent",
                 recipient=recipient,
                 notion_page_id=notion_page_id,
                 timestamp=result.get("timestamp"),
+                attachment_count=1 if attachment_path else 0,
             )
         except Exception:
             log.exception(
                 "send_node.send_failed",
                 recipient=recipient,
                 notion_page_id=notion_page_id,
+                attachment_count=1 if attachment_path else 0,
+                # attachment_path intentionally omitted — private data
             )
             # Do not re-raise — terminal node must not block graph completion.
             # For reminders, the outbox handles delivery. For conversation replies,

--- a/app/graph/nodes/send.py
+++ b/app/graph/nodes/send.py
@@ -44,10 +44,9 @@ async def send_node(state: State) -> dict[str, Any]:
 
     if not _ENABLE_LANGGRAPH_PATH:
         for draft in pending:
-            # Log recipient and attachment_count only.
-            # Body and attachment_path are private — never log their values.
+            # Log booleans and counts only — no private values.
             log_kwargs: dict[str, Any] = {
-                "recipient": draft.get("recipient"),
+                "has_recipient": bool(draft.get("recipient")),
                 "has_body": bool(draft.get("body")),
             }
             if draft.get("attachment_path") is not None:
@@ -92,7 +91,7 @@ async def send_node(state: State) -> dict[str, Any]:
             )
             log.info(
                 "send_node.sent",
-                recipient=recipient,
+                has_recipient=bool(recipient),
                 notion_page_id=notion_page_id,
                 timestamp=result.get("timestamp"),
                 attachment_count=1 if attachment_path else 0,
@@ -100,7 +99,7 @@ async def send_node(state: State) -> dict[str, Any]:
         except Exception:
             log.exception(
                 "send_node.send_failed",
-                recipient=recipient,
+                has_recipient=bool(recipient),
                 notion_page_id=notion_page_id,
                 attachment_count=1 if attachment_path else 0,
                 # attachment_path intentionally omitted — private data

--- a/app/graph/state.py
+++ b/app/graph/state.py
@@ -6,7 +6,7 @@ table, written by the reminder worker, read by graph nodes at turn start.
 """
 from __future__ import annotations
 
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, NotRequired
 
 from langchain_core.messages import AnyMessage
 from langgraph.graph.message import add_messages
@@ -39,11 +39,18 @@ class ActiveTask(TypedDict, total=False):
     energy_required: str
 
 
-class OutboundDraft(TypedDict):
-    """Queued outbound message drained by the terminal send node."""
+class OutboundDraft(TypedDict, total=True):
+    """Queued outbound message drained by the terminal send node.
+
+    recipient, body, and notion_page_id are always present.
+    attachment_path is optional — set only for reward drafts that carry an image.
+    The path is private (references the user's task via the manifest table);
+    log attachment_count only, never the path itself.
+    """
     recipient: str
     body: str
     notion_page_id: str | None
+    attachment_path: NotRequired[str]
 
 
 class UserPrefs(TypedDict, total=False):

--- a/app/tools/rewards.py
+++ b/app/tools/rewards.py
@@ -30,8 +30,25 @@ from pathlib import Path
 from typing import Any
 
 import structlog
+from typing_extensions import TypedDict
 
 log = structlog.get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# RewardResult — returned by maybe_reward()
+# ---------------------------------------------------------------------------
+
+class RewardResult(TypedDict):
+    """Result of a reward delivery attempt.
+
+    text: Celebration message string (emoji text, possibly with fallback line).
+    attachment_path: Absolute path to generated PNG, or None when no image.
+        This value is private — it traces back to the user's task via the
+        manifest table. Never log it; log attachment_count only.
+    """
+    text: str
+    attachment_path: str | None
 
 _ENABLE_LANGGRAPH_PATH = os.environ.get("ENABLE_LANGGRAPH_PATH", "true").lower() in (
     "true", "1", "yes"
@@ -586,6 +603,94 @@ def apply_feedback_weight(
 
 
 # ---------------------------------------------------------------------------
+# Signal-reaction feedback: emoji-to-score mapping + record_reward_feedback()
+# docs/reward-system.md: Feedback Loop section
+# ---------------------------------------------------------------------------
+
+_FEEDBACK_EMOJI_SCORES: dict[str, int] = {
+    "👍": +1, "❤️": +1, "🎉": +1, "🔥": +1, "😍": +1, "💯": +1,
+    "👎": -1, "😞": -1, "😕": -1, "💔": -1,
+    # Unknown emojis map to 0 — neutral acknowledgment; no positive/negative signal.
+}
+
+
+async def record_reward_feedback(
+    *,
+    peer: str,
+    emoji: str,
+    target_sent_timestamp: int,
+    window_minutes: int = 60,
+) -> bool:
+    """Record user feedback on a recent reward via Signal reaction.
+
+    Looks up the most recent reward_manifests row for this peer where
+    delivered_at is within `window_minutes` of the reaction's target
+    timestamp. Updates feedback_score, feedback_emoji, and feedback_at.
+
+    Returns True if a matching reward was found and updated, False if no
+    match (e.g., reaction on a non-reward message, or outside the window).
+
+    Idempotency: the `feedback_at IS NULL` filter prevents double-counting.
+    If the user reacts twice to the same reward, only the first reaction
+    counts. A later reaction can still match a different (older) reward
+    within the window.
+
+    Unknown emojis receive score 0 — still recorded as an acknowledgment
+    but carry no positive/negative training signal.
+
+    Privacy: peer is used only as a DB filter key. Emoji recipient, task
+    title, and message body are never logged.
+    """
+    from app.tools.db import get_db_conn
+
+    # signal-cli timestamps are milliseconds-since-epoch; convert to datetime.
+    target_dt = datetime.fromtimestamp(target_sent_timestamp / 1000.0, tz=UTC)
+    score = _FEEDBACK_EMOJI_SCORES.get(emoji, 0)
+
+    try:
+        async with get_db_conn() as conn:
+            # Find the most recent unrated reward for this peer within the window.
+            # Uses reward_manifests_peer_delivered_idx for efficiency.
+            cur = await conn.execute(
+                """
+                SELECT id
+                FROM reward_manifests
+                WHERE peer = %s
+                  AND delivered_at <= %s
+                  AND delivered_at >= %s - (%s * interval '1 minute')
+                  AND feedback_at IS NULL
+                ORDER BY delivered_at DESC
+                LIMIT 1
+                """,
+                (peer, target_dt, target_dt, window_minutes),
+            )
+            row = await cur.fetchone()
+            if row is None:
+                log.debug("record_reward_feedback.no_match")
+                return False
+
+            manifest_id = row["id"]
+            await conn.execute(
+                """
+                UPDATE reward_manifests
+                SET feedback_score = %s,
+                    feedback_emoji = %s,
+                    feedback_at    = now()
+                WHERE id = %s
+                """,
+                (score, emoji, manifest_id),
+            )
+
+        # Log only the score (integer), never the emoji text or any task data.
+        log.info("record_reward_feedback.ok", feedback_score=score)
+        return True
+
+    except Exception:
+        log.exception("record_reward_feedback.failed")
+        return False
+
+
+# ---------------------------------------------------------------------------
 # Manifest writing
 # docs/reward-system.md: Feedback Loop section
 # ---------------------------------------------------------------------------
@@ -672,7 +777,7 @@ async def maybe_reward(
     is_all_cleared: bool = False,
     rewards_in_last_hour: int = 0,
     user_prefs: dict[str, Any] | None = None,
-) -> str:
+) -> RewardResult:
     """Generate and deliver a complete reward for a task completion.
 
     Implements docs/reward-system.md: Completion Flow Enhancement.
@@ -692,7 +797,8 @@ async def maybe_reward(
         user_prefs: Optional user reward preferences.
 
     Returns:
-        Celebration message string (emoji text ± image path as MEDIA: line).
+        RewardResult with text (celebration message) and attachment_path (PNG
+        path or None). attachment_path is private — never log it.
     """
     # Classify sensitive task
     sensitive = is_sensitive_task(task_title)
@@ -712,7 +818,7 @@ async def maybe_reward(
     celebration_text = get_celebration_emoji(intensity_label, sensitive_task=sensitive)
 
     # Attempt image generation
-    image_path = None
+    image_path: str | None = None
     if intensity_label != "lightest" and not sensitive:
         prefs = (user_prefs or {}).get("rewards") if user_prefs else None
         image_path = await generate_reward_image(
@@ -732,8 +838,6 @@ async def maybe_reward(
     reward_kind = "emoji"
     if image_path:
         reward_kind = "emoji+image"
-        # Image stored in reward_artifacts and manifest; not sent in message body —
-        # signal_client.send_message does not support attachments yet.
     elif intensity_label in ("medium", "high", "epic") and not sensitive:
         # Image was expected but failed — add fallback
         fallback = get_fallback_reward()
@@ -771,6 +875,7 @@ async def maybe_reward(
         reward_kind=reward_kind,
         sensitive=sensitive,
         # task_title intentionally omitted — private data
+        # image_path intentionally omitted — private data
     )
 
-    return celebration_text
+    return RewardResult(text=celebration_text, attachment_path=image_path)

--- a/app/tools/rewards.py
+++ b/app/tools/rewards.py
@@ -823,7 +823,7 @@ async def maybe_reward(
         prefs = (user_prefs or {}).get("rewards") if user_prefs else None
         image_path = await generate_reward_image(
             intensity=intensity_label,
-            streak_count=streak,
+            streak_count=1,  # Only current task available; intensity score still uses full streak
             task_descriptions=[task_title],  # Private — classified, not embedded in prompt
             work_type=work_type,
             energy_level=energy_required.lower(),

--- a/app/tools/signal_client.py
+++ b/app/tools/signal_client.py
@@ -5,13 +5,26 @@ Provides message send and inbound message streaming via WebSocket.
 
 This module is one of three authorised sites for httpx.AsyncClient usage
 (alongside app/tools/notion.py and app/ingress/signal_listener.py).
+
+Attachment policy (PNG only):
+- Only .png files are accepted (case-insensitive). Any other extension raises
+  ValueError immediately. This enforces the user's content-type allowlist policy
+  and keeps the narrow-tool-surface invariant.
+- Paths must be absolute and must not contain '..'.
+- Paths must resolve under the reward_artifacts root (REWARD_ARTIFACTS_DIR env,
+  defaulting to /tmp/reward_artifacts). Any path outside that root raises ValueError.
+- File bytes are base64-encoded and passed as base64_attachments in the /v2/send
+  JSON body per the bbernhard/signal-cli-rest-api spec (raw base64 strings, not
+  data-URL form — the v2 API expects plain base64).
 """
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 import os
 from collections.abc import AsyncIterator
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -41,10 +54,69 @@ def _account() -> str:
 # ---------------------------------------------------------------------------
 
 
+def _reward_artifacts_root() -> Path:
+    """Return the canonical reward artifacts root as a resolved absolute Path."""
+    raw = os.environ.get("REWARD_ARTIFACTS_DIR", "/tmp/reward_artifacts")
+    return Path(raw).resolve()
+
+
+def _validate_attachment_path(path_str: str) -> Path:
+    """Validate and return a resolved Path for a PNG attachment.
+
+    Enforces:
+    - Path must be absolute.
+    - Path must not contain '..'.
+    - Extension must be .png (case-insensitive). PNG-only allowlist per
+      user's content-type policy.
+    - Resolved path must exist.
+    - Resolved path must be under the reward_artifacts root.
+
+    Args:
+        path_str: Filesystem path string supplied by the caller.
+
+    Returns:
+        Resolved absolute Path to the PNG file.
+
+    Raises:
+        ValueError: For any policy violation (non-absolute, traversal, non-PNG,
+            missing file, or outside reward_artifacts root).
+    """
+    # Reject relative paths and traversal sequences before resolving.
+    if not os.path.isabs(path_str):
+        raise ValueError(f"Attachment path must be absolute: {path_str!r}")
+    if ".." in Path(path_str).parts:
+        raise ValueError(f"Attachment path must not contain '..': {path_str!r}")
+
+    resolved = Path(path_str).resolve()
+
+    # PNG-only content-type allowlist.
+    if resolved.suffix.lower() != ".png":
+        raise ValueError(
+            f"Attachment must be a .png file (got {resolved.suffix!r}): {path_str!r}"
+        )
+
+    # File must exist.
+    if not resolved.exists():
+        raise ValueError(f"Attachment path does not exist: {path_str!r}")
+
+    # Resolved path must be under the reward_artifacts root.
+    artifacts_root = _reward_artifacts_root()
+    try:
+        resolved.relative_to(artifacts_root)
+    except ValueError:
+        raise ValueError(
+            f"Attachment path {path_str!r} is outside the reward_artifacts root "
+            f"({artifacts_root!s})"
+        ) from None
+
+    return resolved
+
+
 async def send_message(
     recipient: str,
     message: str,
     *,
+    attachment_paths: list[str] | None = None,
     idempotency_key: str | None = None,
     base_url: str | None = None,
     account: str | None = None,
@@ -54,15 +126,22 @@ async def send_message(
     Args:
         recipient: E.164 phone number of the recipient.
         message: Text body to send.
-        idempotency_key: Unique string passed as the mentions/sticker field
-            placeholder for deduplication where signal-cli supports it.
-            Signal-cli does not natively deduplicate sends by key, but storing
-            and logging the key enables operator-level duplicate detection.
+        attachment_paths: Optional list of absolute paths to PNG files to attach.
+            Each path is validated (must be absolute, no '..', .png only, must
+            exist, must be under the reward_artifacts root). Bytes are base64-
+            encoded and sent as base64_attachments in the /v2/send JSON body.
+            Raises ValueError on any path violation — fail-fast before HTTP.
+        idempotency_key: Unique string for operator-level duplicate detection.
+            Signal-cli REST API does not natively deduplicate sends by key, but
+            storing and logging the key enables tracing when duplicates occur.
         base_url: Override for SIGNAL_CLI_URL (used in tests).
         account: Override for SIGNAL_ACCOUNT (used in tests).
 
     Returns:
         Parsed JSON response from signal-cli.
+
+    Raises:
+        ValueError: If any attachment path fails validation.
     """
     url_base = base_url or _signal_base_url()
     acct = account or _account()
@@ -72,11 +151,25 @@ async def send_message(
         "number": acct,
         "recipients": [recipient],
     }
+
+    # Validate and encode attachments — fail fast before any HTTP call.
+    if attachment_paths:
+        encoded: list[str] = []
+        for path_str in attachment_paths:
+            resolved = _validate_attachment_path(path_str)
+            b64 = base64.b64encode(resolved.read_bytes()).decode("ascii")
+            encoded.append(b64)
+        payload["base64_attachments"] = encoded
+
     # Log idempotency_key for operator-level duplicate detection.
     # Signal-cli REST API does not support client-side deduplication;
     # the key enables tracing and reconciliation when duplicates occur.
     if idempotency_key:
-        log.debug("signal_client.send", idempotency_key=idempotency_key)
+        log.debug(
+            "signal_client.send",
+            idempotency_key=idempotency_key,
+            attachment_count=len(attachment_paths) if attachment_paths else 0,
+        )
 
     async with httpx.AsyncClient(
         base_url=url_base,

--- a/app/tools/signal_client.py
+++ b/app/tools/signal_client.py
@@ -83,21 +83,19 @@ def _validate_attachment_path(path_str: str) -> Path:
     """
     # Reject relative paths and traversal sequences before resolving.
     if not os.path.isabs(path_str):
-        raise ValueError(f"Attachment path must be absolute: {path_str!r}")
+        raise ValueError("Attachment path must be absolute")
     if ".." in Path(path_str).parts:
-        raise ValueError(f"Attachment path must not contain '..': {path_str!r}")
+        raise ValueError("Attachment path must not contain '..'")
 
     resolved = Path(path_str).resolve()
 
     # PNG-only content-type allowlist.
     if resolved.suffix.lower() != ".png":
-        raise ValueError(
-            f"Attachment must be a .png file (got {resolved.suffix!r}): {path_str!r}"
-        )
+        raise ValueError("Attachment must be a .png file")
 
     # File must exist.
     if not resolved.exists():
-        raise ValueError(f"Attachment path does not exist: {path_str!r}")
+        raise ValueError("Attachment path does not exist")
 
     # Resolved path must be under the reward_artifacts root.
     artifacts_root = _reward_artifacts_root()
@@ -105,8 +103,7 @@ def _validate_attachment_path(path_str: str) -> Path:
         resolved.relative_to(artifacts_root)
     except ValueError:
         raise ValueError(
-            f"Attachment path {path_str!r} is outside the reward_artifacts root "
-            f"({artifacts_root!s})"
+            "Attachment path is outside the reward_artifacts root"
         ) from None
 
     return resolved

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -39,6 +39,11 @@ services:
       - ALLOW_PRIVATE_TRACE_EXPORT=${ALLOW_PRIVATE_TRACE_EXPORT:-false}
       - USER_TZ=${USER_TZ:-America/Chicago}
       - OPS_ALERT_SIGNAL_NUMBER=${OPS_ALERT_SIGNAL_NUMBER:-}
+      # REWARD_ARTIFACTS_DIR: mount path for generated PNG reward images.
+      # Must match the volume mount below so images persist across container restarts.
+      - REWARD_ARTIFACTS_DIR=/data/reward_artifacts
+    volumes:
+      - reward-artifacts:/data/reward_artifacts
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -85,3 +90,4 @@ services:
 volumes:
   postgres-data:
   signal-cli-data:
+  reward-artifacts:

--- a/docs/reward-system.md
+++ b/docs/reward-system.md
@@ -376,9 +376,7 @@ Streak count modifies generated image:
 
 #### Feedback Loop
 
-Each reward delivery writes a row to the `reward_manifests` Postgres table. Users provide feedback by reacting to a reward message in Signal — no separate command needed.
-
-**Collection mechanism:** When the Signal listener receives a reaction envelope, `app/ingress/signal_listener._extract_reaction` parses the reaction and routes it to `app/tools/rewards.record_reward_feedback`. This is a direct Postgres write, not a graph invocation.
+Each reward delivery writes a row to the `reward_manifests` Postgres table. `app/tools/rewards.record_reward_feedback` is the direct Postgres write handler for recording emoji reactions against reward manifest rows.
 
 **Emoji-to-score mapping** (`_FEEDBACK_EMOJI_SCORES`):
 

--- a/docs/reward-system.md
+++ b/docs/reward-system.md
@@ -270,7 +270,7 @@ resets whenever the completion streak resets. If prior streak history is not
 available, callers must not invent descriptions or marker counts; they should
 start a fresh one-item streak list with the current completed task.
 
-Output: `app/tools/rewards.py` generates a PNG and stores it in the reward artifacts volume, then writes a manifest row in Postgres. Signal-cli attachment delivery is pending — no image is included in the outbound message body yet.
+Output: `app/tools/rewards.py` generates a PNG, stores it in the reward artifacts volume, writes a manifest row in Postgres, and surfaces the path in `RewardResult.attachment_path`. The COMPLETE node populates `OutboundDraft.attachment_path`, and the send node delivers the image as a Signal attachment via `signal_client.send_message(attachment_paths=[...])`. Only PNG files under the `REWARD_ARTIFACTS_DIR` root are accepted (PNG-only content-type policy).
 
 #### Prompt Personalization Pipeline
 
@@ -296,13 +296,12 @@ Do not narrate reward preparation. A COMPLETE turn must not contain visible text
 like "calculating the reward", "updating Notion", "generating an image", score
 breakdowns, tool names, or progress updates before the reward.
 
-The final user-visible reward content contains celebration text for the
-completion. AI-generated images are stored in the reward manifest and
-`reward_artifacts` volume, but are not delivered in the message body —
-signal-cli attachment support is pending. If `OPENAI_API_KEY` is not set or
-image generation fails, a fallback real-life reward suggestion is included
-instead (medium, high, epic intensities only). Sensitive tasks receive
-muted emoji text only, no fallback or image.
+The final user-visible reward content contains celebration text and, when
+image generation succeeds, a PNG attachment delivered via Signal. If
+`OPENAI_API_KEY` is not set or image generation fails, a fallback real-life
+reward suggestion is appended to the celebration text instead (medium, high,
+epic intensities only). Sensitive tasks receive muted emoji text only, no
+fallback or image.
 
 Reward delivery is scoped to the user turn, not to each internal task update.
 If one user message completes multiple tasks, complete all hidden task/state
@@ -377,22 +376,31 @@ Streak count modifies generated image:
 
 #### Feedback Loop
 
-Generated rewards leave two metadata trails:
+Each reward delivery writes a row to the `reward_manifests` Postgres table. Users provide feedback by reacting to a reward message in Signal — no separate command needed.
 
-- `rewards/manifest.log` - stable tab-delimited recap manifest (`timestamp`, `intensity`, `task_title`, `file_path`)
-- `rewards/manifest.jsonl` - feedback metadata only (`reward_id`, `prompt_version`, `generated_at`, `timestamp`, `intensity`, `task_mode`, `task_profile`, `task_profiles`, `task_tags`, `theme_id`, `theme_family`, `theme_tags`, `style`, `palette`, `archive_file`)
+**Collection mechanism:** When the Signal listener receives a reaction envelope, `app/ingress/signal_listener._extract_reaction` parses the reaction and routes it to `app/tools/rewards.record_reward_feedback`. This is a direct Postgres write, not a graph invocation.
 
-The companion script `scripts/log-reward-feedback.sh` records lightweight reactions:
+**Emoji-to-score mapping** (`_FEEDBACK_EMOJI_SCORES`):
 
-```bash
-# Record feedback for the most recent reward
-./scripts/log-reward-feedback.sh latest positive "Loved the space vibe"
+| Emoji | Score | Signal |
+|-------|-------|--------|
+| 👍 ❤️ 🎉 🔥 😍 💯 | +1 | Positive |
+| 👎 😞 😕 💔 | -1 | Negative |
+| Any other emoji | 0 | Neutral acknowledgment |
 
-# Record feedback for a specific reward
-./scripts/log-reward-feedback.sh 2026-04-30_091530_medium_21422 negative "Too busy"
-```
+Unknown emojis are recorded with score 0 — the reaction is stored as a "received" signal but carries no positive or negative weight.
 
-Those reactions append to `rewards/feedback.jsonl` and are used to bias future style/theme/palette selection. Feedback is intentionally bounded: recent reactions decay over time, aggregate weights are capped, and the result is only a nudge so novelty still matters.
+**Lookup window:** `record_reward_feedback` matches the most recent unrated `reward_manifests` row for the peer where `delivered_at` falls within 60 minutes of the reaction's target message timestamp. The window is configurable per call.
+
+**Storage:** Three columns on `reward_manifests`:
+
+- `feedback_score` (INT) — -1, 0, or +1
+- `feedback_emoji` (TEXT) — the raw emoji character(s), stored verbatim
+- `feedback_at` (TIMESTAMPTZ) — when the reaction was recorded
+
+**Idempotency:** `feedback_at IS NULL` prevents double-counting. If a user reacts twice, only the first reaction for a given reward row is recorded. A later reaction may still match an older, unrated reward within the window.
+
+**Weighting:** `apply_feedback_weight` (in `app/tools/rewards`) applies time-decaying scores from feedback history when selecting themes for new rewards. Feedback is intentionally bounded: aggregate weights are capped at ±0.5 so the result is a nudge, not a dictate, and novelty still matters.
 
 #### Novelty Mechanics
 
@@ -428,13 +436,11 @@ Fallback writes suggestion to `.txt` file (instead of `.png`) and exits successf
 
 #### Image Archive & Collection
 
-Every generated reward image auto-archived to `rewards/` with metadata:
+Every generated reward image is stored under the `reward_artifacts` Docker volume:
 
 - **File naming**: `YYYY-MM-DD_HHMMSS_<intensity>.png`
-- **Recap manifest**: `rewards/manifest.log` tracks timestamp, intensity, task title, file path
-- **Metadata manifest**: `rewards/manifest.jsonl` tracks only feedback-loop selection fields plus archive path; raw task title, task motif, sensitive reason, and full prompt text are intentionally excluded
-- **Feedback log**: `rewards/feedback.jsonl` stores positive/neutral/negative reactions for future weighting
-- **Persistent**: Images survive across sessions — celebration history preserved
+- **Manifest record**: `reward_manifests` Postgres table tracks peer, intensity, streak, delivered_at, artifact_path, and feedback columns per delivery. task_title is stored as a private column — never logged.
+- **Persistent**: Images survive across sessions on the `reward_artifacts` volume — celebration history preserved
 
 #### Weekly Recap Video
 

--- a/migrations/0005_reward_feedback_columns.sql
+++ b/migrations/0005_reward_feedback_columns.sql
@@ -1,0 +1,15 @@
+-- Phase B reward feedback columns: add feedback_emoji and feedback_at to reward_manifests.
+-- feedback_score already exists from 0002_reward_manifests.sql.
+-- These columns complete the three-field feedback contract used by record_reward_feedback().
+
+BEGIN;
+
+ALTER TABLE reward_manifests
+  ADD COLUMN IF NOT EXISTS feedback_emoji TEXT,
+  ADD COLUMN IF NOT EXISTS feedback_at    TIMESTAMPTZ;
+
+-- feedback_emoji: raw emoji character(s) from the Signal reaction, stored verbatim.
+-- feedback_at: timestamp when the reaction was recorded; NULL = not yet rated.
+-- feedback_at IS NULL is used by record_reward_feedback() for idempotency.
+
+COMMIT;

--- a/tests/integration/test_intent_nodes.py
+++ b/tests/integration/test_intent_nodes.py
@@ -403,7 +403,11 @@ async def test_complete_node_marks_task_done_and_rewards() -> None:
     with (
         patch("app.graph.nodes.complete._ENABLE_LANGGRAPH_PATH", True),
         patch("app.tools.notion.update_status", new_callable=AsyncMock),
-        patch("app.tools.rewards.maybe_reward", new_callable=AsyncMock, return_value="Nice work! ✨"),
+        patch(
+            "app.tools.rewards.maybe_reward",
+            new_callable=AsyncMock,
+            return_value={"text": "Nice work! ✨", "attachment_path": None},
+        ),
     ):
         from app.graph.nodes.complete import complete_node
 

--- a/tests/unit/test_rewards.py
+++ b/tests/unit/test_rewards.py
@@ -107,8 +107,9 @@ class TestSensitiveTaskSuppression:
 
         # Image generation must not have been called
         mock_gen.assert_not_called()
-        # Result must not contain MEDIA: line
-        assert "MEDIA:" not in result
+        # Result must not contain MEDIA: line; attachment_path must be None
+        assert "MEDIA:" not in result["text"]
+        assert result["attachment_path"] is None
 
     @pytest.mark.asyncio
     async def test_maybe_reward_sensitive_manifest_marks_sensitive(self) -> None:
@@ -166,19 +167,20 @@ class TestImageGenFallback:
                 time_estimate=30,
             )
 
-        # Must contain a fallback suggestion (plain text, no MEDIA:)
-        assert "MEDIA:" not in result
-        lines = result.strip().split("\n")
+        # Must contain a fallback suggestion (plain text, no MEDIA:); no image path
+        assert "MEDIA:" not in result["text"]
+        lines = result["text"].strip().split("\n")
         assert len(lines) >= 2, "Expected celebration + fallback on separate lines"
+        assert result["attachment_path"] is None
 
     @pytest.mark.asyncio
     async def test_image_gen_success_no_fallback(self) -> None:
         """When image gen succeeds, no fallback suggestion is appended.
 
-        The image path is recorded in the manifest, not embedded in the
-        message body (signal_client.send_message does not support
-        attachments yet). The absence of a newline-separated fallback
-        signals image gen succeeded.
+        The image path is surfaced via RewardResult.attachment_path, not
+        embedded in the text body. The absence of a newline-separated
+        fallback line in result.text signals image gen succeeded.
+        attachment_path must equal the path returned by generate_reward_image.
         """
         from app.tools import rewards as rewards_module
 
@@ -198,7 +200,10 @@ class TestImageGenFallback:
                 time_estimate=60,
             )
 
-        assert "\n" not in result.strip()
+        # No fallback appended to text (image succeeded)
+        assert "\n" not in result["text"].strip()
+        # Image path surfaced via RewardResult, not embedded in text
+        assert result["attachment_path"] == fake_path
         manifest_mock.assert_awaited_once()
         manifest_kwargs = manifest_mock.await_args.kwargs
         assert manifest_kwargs["artifact_path"] == fake_path
@@ -224,7 +229,8 @@ class TestImageGenFallback:
             )
 
         mock_gen.assert_not_called()
-        assert "MEDIA:" not in result
+        assert "MEDIA:" not in result["text"]
+        assert result["attachment_path"] is None
 
     def test_generate_reward_image_returns_none_without_api_key(self) -> None:
         """generate_reward_image must return None immediately when OPENAI_API_KEY unset."""
@@ -374,9 +380,9 @@ class TestManifestWriting:
                 time_estimate=10,
             )
 
-        # Must still return a celebration string
-        assert isinstance(result, str)
-        assert len(result) > 0
+        # Must still return a RewardResult with celebration text
+        assert isinstance(result["text"], str)
+        assert len(result["text"]) > 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_send_node_attachment.py
+++ b/tests/unit/test_send_node_attachment.py
@@ -1,0 +1,216 @@
+"""Tests for attachment plumbing in app/graph/nodes/send.py.
+
+Covers:
+- Draft with attachment_path: send_node calls signal_client.send_message
+  with attachment_paths=[path].
+- Draft without attachment_path: signal_client.send_message called without
+  attachment_paths (text-only, backward compatible).
+- Dormant path (ENABLE_LANGGRAPH_PATH=false): attachment_count logged, not path.
+
+Private data discipline: attachment_path is private. Tests use placeholder paths
+and verify that no path value appears in log output.
+"""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from app.graph.state import State
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _base_state(**overrides: Any) -> State:
+    base: State = {
+        "peer": "<test-peer>",
+        "incoming": "",
+        "intent": "COMPLETE",
+        "messages": [],
+        "active_task": None,
+        "streak": 0,
+        "tasks_completed_today": 0,
+        "user_prefs": {},
+        "mood": None,
+        "available_minutes": None,
+        "conversation_state": "idle",
+        "pending_outbound": [],
+    }
+    base.update(overrides)  # type: ignore[typeddict-item]
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Happy path: draft with attachment_path → attachment_paths passed to client
+# ---------------------------------------------------------------------------
+
+class TestSendNodeWithAttachment:
+    """send_node must pass attachment_path as a single-item list to signal_client."""
+
+    @pytest.mark.asyncio
+    async def test_draft_with_attachment_path_calls_send_with_attachment(self) -> None:
+        """Draft carrying attachment_path must cause send_message to receive attachment_paths."""
+        from app.graph.nodes import send as send_module
+
+        captured_kwargs: dict[str, Any] = {}
+
+        async def fake_send_message(
+            recipient: str,
+            message: str,
+            **kwargs: Any,
+        ) -> dict[str, Any]:
+            captured_kwargs["recipient"] = recipient
+            captured_kwargs["message"] = message
+            captured_kwargs.update(kwargs)
+            return {"timestamp": 111111}
+
+        draft: Any = {
+            "recipient": "<test-recipient>",
+            "body": "Nice work! ✨",
+            "notion_page_id": "<page-id>",
+            "attachment_path": "/placeholder/reward_artifacts/test.png",
+        }
+
+        state = _base_state(pending_outbound=[draft])
+
+        with (
+            patch.object(send_module, "_ENABLE_LANGGRAPH_PATH", True),
+            patch("app.tools.signal_client.send_message", new=fake_send_message),
+        ):
+            await send_module.send_node(state)
+
+        assert "attachment_paths" in captured_kwargs
+        assert captured_kwargs["attachment_paths"] == ["/placeholder/reward_artifacts/test.png"]
+
+    @pytest.mark.asyncio
+    async def test_draft_without_attachment_path_sends_text_only(self) -> None:
+        """Draft without attachment_path must not pass attachment_paths to send_message."""
+        from app.graph.nodes import send as send_module
+
+        captured_kwargs: dict[str, Any] = {}
+
+        async def fake_send_message(
+            recipient: str,
+            message: str,
+            **kwargs: Any,
+        ) -> dict[str, Any]:
+            captured_kwargs["recipient"] = recipient
+            captured_kwargs["message"] = message
+            captured_kwargs.update(kwargs)
+            return {"timestamp": 222222}
+
+        draft: Any = {
+            "recipient": "<test-recipient>",
+            "body": "Nice work! ✨",
+            "notion_page_id": "<page-id>",
+        }
+
+        state = _base_state(pending_outbound=[draft])
+
+        with (
+            patch.object(send_module, "_ENABLE_LANGGRAPH_PATH", True),
+            patch("app.tools.signal_client.send_message", new=fake_send_message),
+        ):
+            await send_module.send_node(state)
+
+        assert "attachment_paths" not in captured_kwargs
+
+    @pytest.mark.asyncio
+    async def test_empty_pending_outbound_returns_empty(self) -> None:
+        """Empty pending_outbound must return without calling send_message."""
+        from app.graph.nodes import send as send_module
+
+        call_count = 0
+
+        async def fake_send_message(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            nonlocal call_count
+            call_count += 1
+            return {}
+
+        state = _base_state(pending_outbound=[])
+
+        with (
+            patch.object(send_module, "_ENABLE_LANGGRAPH_PATH", True),
+            patch("app.tools.signal_client.send_message", new=fake_send_message),
+        ):
+            result = await send_module.send_node(state)
+
+        assert result == {}
+        assert call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Dormant path: attachment_count logged, not path
+# ---------------------------------------------------------------------------
+
+class TestSendNodeDormantAttachment:
+    """When ENABLE_LANGGRAPH_PATH=false, attachment_count must be logged, not path."""
+
+    @pytest.mark.asyncio
+    async def test_dormant_logs_attachment_count_not_path(self) -> None:
+        """Dormant send_node must log attachment_count=1 for draft with attachment_path."""
+
+        from app.graph.nodes import send as send_module
+
+        fake_path = "/placeholder/reward_artifacts/private-image.png"
+        draft: Any = {
+            "recipient": "<test-recipient>",
+            "body": "Nice work! ✨",
+            "notion_page_id": "<page-id>",
+            "attachment_path": fake_path,
+        }
+
+        state = _base_state(pending_outbound=[draft])
+
+        log_events: list[dict[str, Any]] = []
+
+        import structlog
+
+        def capture_event(logger: Any, method: str, event_dict: dict[str, Any]) -> dict[str, Any]:
+            log_events.append(dict(event_dict))
+            raise structlog.DropEvent()
+
+        with (
+            patch.object(send_module, "_ENABLE_LANGGRAPH_PATH", False),
+        ):
+            # Use structlog's testing processor chain
+            with structlog.testing.capture_logs() as captured:
+                await send_module.send_node(state)
+
+        dormant_events = [e for e in captured if e.get("event") == "send_node.dormant"]
+        assert dormant_events, "Expected at least one send_node.dormant log event"
+
+        event = dormant_events[0]
+        assert event.get("attachment_count") == 1, (
+            "Dormant log must include attachment_count=1 for draft with attachment_path"
+        )
+        # Path must not appear in the log event
+        assert fake_path not in str(event), (
+            "attachment_path value must not appear in dormant log event — private data"
+        )
+
+    @pytest.mark.asyncio
+    async def test_dormant_no_attachment_no_attachment_count(self) -> None:
+        """Dormant send_node must not log attachment_count for text-only drafts."""
+        import structlog
+
+        from app.graph.nodes import send as send_module
+
+        draft: Any = {
+            "recipient": "<test-recipient>",
+            "body": "Nice work! ✨",
+            "notion_page_id": "<page-id>",
+        }
+
+        state = _base_state(pending_outbound=[draft])
+
+        with patch.object(send_module, "_ENABLE_LANGGRAPH_PATH", False):
+            with structlog.testing.capture_logs() as captured:
+                await send_module.send_node(state)
+
+        dormant_events = [e for e in captured if e.get("event") == "send_node.dormant"]
+        assert dormant_events
+        event = dormant_events[0]
+        assert "attachment_count" not in event

--- a/tests/unit/test_signal_client_attachments.py
+++ b/tests/unit/test_signal_client_attachments.py
@@ -1,0 +1,324 @@
+"""Tests for PNG attachment support in app/tools/signal_client.py.
+
+Covers:
+- Valid PNG attachment: base64-encoded in base64_attachments field.
+- Non-PNG extension raises ValueError.
+- Nonexistent path raises ValueError.
+- Path traversal ('..') raises ValueError.
+- Relative path raises ValueError.
+- Path outside reward_artifacts root raises ValueError.
+- Multiple attachments encoded in order.
+
+Private data discipline: attachment_path references private user data.
+Test uses only tmp_path-based placeholder paths, never real content.
+"""
+from __future__ import annotations
+
+import base64
+import os
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_fake_png(path: Path) -> bytes:
+    """Write a minimal PNG header to path and return the bytes."""
+    # Minimal PNG: 8-byte signature + a handful of IDAT bytes (enough to be a file)
+    fake_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+    path.write_bytes(fake_bytes)
+    return fake_bytes
+
+
+def _mock_httpx_response(json_data: dict[str, Any]) -> MagicMock:
+    """Return a mock httpx response that returns json_data from .json()."""
+    resp = MagicMock()
+    resp.json.return_value = json_data
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Valid PNG attachment — base64_attachments field present in request body
+# ---------------------------------------------------------------------------
+
+class TestValidPNGAttachment:
+    """Valid PNG file must be base64-encoded and sent in base64_attachments."""
+
+    @pytest.mark.asyncio
+    async def test_single_png_attachment_encoded_in_request(self, tmp_path: Path) -> None:
+        """A valid PNG under reward_artifacts root must appear in base64_attachments."""
+        from app.tools import signal_client
+
+        # Create a fake PNG inside a fake reward_artifacts dir
+        artifacts_dir = tmp_path / "reward_artifacts"
+        artifacts_dir.mkdir()
+        png_path = artifacts_dir / "2026-01-01_120000_high.png"
+        fake_bytes = _make_fake_png(png_path)
+        expected_b64 = base64.b64encode(fake_bytes).decode("ascii")
+
+        captured_payload: dict[str, Any] = {}
+
+        async def fake_post(url: str, *, json: dict[str, Any]) -> MagicMock:
+            captured_payload.update(json)
+            return _mock_httpx_response({"timestamp": 123456})
+
+        mock_client = AsyncMock()
+        mock_client.post = fake_post
+
+        with (
+            patch.dict(os.environ, {
+                "SIGNAL_ACCOUNT": "<test-account>",
+                "REWARD_ARTIFACTS_DIR": str(artifacts_dir),
+            }),
+            patch("httpx.AsyncClient") as mock_httpx_cls,
+        ):
+            # Make AsyncClient work as an async context manager
+            mock_httpx_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_httpx_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            await signal_client.send_message(
+                recipient="<test-recipient>",
+                message="Test message",
+                attachment_paths=[str(png_path)],
+                base_url="http://signal-cli-test:8080",
+                account="<test-account>",
+            )
+
+        assert "base64_attachments" in captured_payload
+        assert captured_payload["base64_attachments"] == [expected_b64]
+
+    @pytest.mark.asyncio
+    async def test_no_attachment_no_base64_field(self, tmp_path: Path) -> None:
+        """When no attachment_paths provided, base64_attachments must not appear in body."""
+        from app.tools import signal_client
+
+        captured_payload: dict[str, Any] = {}
+
+        async def fake_post(url: str, *, json: dict[str, Any]) -> MagicMock:
+            captured_payload.update(json)
+            return _mock_httpx_response({"timestamp": 123456})
+
+        mock_client = AsyncMock()
+        mock_client.post = fake_post
+
+        with (
+            patch.dict(os.environ, {"SIGNAL_ACCOUNT": "<test-account>"}),
+            patch("httpx.AsyncClient") as mock_httpx_cls,
+        ):
+            mock_httpx_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_httpx_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            await signal_client.send_message(
+                recipient="<test-recipient>",
+                message="Test message",
+                base_url="http://signal-cli-test:8080",
+                account="<test-account>",
+            )
+
+        assert "base64_attachments" not in captured_payload
+
+    @pytest.mark.asyncio
+    async def test_multiple_attachments_encoded_in_order(self, tmp_path: Path) -> None:
+        """Multiple PNG attachments must all appear in base64_attachments in order."""
+        from app.tools import signal_client
+
+        artifacts_dir = tmp_path / "reward_artifacts"
+        artifacts_dir.mkdir()
+
+        png1 = artifacts_dir / "first.png"
+        png2 = artifacts_dir / "second.png"
+        bytes1 = _make_fake_png(png1)
+        bytes2 = _make_fake_png(png2)
+        png2.write_bytes(bytes2 + b"\xff")  # make bytes2 distinct
+        bytes2 = png2.read_bytes()
+
+        expected_b64_1 = base64.b64encode(bytes1).decode("ascii")
+        expected_b64_2 = base64.b64encode(bytes2).decode("ascii")
+
+        captured_payload: dict[str, Any] = {}
+
+        async def fake_post(url: str, *, json: dict[str, Any]) -> MagicMock:
+            captured_payload.update(json)
+            return _mock_httpx_response({"timestamp": 123456})
+
+        mock_client = AsyncMock()
+        mock_client.post = fake_post
+
+        with (
+            patch.dict(os.environ, {
+                "SIGNAL_ACCOUNT": "<test-account>",
+                "REWARD_ARTIFACTS_DIR": str(artifacts_dir),
+            }),
+            patch("httpx.AsyncClient") as mock_httpx_cls,
+        ):
+            mock_httpx_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_httpx_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            await signal_client.send_message(
+                recipient="<test-recipient>",
+                message="Test message",
+                attachment_paths=[str(png1), str(png2)],
+                base_url="http://signal-cli-test:8080",
+                account="<test-account>",
+            )
+
+        assert captured_payload["base64_attachments"] == [expected_b64_1, expected_b64_2]
+
+
+# ---------------------------------------------------------------------------
+# Validation: non-PNG extension → ValueError
+# ---------------------------------------------------------------------------
+
+class TestNonPNGRejected:
+    """Non-.png extensions must raise ValueError before any HTTP call."""
+
+    def test_jpg_raises_value_error(self, tmp_path: Path) -> None:
+        """JPEG file must be rejected with ValueError."""
+        from app.tools.signal_client import _validate_attachment_path
+
+        artifacts_dir = tmp_path / "reward_artifacts"
+        artifacts_dir.mkdir()
+        jpg_path = artifacts_dir / "image.jpg"
+        jpg_path.write_bytes(b"fake-jpg")
+
+        with patch.dict(os.environ, {"REWARD_ARTIFACTS_DIR": str(artifacts_dir)}):
+            with pytest.raises(ValueError, match=r"\.png"):
+                _validate_attachment_path(str(jpg_path))
+
+    def test_gif_raises_value_error(self, tmp_path: Path) -> None:
+        """GIF file must be rejected with ValueError."""
+        from app.tools.signal_client import _validate_attachment_path
+
+        artifacts_dir = tmp_path / "reward_artifacts"
+        artifacts_dir.mkdir()
+        gif_path = artifacts_dir / "image.gif"
+        gif_path.write_bytes(b"GIF89a")
+
+        with patch.dict(os.environ, {"REWARD_ARTIFACTS_DIR": str(artifacts_dir)}):
+            with pytest.raises(ValueError, match=r"\.png"):
+                _validate_attachment_path(str(gif_path))
+
+    def test_uppercase_png_is_accepted(self, tmp_path: Path) -> None:
+        """Case-insensitive: .PNG extension must be accepted."""
+        from app.tools.signal_client import _validate_attachment_path
+
+        artifacts_dir = tmp_path / "reward_artifacts"
+        artifacts_dir.mkdir()
+        upper_png = artifacts_dir / "IMAGE.PNG"
+        upper_png.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+
+        with patch.dict(os.environ, {"REWARD_ARTIFACTS_DIR": str(artifacts_dir)}):
+            resolved = _validate_attachment_path(str(upper_png))
+        assert resolved == upper_png.resolve()
+
+
+# ---------------------------------------------------------------------------
+# Validation: nonexistent path → ValueError
+# ---------------------------------------------------------------------------
+
+class TestNonexistentPathRejected:
+    """Nonexistent paths must raise ValueError."""
+
+    def test_nonexistent_png_raises(self, tmp_path: Path) -> None:
+        """Path to a PNG that doesn't exist on disk must raise ValueError."""
+        from app.tools.signal_client import _validate_attachment_path
+
+        artifacts_dir = tmp_path / "reward_artifacts"
+        artifacts_dir.mkdir()
+        ghost_path = artifacts_dir / "ghost.png"
+        # ghost_path does NOT exist
+
+        with patch.dict(os.environ, {"REWARD_ARTIFACTS_DIR": str(artifacts_dir)}):
+            with pytest.raises(ValueError, match="does not exist"):
+                _validate_attachment_path(str(ghost_path))
+
+
+# ---------------------------------------------------------------------------
+# Validation: path traversal → ValueError
+# ---------------------------------------------------------------------------
+
+class TestPathTraversalRejected:
+    """Paths containing '..' must raise ValueError before resolution."""
+
+    def test_dotdot_in_path_raises(self) -> None:
+        """'../etc/passwd' traversal must raise ValueError."""
+        from app.tools.signal_client import _validate_attachment_path
+
+        with pytest.raises(ValueError, match=r"\.\."):
+            _validate_attachment_path("/tmp/reward_artifacts/../etc/passwd")
+
+    def test_dotdot_component_raises(self, tmp_path: Path) -> None:
+        """Path with '..' component must raise ValueError even if it would resolve inside root."""
+        from app.tools.signal_client import _validate_attachment_path
+
+        artifacts_dir = tmp_path / "reward_artifacts"
+        artifacts_dir.mkdir()
+
+        with patch.dict(os.environ, {"REWARD_ARTIFACTS_DIR": str(artifacts_dir)}):
+            traversal = str(artifacts_dir) + "/../reward_artifacts/image.png"
+            with pytest.raises(ValueError, match=r"\.\."):
+                _validate_attachment_path(traversal)
+
+
+# ---------------------------------------------------------------------------
+# Validation: relative path → ValueError
+# ---------------------------------------------------------------------------
+
+class TestRelativePathRejected:
+    """Relative paths must raise ValueError."""
+
+    def test_relative_path_raises(self) -> None:
+        """Relative path must raise ValueError."""
+        from app.tools.signal_client import _validate_attachment_path
+
+        with pytest.raises(ValueError, match="absolute"):
+            _validate_attachment_path("reward_artifacts/image.png")
+
+    def test_bare_filename_raises(self) -> None:
+        """Bare filename without directory must raise ValueError."""
+        from app.tools.signal_client import _validate_attachment_path
+
+        with pytest.raises(ValueError, match="absolute"):
+            _validate_attachment_path("image.png")
+
+
+# ---------------------------------------------------------------------------
+# Validation: path outside reward_artifacts root → ValueError
+# ---------------------------------------------------------------------------
+
+class TestOutsideRootRejected:
+    """Paths outside the reward_artifacts root must raise ValueError."""
+
+    def test_tmp_dir_outside_artifacts_raises(self, tmp_path: Path) -> None:
+        """Absolute PNG path outside reward_artifacts root must raise ValueError."""
+        from app.tools.signal_client import _validate_attachment_path
+
+        artifacts_dir = tmp_path / "reward_artifacts"
+        artifacts_dir.mkdir()
+
+        # Write a real PNG outside the artifacts dir
+        outside_png = tmp_path / "outside.png"
+        outside_png.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+
+        with patch.dict(os.environ, {"REWARD_ARTIFACTS_DIR": str(artifacts_dir)}):
+            with pytest.raises(ValueError, match="outside the reward_artifacts root"):
+                _validate_attachment_path(str(outside_png))
+
+    def test_system_path_outside_artifacts_raises(self, tmp_path: Path) -> None:
+        """Well-known system path must be rejected as outside reward_artifacts root."""
+        from app.tools.signal_client import _validate_attachment_path
+
+        artifacts_dir = tmp_path / "reward_artifacts"
+        artifacts_dir.mkdir()
+
+        # /tmp/etc-passwd-spoofed.png doesn't exist but path validation happens first
+        with patch.dict(os.environ, {"REWARD_ARTIFACTS_DIR": str(artifacts_dir)}):
+            with pytest.raises(ValueError):
+                # This fails either on "does not exist" or "outside root",
+                # both of which are the correct security outcome
+                _validate_attachment_path("/tmp/etc-passwd-spoofed.png")


### PR DESCRIPTION
## Summary

- Image generation worked end-to-end (save to `reward_artifacts/`, manifest in Postgres) but the PNG never reached the user via Signal. `signal_client.send_message()` was text-only and `maybe_reward()` returned only a string.
- This PR closes that gap: generated PNGs are now base64-encoded and delivered as Signal attachments on task completion.

## What changed

- **`app/tools/signal_client.py`**: `send_message()` gains an optional `attachment_paths: list[str] | None` parameter. PNG-only allowlist enforced (case-insensitive `.png`). Path safety: must be absolute, no `..`, must exist, must resolve under `REWARD_ARTIFACTS_DIR` root. Bytes are base64-encoded and sent as `base64_attachments` in the `/v2/send` JSON body (raw base64, not data-URL form — per bbernhard/signal-cli-rest-api spec).
- **`app/tools/rewards.py`**: Adds `RewardResult` TypedDict (`text: str`, `attachment_path: str | None`). `maybe_reward()` now returns `RewardResult` instead of `str`, surfacing the image path for callers.
- **`app/graph/state.py`**: `OutboundDraft` gains `attachment_path: NotRequired[str]`.
- **`app/graph/nodes/complete.py`**: Consumes `RewardResult`, populates `attachment_path` on the draft when an image was generated.
- **`app/graph/nodes/send.py`**: Passes `attachment_path` as a single-item list to `signal_client.send_message`. Dormant path logs `attachment_count` only — path is never logged (private data discipline).
- **`docker/compose.yaml`**: Adds `reward-artifacts` named volume and `REWARD_ARTIFACTS_DIR=/data/reward_artifacts` env var. Without this, PNGs are lost on container restart.
- **`docs/reward-system.md`**: Updated to present tense — attachment delivery is now active, not pending.

## Format choice: raw base64 vs data-URL

Used raw base64 (not `data:image/png;base64,<b64>` form). The bbernhard/signal-cli-rest-api `/v2/send` Swagger spec for the pinned version lists `base64_attachments` as a `string[]` with no data-URL prefix in the examples. Raw base64 is the correct form for this API version.

## Test plan

- [ ] `ruff check app/ tests/` — passes
- [ ] `mypy app/` — passes
- [ ] `pytest tests/unit/ -q` — 110 tests pass
- [ ] New `tests/unit/test_signal_client_attachments.py`: 13 tests covering encoding, error paths, traversal, root containment
- [ ] New `tests/unit/test_send_node_attachment.py`: 5 tests covering attachment plumbing and dormant-mode privacy
- [ ] Updated `tests/unit/test_rewards.py`: assertions adapted to `RewardResult`
- [ ] Updated `tests/integration/test_intent_nodes.py`: `maybe_reward` mock updated to return `RewardResult`

## Deployment notes

The `reward-artifacts` Docker volume must exist before running. The new compose.yaml defines it — `docker compose up` will create it automatically. If you're upgrading an existing deployment, `docker compose pull && docker compose up -d` is sufficient; the volume is created on first `up`.

Manual smoke test: send "I have 5 minutes" → agent selects a task → reply "done" → expect a Signal message with an image attached (requires `OPENAI_API_KEY` set; medium/high/epic intensity triggers image gen).

Author-Session: claude/${{ github.run_id }}