### PR TITLE
chore(docker): add postgresql-client to runtime image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ build/
 Thumbs.db
 .github-pat
 *.original.md
+gravwell.token

--- a/.gitignore
+++ b/.gitignore
@@ -66,4 +66,3 @@ build/
 Thumbs.db
 .github-pat
 *.original.md
-gravwell.token

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,6 +25,7 @@ WORKDIR /app
 # Runtime system deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libpq-dev \
+    postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy installed packages from builder


### PR DESCRIPTION
## Summary

Adds `psql` (PostgreSQL CLI) to the runtime Dockerfile so the devcontainer and production runtime can run ad-hoc SQL queries against the `hml_readonly` Postgres instances.

- Contributes ~10MB to image size
- Small, well-defined addition via Debian's `postgresql-client` package
- Enables interactive queries against read-only instances at ports 5433 (hml-test) and 5434 (hml-caroline)

## Test Plan

- [x] Docker build succeeds: `docker build -f docker/Dockerfile --target runtime -t hml-test:psql .`
- [x] psql binary available: `docker run --rm hml-test:psql psql --version` returns `psql (PostgreSQL) 17.10`
- [x] Builder stage unchanged (psql not needed at build time)