### PR TITLE
Add optional file logging for Gravwell ingestion

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -15,10 +15,31 @@ import asyncio
 import logging
 import os
 import sys
+from typing import Any
 
 import structlog
 
 log = structlog.get_logger()
+
+_RECIPIENT_LOG_FIELDS = frozenset({"peer", "recipient", "phone_number", "signal_account"})
+_PRIVATE_TEXT_LOG_FIELDS = frozenset(
+    {"message", "body", "task_title", "title", "notion_page_title", "reminder_content"}
+)
+
+
+def _redact_private_log_fields(
+    _logger: Any,
+    _method_name: str,
+    event_dict: dict[str, Any],
+) -> dict[str, Any]:
+    """Redact private field values before logs reach stdout or file sinks."""
+    for key in _RECIPIENT_LOG_FIELDS:
+        if key in event_dict:
+            event_dict[key] = "<recipient>"
+    for key in _PRIVATE_TEXT_LOG_FIELDS:
+        if key in event_dict:
+            event_dict[key] = "<private>"
+    return event_dict
 
 
 def _check_langsmith_guard() -> None:
@@ -59,9 +80,7 @@ async def _run_app() -> None:
         await listener.run()
 
 
-def main() -> None:
-    _check_langsmith_guard()
-
+def _configure_logging() -> None:
     log_file = os.environ.get("LOG_FILE", "")
     handlers: list[logging.Handler] = [logging.StreamHandler(sys.stdout)]
     if log_file:
@@ -77,11 +96,17 @@ def main() -> None:
             structlog.stdlib.add_log_level,
             structlog.stdlib.PositionalArgumentsFormatter(),
             structlog.processors.TimeStamper(fmt="iso"),
+            _redact_private_log_fields,
             structlog.processors.JSONRenderer(),
         ],
         logger_factory=structlog.stdlib.LoggerFactory(),
         wrapper_class=structlog.stdlib.BoundLogger,
     )
+
+
+def main() -> None:
+    _check_langsmith_guard()
+    _configure_logging()
 
     enable = os.environ.get("ENABLE_LANGGRAPH_PATH", "true").lower() == "true"
 

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ ALLOW_PRIVATE_TRACE_EXPORT=true is also set.
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import sys
 
@@ -61,6 +62,16 @@ async def _run_app() -> None:
 def main() -> None:
     _check_langsmith_guard()
 
