### PR TITLE
Wire reward reaction feedback loop

### DIFF
--- a/app/ingress/signal_listener.py
+++ b/app/ingress/signal_listener.py
@@ -62,8 +62,8 @@ def _extract_peer_and_text(envelope: dict[str, Any]) -> tuple[str, str] | None:
     return source, text
 
 
-def _extract_reaction(envelope: dict[str, Any]) -> tuple[str, str, int] | None:
-    """Extract (sender_e164, emoji, target_sent_timestamp) from a reaction.
+def _extract_reaction(envelope: dict[str, Any]) -> tuple[str, str, int, str] | None:
+    """Extract reaction feedback fields from a signal-cli envelope.
 
     Returns None for non-reaction envelopes, removed reactions, or malformed
     reaction payloads.
@@ -79,11 +79,23 @@ def _extract_reaction(envelope: dict[str, Any]) -> tuple[str, str, int] | None:
 
     source = outer.get("source", "")
     emoji = reaction.get("emoji", "")
+    target_author = reaction.get("targetAuthor", "")
     target_sent_timestamp = reaction.get("targetSentTimestamp")
-    if not source or not emoji or not isinstance(target_sent_timestamp, int):
+    if (
+        not source
+        or not emoji
+        or not target_author
+        or not isinstance(target_sent_timestamp, int)
+    ):
         return None
 
-    return source, emoji, target_sent_timestamp
+    return source, emoji, target_sent_timestamp, target_author
+
+
+def _target_author_matches_account(target_author: str, account: str | None) -> bool:
+    """Return whether a reaction targeted a bot-authored message."""
+    expected_account = account or os.environ.get("SIGNAL_ACCOUNT", "")
+    return bool(expected_account) and target_author == expected_account
 
 
 class SignalListener:
@@ -128,9 +140,13 @@ class SignalListener:
         ):
             reaction = _extract_reaction(envelope)
             if reaction is not None:
-                peer, emoji, target_sent_timestamp = reaction
+                peer, emoji, target_sent_timestamp, target_author = reaction
                 if peer not in self._authorized_peers:
                     log.warning("signal_listener.unauthorized_peer_dropped")
+                    continue
+
+                if not _target_author_matches_account(target_author, self._account):
+                    log.info("signal_listener.reaction_non_bot_target_dropped")
                     continue
 
                 from app.tools.rewards import record_reward_feedback
@@ -140,7 +156,7 @@ class SignalListener:
                     emoji=emoji,
                     target_sent_timestamp=target_sent_timestamp,
                 )
-                log.info("signal_listener.reaction_recorded", peer=peer[:4] + "***")
+                log.info("signal_listener.reaction_recorded")
                 continue
 
             result = _extract_peer_and_text(envelope)

--- a/app/ingress/signal_listener.py
+++ b/app/ingress/signal_listener.py
@@ -62,6 +62,30 @@ def _extract_peer_and_text(envelope: dict[str, Any]) -> tuple[str, str] | None:
     return source, text
 
 
+def _extract_reaction(envelope: dict[str, Any]) -> tuple[str, str, int] | None:
+    """Extract (sender_e164, emoji, target_sent_timestamp) from a reaction.
+
+    Returns None for non-reaction envelopes, removed reactions, or malformed
+    reaction payloads.
+    """
+    outer = envelope.get("envelope", {})
+    data_message = outer.get("dataMessage", {})
+    reaction = data_message.get("reaction")
+    if not isinstance(reaction, dict):
+        return None
+
+    if reaction.get("isRemove") is True:
+        return None
+
+    source = outer.get("source", "")
+    emoji = reaction.get("emoji", "")
+    target_sent_timestamp = reaction.get("targetSentTimestamp")
+    if not source or not emoji or not isinstance(target_sent_timestamp, int):
+        return None
+
+    return source, emoji, target_sent_timestamp
+
+
 class SignalListener:
     """Asyncio task that consumes signal-cli WebSocket and drives the graph."""
 
@@ -92,7 +116,7 @@ class SignalListener:
 
     async def run(self) -> None:
         """Main loop: consume WebSocket, route each message to the graph."""
