### PR TITLE
fix(tests): resolve ruff lint and asyncio compat issues post-observability merge

### DIFF
--- a/tests/integration/test_llm_callback_integration.py
+++ b/tests/integration/test_llm_callback_integration.py
@@ -19,7 +19,6 @@ from unittest.mock import MagicMock, patch
 
 from app.observability.llm_callback import LLMObservabilityCallback
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -160,7 +159,7 @@ def test_ainvoke_triggers_callback_events() -> None:
         run_id = uuid.uuid4()
 
         from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
-        from langchain_core.outputs import ChatGeneration, ChatResult
+        from langchain_core.outputs import ChatGeneration
 
         async def _simulate_call() -> None:
             await handler.on_chat_model_start(

--- a/tests/unit/test_conversation_context.py
+++ b/tests/unit/test_conversation_context.py
@@ -123,7 +123,7 @@ class TestClassifyIntentUsesHistory:
                 captured["msgs"] = msgs
                 return _FakeResp()
 
-        def _fake_llm(_tier: str) -> Any:
+        def _fake_llm(_tier: str, **_kwargs: Any) -> Any:
             return _FakeModel()
 
         prior = [
@@ -160,7 +160,7 @@ class TestClassifyIntentUsesHistory:
                 captured["msgs"] = msgs
                 return _FakeResp()
 
-        def _fake_llm(_tier: str) -> Any:
+        def _fake_llm(_tier: str, **_kwargs: Any) -> Any:
             return _FakeModel()
 
         state = _base_state(incoming="Hello", messages=[])

--- a/tests/unit/test_llm_callback.py
+++ b/tests/unit/test_llm_callback.py
@@ -22,7 +22,6 @@ from app.observability.llm_callback import (
     _safe_int,
 )
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -112,7 +111,7 @@ def test_on_chat_model_start_records_start_time() -> None:
         log_events.append(dict(event_dict))
         return event_dict
 
-    with patch("app.observability.llm_callback.log") as mock_log:
+    with patch("app.observability.llm_callback.log"):
         asyncio.run(handler.on_chat_model_start(
             serialized={},
             messages=[[MagicMock(), MagicMock()]],

--- a/tests/unit/test_perf_harness.py
+++ b/tests/unit/test_perf_harness.py
@@ -15,7 +15,6 @@ import pytest
 
 from tests.perf.test_llm_perf import aggregate_latencies, aggregate_tokens
 
-
 # ---------------------------------------------------------------------------
 # aggregate_latencies
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_rewards.py
+++ b/tests/unit/test_rewards.py
@@ -290,7 +290,7 @@ class TestImageGenFallback:
         env = dict(os.environ)
         env.pop("OPENAI_API_KEY", None)
         with patch.dict(os.environ, env, clear=True):
-            result = asyncio.get_event_loop().run_until_complete(
+            result = asyncio.run(
                 generate_reward_image(
                     intensity="medium",
                     streak_count=2,
@@ -305,10 +305,10 @@ class TestImageGenFallback:
         import asyncio
         import base64
         import tempfile
-        from unittest.mock import AsyncMock as _AsyncMock, MagicMock as _MagicMock
+        from unittest.mock import AsyncMock as _AsyncMock
+        from unittest.mock import MagicMock as _MagicMock
 
         from app.tools.rewards import generate_reward_image
-        import app.tools.rewards as rewards_module
 
         fake_b64 = base64.b64encode(b"fake-image-bytes").decode()
         fake_image = _MagicMock()
@@ -325,7 +325,7 @@ class TestImageGenFallback:
             with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key", "REWARD_ARTIFACTS_DIR": tmpdir}):
                 with patch("app.tools.rewards.log") as mock_log:
                     with patch("openai.AsyncOpenAI", mock_openai_cls):
-                        result = asyncio.get_event_loop().run_until_complete(
+                        result = asyncio.run(
                             generate_reward_image(
                                 intensity="medium",
                                 streak_count=1,


### PR DESCRIPTION
## Summary

- `test_conversation_context`: two `_fake_llm()` mocks rejected `caller=` kwarg from `llm("medium", caller="classify")` — added `**_kwargs`
- `test_rewards`: `asyncio.get_event_loop().run_until_complete()` raises `RuntimeError` in Python 3.12 with no current event loop; replaced with `asyncio.run()` in both affected tests (pre-existing + fixer-added)
- `test_rewards`: removed unused `app.tools.rewards as rewards_module` import; split combined `AsyncMock, MagicMock` import onto two lines for ruff I001 compliance
- `test_llm_callback`: removed `as mock_log` assignment (F841 unused variable); fixed import sort (I001)
- `test_llm_callback_integration`: removed unused `ChatResult` import (F401); fixed blank line causing I001
- `test_perf_harness`: fixed import sort order (I001)

All 191 unit tests pass locally after these fixes. Ruff clean.

## Test plan

- [ ] Ruff Lint passes
- [ ] Pytest Unit Tests passes (191 tests)
- [ ] Mypy Type Check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)