+    log_file = os.environ.get("LOG_FILE", "")
+    handlers: list[logging.Handler] = [logging.StreamHandler(sys.stdout)]
+    if log_file:
+        log_dir = os.path.dirname(log_file)
+        if log_dir:
+            os.makedirs(log_dir, exist_ok=True)
+        handlers.append(logging.FileHandler(log_file))
+
+    logging.basicConfig(handlers=handlers, level=logging.INFO, format="%(message)s")
+
     structlog.configure(
         processors=[
             structlog.stdlib.add_log_level,
@@ -68,6 +79,8 @@ def main() -> None:
             structlog.processors.TimeStamper(fmt="iso"),
             structlog.processors.JSONRenderer(),
         ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
     )
 
     enable = os.environ.get("ENABLE_LANGGRAPH_PATH", "true").lower() == "true"

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -34,6 +34,7 @@ services:
       # gated here. Empty/unset = refuse to start (fail-safe closed default).
       - AUTHORIZED_PEERS=${AUTHORIZED_PEERS:-}
       - ENABLE_LANGGRAPH_PATH=${ENABLE_LANGGRAPH_PATH:-true}
+      - LOG_FILE=${LOG_FILE:-}
       # LangSmith guard: requires explicit opt-in with ALLOW_PRIVATE_TRACE_EXPORT=true
       - LANGSMITH_TRACING=${LANGSMITH_TRACING:-false}
       - ALLOW_PRIVATE_TRACE_EXPORT=${ALLOW_PRIVATE_TRACE_EXPORT:-false}
@@ -46,6 +47,8 @@ services:
         condition: service_healthy
     networks:
       - internal
+    volumes:
+      - ${HML_LOG_DIR:-/tmp/hml-logs}:/var/log/hml
     # restart: on-failure keeps the service alive on crashes but does NOT restart it
     # when it exits 0 (skeleton mode with ENABLE_LANGGRAPH_PATH=false).
     # Using unless-stopped here would cause a restart loop in dormant/skeleton mode.

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -4,14 +4,18 @@ Verifies LangSmith guard, skeleton mode, and feature-flag behavior.
 """
 from __future__ import annotations
 
+import json
+import os
 import subprocess
 import sys
+from pathlib import Path
 
 
 def _run_main(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
     """Run app.main in a subprocess with the given environment."""
-    import os
     full_env = {**os.environ, **env}
+    if "LOG_FILE" not in env:
+        full_env.pop("LOG_FILE", None)
     return subprocess.run(
         [sys.executable, "-m", "app.main"],
         capture_output=True,
@@ -26,6 +30,22 @@ def test_skeleton_mode_prints_skeleton() -> None:
     result = _run_main({"ENABLE_LANGGRAPH_PATH": "false"})
     assert result.returncode == 0
     assert "skeleton" in result.stdout
+
+
+def test_log_file_writes_structured_logs_and_preserves_stdout(tmp_path: Path) -> None:
+    """LOG_FILE writes JSON logs to disk while stdout logging remains active."""
+    log_file = tmp_path / "logs" / "app.log"
+    result = _run_main({"ENABLE_LANGGRAPH_PATH": "false", "LOG_FILE": str(log_file)})
+
+    assert result.returncode == 0
+    assert "skeleton" in result.stdout
+    assert '"event": "app.skeleton_mode"' in result.stdout
+
+    log_lines = log_file.read_text().splitlines()
+    assert len(log_lines) == 1
+    payload = json.loads(log_lines[0])
+    assert payload["event"] == "app.skeleton_mode"
+    assert payload["level"] == "warning"
 
 
 def test_langsmith_guard_blocks_boot() -> None:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -48,6 +48,52 @@ def test_log_file_writes_structured_logs_and_preserves_stdout(tmp_path: Path) ->
     assert payload["level"] == "warning"
 
 
+def test_log_file_redacts_private_fields_from_file_and_stdout(tmp_path: Path) -> None:
+    """Private log fields are redacted before any configured sink receives them."""
+    log_file = tmp_path / "logs" / "app.log"
+    code = f"""
+import os
+import structlog
+
+from app.main import _configure_logging
+
+os.environ["LOG_FILE"] = {str(log_file)!r}
+_configure_logging()
+structlog.get_logger("test").info(
+    "redaction.check",
+    peer="raw-peer-token",
+    recipient="raw-recipient-token",
+    message="raw-message-token",
+)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        cwd=str(Path(__file__).parent.parent.parent),
+    )
+
+    assert result.returncode == 0
+    assert "raw-peer-token" not in result.stdout
+    assert "raw-recipient-token" not in result.stdout
+    assert "raw-message-token" not in result.stdout
+
+    stdout_payload = json.loads(result.stdout)
+    assert stdout_payload["peer"] == "<recipient>"
+    assert stdout_payload["recipient"] == "<recipient>"
+    assert stdout_payload["message"] == "<private>"
+
+    log_text = log_file.read_text()
+    assert "raw-peer-token" not in log_text
+    assert "raw-recipient-token" not in log_text
+    assert "raw-message-token" not in log_text
+
+    file_payload = json.loads(log_text)
+    assert file_payload["peer"] == "<recipient>"
+    assert file_payload["recipient"] == "<recipient>"
+    assert file_payload["message"] == "<private>"
+
+
 def test_langsmith_guard_blocks_boot() -> None:
     """LANGSMITH_TRACING=true without ALLOW_PRIVATE_TRACE_EXPORT=true must exit 1."""
     result = _run_main({


### PR DESCRIPTION
Resolves #561

## Summary
- Added optional LOG_FILE stdlib logging so structured JSON events go to stdout and an operator-configured file.
- Mounted a host log directory into the app container and passed LOG_FILE through Compose.
- Added unit coverage for file logging while preserving stdout output.

## Test Plan
- python3 -m ruff check app/ tests/
- python3 -m mypy app/
- python3 -m pytest tests/unit/ -x
- DATABASE_URL not set; skipped python3 -m pytest tests/integration/ -x
- yamllint docker/compose.yaml
- git push hook ran shell/doc/Mermaid/workflow validations
- docker compose config not run: docker is not installed in this environment

Generated with Codex

Author-Session: codex/26487391469