### PR TITLE
Add /review fallback hint to PR templates

### DIFF
--- a/.github/ci/prompts/claude-resolve-issue.md
+++ b/.github/ci/prompts/claude-resolve-issue.md
@@ -64,6 +64,10 @@ gh pr create --title '<brief description of what this PR accomplishes>' \
 ## Test Plan
 <how to verify the fix>
 
+## Review Pipeline Fallback
+If review pipeline checks do not appear within 2 minutes of opening this PR,
+comment `/review` on the PR to manually trigger a fresh review cycle.
+
 Generated with Claude Code
 
 Author-Session: claude/${RUN_ID}' \

--- a/.github/ci/prompts/codex-resolve-issue.md
+++ b/.github/ci/prompts/codex-resolve-issue.md
@@ -64,6 +64,10 @@ gh pr create --title '<brief description of what this PR accomplishes>' \
 ## Test Plan
 <how to verify the fix>
 
+## Review Pipeline Fallback
+If review pipeline checks do not appear within 2 minutes of opening this PR,
+comment `/review` on the PR to manually trigger a fresh review cycle.
+
 Generated with Codex
 
 Author-Session: codex/${RUN_ID}' \

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## Summary
+
+## Test Plan
+
+## Review Pipeline Fallback
+If review pipeline checks do not appear within 2 minutes of opening this PR,
+comment `/review` on the PR to manually trigger a fresh review cycle.

--- a/DEV-AGENTS.md
+++ b/DEV-AGENTS.md
@@ -94,6 +94,7 @@ Support dev pipeline. Edit directly via PRs — any contributor or agent (Claude
 
 - `.github/workflows/` — GitHub Actions workflow definitions
 - `.github/actions/` — Composite actions used by workflows
+- `.github/pull_request_template.md` — Default PR body template, including the `/review` fallback hint for missing initial review checks
 - `.github/actions/review-claude-run/` — Direct-`docker run` composite invoking Claude Code against the LiteLLM Anthropic endpoint; v2 pipeline single-writer fixer (fresh-Claude fallback path for human-authored PRs)
 - `.github/actions/review-codex-resume/` — Composite that resumes the original `resolve-issue` Codex author session as the v2 fixer; bind-mounts the persisted session into `/home/ci/.codex` and runs `codex exec resume --last`
 - `.github/actions/review-claude-resume/` — Composite that resumes the original `resolve-issue` Claude Code author session as the v2 fixer; bind-mounts the persisted session into `/home/ci/.claude` and runs `claude --continue`


### PR DESCRIPTION
Resolves #582

## Summary
- Added a review pipeline fallback section to Codex and Claude generated PR bodies.
- Added a repository PR template so manually opened PRs also tell authors to comment `/review` if checks do not appear within 2 minutes.

## Test Plan
- `git diff --check`
- `scripts/check-doc-links.sh`
- pre-push hook on `git push -u origin codex/issue-582`

Generated with Codex

Author-Session: codex/26517806539