-        graph = self._get_graph()
+        graph: Any | None = None
         log.info(
             "signal_listener.started",
             authorized_peer_count=len(self._authorized_peers),
@@ -102,6 +126,23 @@ class SignalListener:
             base_url=self._base_url,
             account=self._account,
         ):
+            reaction = _extract_reaction(envelope)
+            if reaction is not None:
+                peer, emoji, target_sent_timestamp = reaction
+                if peer not in self._authorized_peers:
+                    log.warning("signal_listener.unauthorized_peer_dropped")
+                    continue
+
+                from app.tools.rewards import record_reward_feedback
+
+                await record_reward_feedback(
+                    peer=peer,
+                    emoji=emoji,
+                    target_sent_timestamp=target_sent_timestamp,
+                )
+                log.info("signal_listener.reaction_recorded", peer=peer[:4] + "***")
+                continue
+
             result = _extract_peer_and_text(envelope)
             if result is None:
                 continue
@@ -115,6 +156,8 @@ class SignalListener:
             log.info("signal_listener.message_received", peer=peer[:4] + "***")
 
             try:
+                if graph is None:
+                    graph = self._get_graph()
                 await graph.ainvoke(
                     {"peer": peer, "incoming": text},
                     config={"configurable": {"thread_id": peer}},

--- a/app/tools/rewards.py
+++ b/app/tools/rewards.py
@@ -350,16 +350,40 @@ def _build_image_prompt(
     else:
         streak_str = f"exactly {streak_count} small glowing progress markers"
 
+    feedback_guidance = _feedback_prompt_guidance(feedback_history or [])
+    feedback_str = f" Reward feedback context: {feedback_guidance}" if feedback_guidance else ""
+
     prompt = (
         f"A {style} artwork in {palette} color palette. "
         f"Theme: {theme['theme']}. "
-        f"Mood: celebratory, uplifting, {humor} energy. "
+        f"Mood: celebratory, uplifting, {humor} energy.{feedback_str} "
         f"Include {streak_str} subtly integrated into the composition. "
         f"Professional quality, no text, no words, no letters.{avoid_str} "
         f"High resolution, clean composition."
     )
 
     return prompt
+
+
+def _feedback_prompt_guidance(feedback_history: list[dict[str, Any]]) -> str:
+    """Return short prompt guidance from recent reward feedback."""
+    if len(feedback_history) < 3:
+        return ""
+
+    positive_count = sum(1 for item in feedback_history if item.get("score", 0) > 0)
+    negative_count = sum(1 for item in feedback_history if item.get("score", 0) < 0)
+
+    if positive_count > negative_count:
+        return (
+            "User has positively responded to recent rewards; "
+            "lean energetic and celebratory."
+        )
+    if negative_count > positive_count:
+        return (
+            "User has given mixed/negative feedback recently; "
+            "be a bit more subdued."
+        )
+    return ""
 
 
 async def generate_reward_image(
@@ -623,13 +647,13 @@ async def record_reward_feedback(
     peer: str,
     emoji: str,
     target_sent_timestamp: int,
-    window_minutes: int = 60,
+    match_window_seconds: int = 30,
 ) -> bool:
     """Record user feedback on a recent reward via Signal reaction.
 
-    Looks up the most recent reward_manifests row for this peer where
-    delivered_at is within `window_minutes` of the reaction's target
-    timestamp. Updates feedback_score, feedback_emoji, and feedback_at.
+    Looks up the closest reward_manifests row for this peer where delivered_at
+    is within `match_window_seconds` of the reaction's target timestamp.
+    Updates feedback_score, feedback_emoji, and feedback_at.
 
     Returns True if a matching reward was found and updated, False if no
     match (e.g., reaction on a non-reward message, or outside the window).
@@ -653,20 +677,27 @@ async def record_reward_feedback(
 
     try:
         async with get_db_conn() as conn:
-            # Find the most recent unrated reward for this peer within the window.
+            # Find the closest unrated reward for this peer within the tight window.
             # Uses reward_manifests_peer_delivered_idx for efficiency.
             cur = await conn.execute(
                 """
                 SELECT id
                 FROM reward_manifests
                 WHERE peer = %s
-                  AND delivered_at <= %s
-                  AND delivered_at >= %s - (%s * interval '1 minute')
+                  AND delivered_at BETWEEN (%s - (%s * interval '1 second'))
+                                      AND (%s + (%s * interval '1 second'))
                   AND feedback_at IS NULL
-                ORDER BY delivered_at DESC
+                ORDER BY ABS(EXTRACT(EPOCH FROM (delivered_at - %s))) ASC
                 LIMIT 1
                 """,
-                (peer, target_dt, target_dt, window_minutes),
+                (
+                    peer,
+                    target_dt,
+                    match_window_seconds,
+                    target_dt,
+                    match_window_seconds,
+                    target_dt,
+                ),
             )
             row = await cur.fetchone()
             if row is None:
@@ -692,6 +723,53 @@ async def record_reward_feedback(
     except Exception:
         log.exception("record_reward_feedback.failed")
         return False
+
+
+async def load_feedback_history(peer: str, days: int = 90) -> list[dict[str, Any]]:
+    """Load recent reward feedback for prompt personalization.
+
+    Returns an empty list on DB failure so reward delivery can proceed with
+    neutral generation.
+    """
+    from app.tools.db import get_db_conn
+
+    try:
+        async with get_db_conn() as conn:
+            cur = await conn.execute(
+                """
+                SELECT feedback_score, feedback_emoji, feedback_at, intensity, reward_kind
+                FROM reward_manifests
+                WHERE peer = %s
+                  AND feedback_at IS NOT NULL
+                  AND feedback_at >= now() - (%s * interval '1 day')
+                ORDER BY feedback_at DESC
+                """,
+                (peer, days),
+            )
+            rows = await cur.fetchall()
+
+        history: list[dict[str, Any]] = []
+        for row in rows:
+            feedback_at = row["feedback_at"]
+            timestamp = (
+                feedback_at.isoformat()
+                if isinstance(feedback_at, datetime)
+                else str(feedback_at)
+            )
+            history.append(
+                {
+                    "score": row["feedback_score"],
+                    "emoji": row["feedback_emoji"],
+                    "timestamp": timestamp,
+                    "intensity": row["intensity"],
+                    "reward_kind": row["reward_kind"],
+                }
+            )
+        return history
+
+    except Exception:
+        log.warning("load_feedback_history.failed")
+        return []
 
 
 # ---------------------------------------------------------------------------
@@ -825,6 +903,11 @@ async def maybe_reward(
     image_path: str | None = None
     if intensity_label != "lightest" and not sensitive:
         prefs = (user_prefs or {}).get("rewards") if user_prefs else None
+        try:
+            feedback_history = await load_feedback_history(peer)
+        except Exception:
+            log.warning("maybe_reward.feedback_history_failed")
+            feedback_history = []
         image_path = await generate_reward_image(
             intensity=intensity_label,
             streak_count=1,  # Only current task available; intensity score still uses full streak
@@ -833,6 +916,7 @@ async def maybe_reward(
             energy_level=energy_required.lower(),
             sensitive_task=sensitive,
             user_prefs=prefs,
+            feedback_history=feedback_history,
         )
     elif sensitive:
         # Sensitive: muted emoji only (no image)

--- a/docs/reward-system.md
+++ b/docs/reward-system.md
@@ -388,7 +388,9 @@ Each reward delivery writes a row to the `reward_manifests` Postgres table. `app
 
 Unknown emojis are recorded with score 0 — the reaction is stored as a "received" signal but carries no positive or negative weight.
 
-**Lookup window:** `record_reward_feedback` matches the most recent unrated `reward_manifests` row for the peer where `delivered_at` falls within 60 minutes of the reaction's target message timestamp. The window is configurable per call.
+**Reaction routing:** Signal reaction envelopes are administrative events. The listener records feedback only when the sender is in `AUTHORIZED_PEERS` and the reaction target author matches the bot Signal account. Reactions do not invoke the LangGraph conversation path.
+
+**Lookup window:** `record_reward_feedback` converts Signal's target message timestamp from milliseconds to UTC and matches the closest unrated `reward_manifests` row for the peer where `delivered_at` falls within ±30 seconds of that target timestamp. The `match_window_seconds` value is configurable per call. This tight window accounts for local manifest-write time, send latency, and clock skew without attributing reactions on unrelated nearby messages to older rewards.
 
 **Storage:** Three columns on `reward_manifests`:
 
@@ -396,9 +398,15 @@ Unknown emojis are recorded with score 0 — the reaction is stored as a "receiv
 - `feedback_emoji` (TEXT) — the raw emoji character(s), stored verbatim
 - `feedback_at` (TIMESTAMPTZ) — when the reaction was recorded
 
-**Idempotency:** `feedback_at IS NULL` prevents double-counting. If a user reacts twice, only the first reaction for a given reward row is recorded. A later reaction may still match an older, unrated reward within the window.
+**Idempotency:** `feedback_at IS NULL` prevents double-counting. If a user reacts twice, only the first reaction for a given reward row is recorded. A later reaction may still match another unrated reward inside the tight timestamp window.
 
-**Weighting:** `apply_feedback_weight` (in `app/tools/rewards`) applies time-decaying scores from feedback history when selecting themes for new rewards. Feedback is intentionally bounded: aggregate weights are capped at ±0.5 so the result is a nudge, not a dictate, and novelty still matters.
+**Prompt personalization:** `load_feedback_history` loads recent rated rewards for the peer from the last 90 days. Image generation summarizes feedback only after at least three ratings:
+
+- More positive than negative ratings adds guidance to lean energetic and celebratory.
+- More negative than positive ratings adds guidance to be a bit more subdued.
+- Small or balanced samples add no feedback guidance.
+
+The prompt guidance is intentionally short and coarse so feedback nudges future rewards without turning one reaction into a hard preference.
 
 #### Novelty Mechanics
 

--- a/tests/unit/test_rewards.py
+++ b/tests/unit/test_rewards.py
@@ -17,11 +17,60 @@ import os
 import uuid
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+
+class _FakeCursor:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+
+    async def fetchone(self) -> dict[str, Any] | None:
+        return self._rows[0] if self._rows else None
+
+    async def fetchall(self) -> list[dict[str, Any]]:
+        return self._rows
+
+
+class _RewardFeedbackConn:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+        self.updated_ids: list[str] = []
+        self.updated_scores: list[int] = []
+
+    async def execute(self, query: str, params: tuple[Any, ...] | None = None) -> _FakeCursor:
+        if "SELECT id" in query:
+            assert params is not None
+            peer, target_dt, lower_seconds, upper_target_dt, upper_seconds, order_dt = params
+            assert target_dt == upper_target_dt == order_dt
+            candidates = [
+                row for row in self.rows
+                if row["peer"] == peer
+                and row["feedback_at"] is None
+                and target_dt - timedelta(seconds=lower_seconds)
+                <= row["delivered_at"]
+                <= target_dt + timedelta(seconds=upper_seconds)
+            ]
+            candidates.sort(key=lambda row: abs((row["delivered_at"] - order_dt).total_seconds()))
+            return _FakeCursor(candidates[:1])
+
+        if "UPDATE reward_manifests" in query:
+            assert params is not None
+            score, emoji, manifest_id = params
+            self.updated_ids.append(manifest_id)
+            self.updated_scores.append(score)
+            for row in self.rows:
+                if row["id"] == manifest_id:
+                    row["feedback_score"] = score
+                    row["feedback_emoji"] = emoji
+                    row["feedback_at"] = datetime.now(UTC)
+            return _FakeCursor([])
+
+        raise AssertionError(f"Unexpected query: {query}")
+
 
 # ---------------------------------------------------------------------------
 # PR-B5-T1: Sensitive-task suppression
@@ -254,6 +303,228 @@ class TestImageGenFallback:
         """Fallback reward pool must have at least 12 entries."""
         from app.tools.rewards import _FALLBACK_REWARDS
         assert len(_FALLBACK_REWARDS) >= 12
+
+
+# ---------------------------------------------------------------------------
+# Reward feedback reactions
+# ---------------------------------------------------------------------------
+
+class TestRewardFeedback:
+    """Signal reaction feedback must attribute only to the reacted-to reward."""
+
+    def test_emoji_score_mapping(self) -> None:
+        """Known feedback emojis map to positive, negative, or neutral scores."""
+        from app.tools.rewards import _FEEDBACK_EMOJI_SCORES
+
+        assert _FEEDBACK_EMOJI_SCORES["👍"] == 1
+        assert _FEEDBACK_EMOJI_SCORES["👎"] == -1
+        assert _FEEDBACK_EMOJI_SCORES.get("🤷", 0) == 0
+
+    @pytest.mark.asyncio
+    async def test_record_reward_feedback_matches_within_thirty_seconds(self) -> None:
+        """A reaction timestamp within the ±30s window updates that reward."""
+        from app.tools import rewards as rewards_module
+
+        target_dt = datetime(2026, 5, 27, 12, 0, 0, tzinfo=UTC)
+        conn = _RewardFeedbackConn([
+            {
+                "id": "manifest-1",
+                "peer": "<test-peer-10>",
+                "delivered_at": target_dt + timedelta(seconds=12),
+                "feedback_at": None,
+            }
+        ])
+
+        @asynccontextmanager
+        async def fake_get_db_conn() -> AsyncGenerator[_RewardFeedbackConn, None]:
+            yield conn
+
+        with patch("app.tools.db.get_db_conn", fake_get_db_conn):
+            result = await rewards_module.record_reward_feedback(
+                peer="<test-peer-10>",
+                emoji="👍",
+                target_sent_timestamp=int(target_dt.timestamp() * 1000),
+            )
+
+        assert result is True
+        assert conn.updated_ids == ["manifest-1"]
+        assert conn.updated_scores == [1]
+
+    @pytest.mark.asyncio
+    async def test_record_reward_feedback_outside_window_returns_false(self) -> None:
+        """A reaction outside ±30s must not update a reward."""
+        from app.tools import rewards as rewards_module
+
+        target_dt = datetime(2026, 5, 27, 12, 0, 0, tzinfo=UTC)
+        conn = _RewardFeedbackConn([
+            {
+                "id": "manifest-1",
+                "peer": "<test-peer-11>",
+                "delivered_at": target_dt - timedelta(seconds=31),
+                "feedback_at": None,
+            }
+        ])
+
+        @asynccontextmanager
+        async def fake_get_db_conn() -> AsyncGenerator[_RewardFeedbackConn, None]:
+            yield conn
+
+        with patch("app.tools.db.get_db_conn", fake_get_db_conn):
+            result = await rewards_module.record_reward_feedback(
+                peer="<test-peer-11>",
+                emoji="👍",
+                target_sent_timestamp=int(target_dt.timestamp() * 1000),
+            )
+
+        assert result is False
+        assert conn.updated_ids == []
+
+    @pytest.mark.asyncio
+    async def test_record_reward_feedback_chooses_closest_reward(self) -> None:
+        """When two rewards are near the timestamp, only the closest one is updated."""
+        from app.tools import rewards as rewards_module
+
+        target_dt = datetime(2026, 5, 27, 12, 0, 0, tzinfo=UTC)
+        conn = _RewardFeedbackConn([
+            {
+                "id": "manifest-older",
+                "peer": "<test-peer-12>",
+                "delivered_at": target_dt - timedelta(seconds=25),
+                "feedback_at": None,
+            },
+            {
+                "id": "manifest-closest",
+                "peer": "<test-peer-12>",
+                "delivered_at": target_dt + timedelta(seconds=2),
+                "feedback_at": None,
+            },
+        ])
+
+        @asynccontextmanager
+        async def fake_get_db_conn() -> AsyncGenerator[_RewardFeedbackConn, None]:
+            yield conn
+
+        with patch("app.tools.db.get_db_conn", fake_get_db_conn):
+            result = await rewards_module.record_reward_feedback(
+                peer="<test-peer-12>",
+                emoji="👎",
+                target_sent_timestamp=int(target_dt.timestamp() * 1000),
+            )
+
+        assert result is True
+        assert conn.updated_ids == ["manifest-closest"]
+        assert conn.updated_scores == [-1]
+
+    @pytest.mark.asyncio
+    async def test_load_feedback_history_returns_recent_feedback(self) -> None:
+        """Feedback history is normalized into prompt-friendly dictionaries."""
+        from app.tools import rewards as rewards_module
+
+        feedback_at = datetime(2026, 5, 27, 12, 5, 0, tzinfo=UTC)
+        rows = [
+            {
+                "feedback_score": 1,
+                "feedback_emoji": "👍",
+                "feedback_at": feedback_at,
+                "intensity": "high",
+                "reward_kind": "emoji+image",
+            }
+        ]
+        mock_conn = MagicMock()
+        mock_conn.execute = AsyncMock(return_value=_FakeCursor(rows))
+
+        @asynccontextmanager
+        async def fake_get_db_conn() -> AsyncGenerator[MagicMock, None]:
+            yield mock_conn
+
+        with patch("app.tools.db.get_db_conn", fake_get_db_conn):
+            result = await rewards_module.load_feedback_history("<test-peer-13>")
+
+        assert result == [
+            {
+                "score": 1,
+                "emoji": "👍",
+                "timestamp": feedback_at.isoformat(),
+                "intensity": "high",
+                "reward_kind": "emoji+image",
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_maybe_reward_passes_feedback_history_to_image_generation(self) -> None:
+        """maybe_reward loads peer feedback and forwards it into image generation."""
+        from app.tools import rewards as rewards_module
+
+        history = [
+            {"score": 1, "timestamp": "2026-05-27T12:00:00+00:00"},
+            {"score": 1, "timestamp": "2026-05-26T12:00:00+00:00"},
+            {"score": 1, "timestamp": "2026-05-25T12:00:00+00:00"},
+        ]
+        image_mock = AsyncMock(return_value="/tmp/reward_artifacts/test-image.png")
+
+        with (
+            patch.object(rewards_module, "load_feedback_history", new=AsyncMock(return_value=history)) as load_mock,
+            patch.object(rewards_module, "generate_reward_image", new=image_mock),
+            patch.object(rewards_module, "write_reward_manifest", new=AsyncMock(return_value=uuid.uuid4())),
+            patch.object(rewards_module, "compute_intensity", return_value=("high", 70)),
+        ):
+            await rewards_module.maybe_reward(
+                peer="<test-peer-14>",
+                task_title="Placeholder task title",
+                notion_page_id="<page-id-014>",
+                streak=3,
+                energy_required="High",
+                time_estimate=45,
+            )
+
+        load_mock.assert_awaited_once_with("<test-peer-14>")
+        assert image_mock.await_args.kwargs["feedback_history"] == history
+
+    @pytest.mark.asyncio
+    async def test_maybe_reward_continues_if_feedback_history_raises(self) -> None:
+        """A feedback history failure must not block reward delivery."""
+        from app.tools import rewards as rewards_module
+
+        async def crashing_history(_peer: str) -> list[dict[str, Any]]:
+            raise RuntimeError("DB unavailable")
+
+        image_mock = AsyncMock(return_value="/tmp/reward_artifacts/test-image.png")
+
+        with (
+            patch.object(rewards_module, "load_feedback_history", new=crashing_history),
+            patch.object(rewards_module, "generate_reward_image", new=image_mock),
+            patch.object(rewards_module, "write_reward_manifest", new=AsyncMock(return_value=uuid.uuid4())),
+            patch.object(rewards_module, "compute_intensity", return_value=("high", 70)),
+        ):
+            result = await rewards_module.maybe_reward(
+                peer="<test-peer-15>",
+                task_title="Placeholder task title",
+                notion_page_id="<page-id-015>",
+                streak=3,
+                energy_required="High",
+                time_estimate=45,
+            )
+
+        assert result["attachment_path"] == "/tmp/reward_artifacts/test-image.png"
+        assert image_mock.await_args.kwargs["feedback_history"] == []
+
+    def test_build_image_prompt_includes_positive_feedback_guidance(self) -> None:
+        """Three or more positive ratings add prompt guidance for future images."""
+        from app.tools.rewards import _build_image_prompt
+
+        prompt = _build_image_prompt(
+            intensity="high",
+            streak_count=3,
+            task_descriptions=["Placeholder task title"],
+            feedback_history=[
+                {"score": 1},
+                {"score": 1},
+                {"score": 1},
+            ],
+        )
+
+        assert "User has positively responded to recent rewards" in prompt
+        assert "lean energetic and celebratory" in prompt
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_signal_listener_auth.py
+++ b/tests/unit/test_signal_listener_auth.py
@@ -23,6 +23,29 @@ def _envelope(source: str, message: str) -> dict[str, Any]:
     }
 
 
+def _reaction_envelope(
+    source: str,
+    emoji: str = "👍",
+    target_sent_timestamp: int = 1_716_800_000_000,
+    *,
+    is_remove: bool = False,
+) -> dict[str, Any]:
+    """Build a minimal signal-cli reaction envelope for tests."""
+    return {
+        "envelope": {
+            "source": source,
+            "dataMessage": {
+                "reaction": {
+                    "emoji": emoji,
+                    "targetAuthor": "+15559876543",
+                    "targetSentTimestamp": target_sent_timestamp,
+                    "isRemove": is_remove,
+                }
+            },
+        }
+    }
+
+
 async def _async_gen(envelopes: list[dict[str, Any]]):
     for env in envelopes:
         yield env
@@ -53,6 +76,29 @@ def test_load_authorized_peers_parses_comma_list(monkeypatch: pytest.MonkeyPatch
 
     peers = _load_authorized_peers()
     assert peers == frozenset({"+15551234567", "+15559876543"})
+
+
+def test_extract_reaction_parses_signal_payload() -> None:
+    """Signal reaction envelopes parse into peer, emoji, and target timestamp."""
+    from app.ingress.signal_listener import _extract_reaction
+
+    result = _extract_reaction(_reaction_envelope("+15551234567"))
+
+    assert result == ("+15551234567", "👍", 1_716_800_000_000)
+
+
+def test_extract_reaction_skips_removed_reaction() -> None:
+    """Un-react events must not be recorded as feedback."""
+    from app.ingress.signal_listener import _extract_reaction
+
+    assert _extract_reaction(_reaction_envelope("+15551234567", is_remove=True)) is None
+
+
+def test_extract_reaction_returns_none_for_text_message() -> None:
+    """Text messages fall through to the normal graph path."""
+    from app.ingress.signal_listener import _extract_reaction
+
+    assert _extract_reaction(_envelope("+15551234567", "hello")) is None
 
 
 def test_listener_construct_fails_without_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -108,6 +154,56 @@ async def test_unauthorized_peer_silently_dropped() -> None:
         await listener.run()
 
     # Graph never reached — the silent drop must happen before invocation.
+    graph.ainvoke.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_authorized_reaction_records_feedback_without_graph() -> None:
+    """Authorized reactions are routed to the feedback handler, not the graph."""
+    from app.ingress.signal_listener import SignalListener
+
+    graph = AsyncMock()
+    listener = SignalListener(
+        graph=graph,
+        authorized_peers=frozenset({"+15551234567"}),
+    )
+
+    record_feedback = AsyncMock(return_value=True)
+    envelopes = [_reaction_envelope("+15551234567", emoji="👍")]
+    with (
+        patch("app.ingress.signal_listener.receive_messages", return_value=_async_gen(envelopes)),
+        patch("app.tools.rewards.record_reward_feedback", new=record_feedback),
+    ):
+        await listener.run()
+
+    record_feedback.assert_awaited_once_with(
+        peer="+15551234567",
+        emoji="👍",
+        target_sent_timestamp=1_716_800_000_000,
+    )
+    graph.ainvoke.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_reaction_dropped_before_feedback_handler() -> None:
+    """Unauthorized reactions must not reach record_reward_feedback."""
+    from app.ingress.signal_listener import SignalListener
+
+    graph = AsyncMock()
+    listener = SignalListener(
+        graph=graph,
+        authorized_peers=frozenset({"+15551234567"}),
+    )
+
+    record_feedback = AsyncMock(return_value=True)
+    envelopes = [_reaction_envelope("+19990001111", emoji="👍")]
+    with (
+        patch("app.ingress.signal_listener.receive_messages", return_value=_async_gen(envelopes)),
+        patch("app.tools.rewards.record_reward_feedback", new=record_feedback),
+    ):
+        await listener.run()
+
+    record_feedback.assert_not_awaited()
     graph.ainvoke.assert_not_awaited()
 
 

--- a/tests/unit/test_signal_listener_auth.py
+++ b/tests/unit/test_signal_listener_auth.py
@@ -27,6 +27,7 @@ def _reaction_envelope(
     source: str,
     emoji: str = "👍",
     target_sent_timestamp: int = 1_716_800_000_000,
+    target_author: str = "+15559876543",
     *,
     is_remove: bool = False,
 ) -> dict[str, Any]:
@@ -37,7 +38,7 @@ def _reaction_envelope(
             "dataMessage": {
                 "reaction": {
                     "emoji": emoji,
-                    "targetAuthor": "+15559876543",
+                    "targetAuthor": target_author,
                     "targetSentTimestamp": target_sent_timestamp,
                     "isRemove": is_remove,
                 }
@@ -84,7 +85,7 @@ def test_extract_reaction_parses_signal_payload() -> None:
 
     result = _extract_reaction(_reaction_envelope("+15551234567"))
 
-    assert result == ("+15551234567", "👍", 1_716_800_000_000)
+    assert result == ("+15551234567", "👍", 1_716_800_000_000, "+15559876543")
 
 
 def test_extract_reaction_skips_removed_reaction() -> None:
@@ -181,6 +182,36 @@ async def test_authorized_reaction_records_feedback_without_graph() -> None:
         emoji="👍",
         target_sent_timestamp=1_716_800_000_000,
     )
+    graph.ainvoke.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_authorized_reaction_to_non_bot_message_dropped() -> None:
+    """Reactions to messages not authored by the bot must not record feedback."""
+    from app.ingress.signal_listener import SignalListener
+
+    graph = AsyncMock()
+    listener = SignalListener(
+        graph=graph,
+        account="+15559876543",
+        authorized_peers=frozenset({"+15551234567"}),
+    )
+
+    record_feedback = AsyncMock(return_value=True)
+    envelopes = [
+        _reaction_envelope(
+            "+15551234567",
+            emoji="👍",
+            target_author="+15550000000",
+        )
+    ]
+    with (
+        patch("app.ingress.signal_listener.receive_messages", return_value=_async_gen(envelopes)),
+        patch("app.tools.rewards.record_reward_feedback", new=record_feedback),
+    ):
+        await listener.run()
+
+    record_feedback.assert_not_awaited()
     graph.ainvoke.assert_not_awaited()
 
 


### PR DESCRIPTION
Resolves #572

## Summary
- Parse Signal reaction envelopes in the listener and route authorized reactions to reward feedback without invoking LangGraph
- Tighten reward attribution to the reacted-to message timestamp with a ±30s match window
- Load recent reward feedback into image generation and add prompt guidance for positive or negative feedback trends
- Add unit coverage for reaction parsing, authorization, attribution windows, history loading, and prompt guidance

## Test Plan
- .venv/bin/ruff check app/ tests/
- .venv/bin/mypy app/
- .venv/bin/pytest tests/unit/ -x
- Integration tests skipped: DATABASE_URL is not set
- Pre-push hook passed script/doc/Mermaid/workflow validations

Generated with Codex

Author-Session: codex/26488863717