### PR TITLE
Fix reminder worker UUID row handling

### DIFF
--- a/app/scheduler/reminder_worker.py
+++ b/app/scheduler/reminder_worker.py
@@ -52,6 +52,13 @@ def _next_due_at(attempt: int) -> datetime:
     return _now() + timedelta(minutes=_BACKOFF_MINUTES[idx])
 
 
+def _coerce_uuid(value: Any) -> uuid.UUID:
+    """Accept psycopg-native UUID values and string-like UUID values."""
+    if isinstance(value, uuid.UUID):
+        return value
+    return uuid.UUID(str(value))
+
+
 async def _throttled_ops_alert(
     conn: psycopg.AsyncConnection[Any],
     alert_kind: str,
@@ -137,7 +144,7 @@ async def dispatch_due_reminders(
     failed_count = 0
 
     for row in rows:
-        rid = uuid.UUID(row["id"])
+        rid = _coerce_uuid(row["id"])
         peer = row["peer"]
         body = row["body"]
         notion_page_id = row["notion_page_id"]

--- a/tests/unit/test_reminder_worker.py
+++ b/tests/unit/test_reminder_worker.py
@@ -1,0 +1,76 @@
+"""Unit tests for the reminder delivery worker."""
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+class FakeConnection:
+    """Minimal async connection surface used by dispatch_due_reminders."""
+
+    def __init__(self) -> None:
+        self.commits = 0
+        self.rollbacks = 0
+        self.executed: list[tuple[str, tuple[Any, ...] | None]] = []
+
+    async def commit(self) -> None:
+        self.commits += 1
+
+    async def rollback(self) -> None:
+        self.rollbacks += 1
+
+    async def execute(
+        self,
+        query: str,
+        params: tuple[Any, ...] | None = None,
+    ) -> None:
+        self.executed.append((query, params))
+
+
+@pytest.mark.asyncio
+async def test_dispatch_due_reminders_accepts_native_uuid_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """psycopg maps Postgres UUID columns to uuid.UUID objects."""
+    from app.scheduler import reminder_worker
+    from app.tools import notion
+
+    reminder_id = uuid.uuid4()
+    idempotency_key = str(uuid.uuid4())
+    row = {
+        "id": reminder_id,
+        "peer": "<peer>",
+        "body": "Test reminder",
+        "notion_page_id": "<page-id>",
+        "idempotency_key": idempotency_key,
+        "attempt": 0,
+        "due_at": datetime.now(UTC) - timedelta(seconds=1),
+    }
+
+    async def fake_claim_due_reminders(
+        conn: Any,
+        worker_id: str,
+    ) -> list[dict[str, Any]]:
+        return [row]
+
+    monkeypatch.setattr(reminder_worker, "_claim_due_reminders", fake_claim_due_reminders)
+    complete_reminder = AsyncMock(return_value={})
+    monkeypatch.setattr(notion, "complete_reminder", complete_reminder)
+
+    signal_send = AsyncMock(return_value={"timestamp": 12345})
+    conn = FakeConnection()
+
+    await reminder_worker.dispatch_due_reminders(conn, signal_send_fn=signal_send)
+
+    signal_send.assert_awaited_once_with(
+        recipient="<peer>",
+        message="Test reminder",
+        idempotency_key=idempotency_key,
+    )
+    complete_reminder.assert_awaited_once_with("<page-id>", "sent")
+    assert conn.rollbacks == 0
+    assert any(params is not None and params[-1] == str(reminder_id) for _, params in conn.executed)


### PR DESCRIPTION
Resolves #570

## Summary
- Accept native psycopg UUID values when dispatching claimed reminder outbox rows.
- Add a unit regression test that returns a real uuid.UUID from the mocked claim path and verifies delivery continues.

## Test Plan
- `.venv/bin/ruff check app/ tests/`
- `.venv/bin/mypy app/`
- `.venv/bin/pytest tests/unit/ -x`
- `.venv/bin/pytest tests/integration/test_outbox.py -x` (skips without DATABASE_URL)
- `.venv/bin/pytest tests/integration/ -x` was attempted, but this environment fails earlier in an unrelated intake test due missing LangGraph/API auth configuration.

Generated with Codex

Author-Session: codex/26488648212