### PR TITLE
fix(main): type _redact_private_log_fields to structlog.Processor signature

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -15,9 +15,9 @@ import asyncio
 import logging
 import os
 import sys
-from typing import Any
 
 import structlog
+from structlog.types import EventDict, WrappedLogger
 
 log = structlog.get_logger()
 
@@ -28,10 +28,10 @@ _PRIVATE_TEXT_LOG_FIELDS = frozenset(
 
 
 def _redact_private_log_fields(
-    _logger: Any,
+    _logger: WrappedLogger,
     _method_name: str,
-    event_dict: dict[str, Any],
-) -> dict[str, Any]:
+    event_dict: EventDict,
+) -> EventDict:
     """Redact private field values before logs reach stdout or file sinks."""
     for key in _RECIPIENT_LOG_FIELDS:
         if key in event_dict:


### PR DESCRIPTION
## Problem

`mypy app/main.py` on main was failing at line 99 with:

```
app/main.py:99: error: List item 3 has incompatible type
  "Callable[[Any, str, dict[str, Any]], dict[str, Any]]";
  expected
  "Callable[[Any, str, MutableMapping[str, Any]],
            Mapping[str, Any] | str | bytes | bytearray | tuple[Any, ...]]"
  [list-item]
```

This caused the `Python Validation Required` check to be red on main, which every open PR inherited.

## Fix

Switched `_redact_private_log_fields` to use `structlog.types.EventDict` and `WrappedLogger` instead of `dict[str, Any]` and `Any`. `EventDict` is `MutableMapping[str, Any]`, which satisfies both the broader input parameter and the wider return type that structlog's `Processor` alias expects.

Also removed the now-unused `from typing import Any` import.

No runtime behavior change.

## Test plan

- [x] `mypy app/main.py` — clean (no issues found in 1 source file)
- [x] `mypy app/` — clean (no issues found in 33 source files)
- [x] `ruff check app/ tests/` — all checks passed
- [x] `pytest tests/unit/ -x` — 121 passed