### PR TITLE
fix(review): unstick v2 fixer when prompt prose collides with schema name

### DIFF
--- a/.github/actions/review-claude-resume/run-in-container.sh
+++ b/.github/actions/review-claude-resume/run-in-container.sh
@@ -46,6 +46,23 @@ timeout 30m claude -p \
   < /dev/null 2>&1 \
   | tee "$OUTPUT_LOG_PATH"
 
+# Salvage block: if the prompt wrote a near-miss filename instead of
+# $OUTPUT_PATH (e.g. fix-result.json because the schema is named
+# fix-result-v1.json), rename it into place with a loud warning.
+# Bounded allow-list — silently masking arbitrary filenames would
+# hide real bugs. The warning is the canary; the real cure is to
+# tighten the prompt so the agent uses $OUTPUT_PATH unambiguously.
+if [ ! -s "$OUTPUT_PATH" ]; then
+  OUTPUT_DIR=$(dirname "$OUTPUT_PATH")
+  for candidate in "$OUTPUT_DIR/fix-result.json" "$OUTPUT_DIR/result.json"; do
+    if [ -s "$candidate" ] && [ "$candidate" != "$OUTPUT_PATH" ]; then
+      echo "::warning::review-claude-resume: prompt wrote $(basename "$candidate") instead of $(basename "$OUTPUT_PATH"); normalizing. Tighten the prompt to remove the ambiguity."
+      mv "$candidate" "$OUTPUT_PATH"
+      break
+    fi
+  done
+fi
+
 if [ ! -s "$OUTPUT_PATH" ]; then
   echo "::error::review-claude-resume: prompt did not produce $OUTPUT_PATH"
   exit 1

--- a/.github/actions/review-claude-run/run-in-container.sh
+++ b/.github/actions/review-claude-run/run-in-container.sh
@@ -40,6 +40,23 @@ timeout 30m claude -p \
   < /dev/null 2>&1 \
   | tee "$OUTPUT_LOG_PATH"
 
+# Salvage block: if the prompt wrote a near-miss filename instead of
+# $OUTPUT_PATH (e.g. fix-result.json because the schema is named
+# fix-result-v1.json), rename it into place with a loud warning.
+# Bounded allow-list — silently masking arbitrary filenames would
+# hide real bugs. The warning is the canary; the real cure is to
+# tighten the prompt so the agent uses $OUTPUT_PATH unambiguously.
+if [ ! -s "$OUTPUT_PATH" ]; then
+  OUTPUT_DIR=$(dirname "$OUTPUT_PATH")
+  for candidate in "$OUTPUT_DIR/fix-result.json" "$OUTPUT_DIR/result.json"; do
+    if [ -s "$candidate" ] && [ "$candidate" != "$OUTPUT_PATH" ]; then
+      echo "::warning::review-claude-run: prompt wrote $(basename "$candidate") instead of $(basename "$OUTPUT_PATH"); normalizing. Tighten the prompt to remove the ambiguity."
+      mv "$candidate" "$OUTPUT_PATH"
+      break
+    fi
+  done
+fi
+
 if [ ! -s "$OUTPUT_PATH" ]; then
   echo "::error::review-claude-run: prompt did not produce $OUTPUT_PATH"
   exit 1

--- a/.github/actions/review-codex-resume/run-in-container.sh
+++ b/.github/actions/review-codex-resume/run-in-container.sh
@@ -46,6 +46,23 @@ timeout 30m codex exec resume \
   < /dev/null 2>&1 \
   | tee "$OUTPUT_LOG_PATH"
 
+# Salvage block: if the prompt wrote a near-miss filename instead of
+# $OUTPUT_PATH (e.g. fix-result.json because the schema is named
+# fix-result-v1.json), rename it into place with a loud warning.
+# Bounded allow-list — silently masking arbitrary filenames would
+# hide real bugs. The warning is the canary; the real cure is to
+# tighten the prompt so the agent uses $OUTPUT_PATH unambiguously.
+if [ ! -s "$OUTPUT_PATH" ]; then
+  OUTPUT_DIR=$(dirname "$OUTPUT_PATH")
+  for candidate in "$OUTPUT_DIR/fix-result.json" "$OUTPUT_DIR/result.json"; do
+    if [ -s "$candidate" ] && [ "$candidate" != "$OUTPUT_PATH" ]; then
+      echo "::warning::review-codex-resume: prompt wrote $(basename "$candidate") instead of $(basename "$OUTPUT_PATH"); normalizing. Tighten the prompt to remove the ambiguity."
+      mv "$candidate" "$OUTPUT_PATH"
+      break
+    fi
+  done
+fi
+
 if [ ! -s "$OUTPUT_PATH" ]; then
   echo "::error::review-codex-resume: prompt did not produce $OUTPUT_PATH"
   exit 1

--- a/.github/scripts/review/prompts/fixer-resume.md
+++ b/.github/scripts/review/prompts/fixer-resume.md
@@ -80,7 +80,7 @@ resolve them all.
    ```bash
    find "${REVIEWER_ARTIFACTS_DIR}" -name '*-result.json'
    ```
-2. No reviewer files or unparseable → no edits. Write a no-op fix result
+2. No reviewer files or unparseable → no edits. Write a no-op result
    to `$OUTPUT_PATH` and stop.
 3. Read every blocker. Categorize each as real / misread / out-of-scope.
 4. Apply real-blocker fixes at the level you originally decided. If a
@@ -100,7 +100,7 @@ resolve them all.
    - The `Author-Session: <agent>/<run-id>` trailer — the next cycle
      reads it to resume you again.
 6. Leave file changes unstaged. Host step commits.
-7. Write fix-result JSON to `$OUTPUT_PATH`.
+7. Write the result as JSON to `$OUTPUT_PATH`.
 
 ## Output contract
 

--- a/.github/scripts/review/prompts/fixer.md
+++ b/.github/scripts/review/prompts/fixer.md
@@ -54,7 +54,7 @@ Same `.git/`-touch prohibition applies: edit files only, do not run `git add`/`m
    ```bash
    find "${REVIEWER_ARTIFACTS_DIR}" -name '*-result.json'
    ```
-2. No reviewer result files, or artifact unparseable → no edits. Write no-op fix result to `$OUTPUT_PATH` and stop.
+2. No reviewer result files, or artifact unparseable → no edits. Write a no-op result to `$OUTPUT_PATH` and stop.
 3. **Scan + group.** Read ALL blockers from ALL reviewer artifacts first. Group blockers that share one conceptual fix — same root cause, same type of change needed across files (e.g., multiple reviewers flagging "docs say X but code says Y" in different files). Ungrouped blockers stay individual.
 4. **Safety gate.** Per group or individual blocker:
 
@@ -78,7 +78,7 @@ Same `.git/`-touch prohibition applies: edit files only, do not run `git add`/`m
 
 ## Output contract
 
-Write fix-result JSON to `$OUTPUT_PATH`, conforming to `.github/scripts/review/schema/fix-result-v1.json`:
+Write the result as JSON to `$OUTPUT_PATH`, conforming to `.github/scripts/review/schema/fix-result-v1.json`:
 
 ```json
 {

--- a/.github/workflows/review-fixer.yml
+++ b/.github/workflows/review-fixer.yml
@@ -37,7 +37,7 @@ on:
         description: 'SHA after fixer push (== reviewed_sha if no-op)'
         value: ${{ jobs.fix.outputs.new_sha }}
       fix_artifact_name:
-        description: 'Artifact name containing fix-result.json'
+        description: 'Artifact name containing fixer-result.json'
         value: ${{ jobs.fix.outputs.fix_artifact_name }}
     secrets:
       WORKFLOW_PAT:
@@ -146,10 +146,15 @@ jobs:
         # fixer-output.jsonl owned by the runner UID (1001). The Codex
         # fixer runs as UID 1000 inside the container and can't
         # overwrite them. Remove stale files so the fixer starts clean.
+        # Also remove near-miss filenames the salvage block may consume
+        # (fix-result.json, result.json) so a stale artifact from a
+        # prior failed run can't be promoted into fixer-result.json.
         run: |
           rm -f "${PR_WORKSPACE_PATH}/.review-output/fixer-result.json" \
                 "${PR_WORKSPACE_PATH}/.review-output/fixer-output.jsonl" \
-                "${PR_WORKSPACE_PATH}/.review-output/write-test"
+                "${PR_WORKSPACE_PATH}/.review-output/write-test" \
+                "${PR_WORKSPACE_PATH}/.review-output/fix-result.json" \
+                "${PR_WORKSPACE_PATH}/.review-output/result.json"
 
       - name: Create directories for devcontainer mounts
         run: mkdir -p ~/.config/gh ~/.claude ~/.codex

--- a/docs/agentic-pipeline-learnings.md
+++ b/docs/agentic-pipeline-learnings.md
@@ -59,7 +59,7 @@ Per-row state is post-fixer: each row cross-references the reviewer's `blocking_
 **Before:** Post-merge follow-ups failed with "could not fetch ref".
 **Evidence:** #308, #351, #353, #354
 
-**Manual regression playbook:** Open PR, let `review-entry.yml` freeze `reviewed_sha`, push another commit before `review-fixer.yml` reaches push step. Fixer should log that `origin/<head_ref>` moved, rewrite `fix-result.json` so `new_sha == input_sha == reviewed_sha`, add `skipped[]` reason, exit without pushing. Judge/finalize should evaluate unchanged reviewed tree instead of overwriting newer commit.
+**Manual regression playbook:** Open PR, let `review-entry.yml` freeze `reviewed_sha`, push another commit before `review-fixer.yml` reaches push step. Fixer should log that `origin/<head_ref>` moved, rewrite `fixer-result.json` so `new_sha == input_sha == reviewed_sha`, add `skipped[]` reason, exit without pushing. Judge/finalize should evaluate unchanged reviewed tree instead of overwriting newer commit.
 
 ### 1.8 Dedupe workflow-failure issues by fingerprint
 **Why:** Helper script fingerprints failures by (workflow, branch, commit) and reuses existing open issue.

--- a/tests/unit/test_fixer_prompt_output_path.py
+++ b/tests/unit/test_fixer_prompt_output_path.py
@@ -74,3 +74,20 @@ def test_no_hard_coded_output_filename(prompt_path: Path) -> None:
         f"This conflicts with $OUTPUT_PATH and risks the same misread that "
         f"caused PR #574 to stall. Reference $OUTPUT_PATH only."
     )
+
+
+@pytest.mark.parametrize("prompt_path", _fixer_prompt_files(), ids=lambda p: p.name)
+def test_output_contract_references_output_path(prompt_path: Path) -> None:
+    """The output-write instruction must reference $OUTPUT_PATH.
+
+    A prompt that avoids 'fix-result JSON' and hard-coded paths but also
+    omits '$OUTPUT_PATH' from the write instruction still leaves the
+    same artifact-discovery failure mode open: the agent has no canonical
+    destination and may invent a filename.
+    """
+    text = prompt_path.read_text()
+    assert "$OUTPUT_PATH" in text, (
+        f"{prompt_path.name} does not reference $OUTPUT_PATH. "
+        f"The output contract section must instruct the agent to write the "
+        f"result JSON to $OUTPUT_PATH so the host runner can locate the artifact."
+    )

--- a/tests/unit/test_fixer_prompt_output_path.py
+++ b/tests/unit/test_fixer_prompt_output_path.py
@@ -1,0 +1,76 @@
+"""Structural lint: v2 fixer prompts must not name the output file in prose.
+
+The fixer schema is named `fix-result-v1.json` and the fixer-role action sets
+`OUTPUT_PATH=.review-output/fixer-result.json`. Prose like "Write fix-result
+JSON to $OUTPUT_PATH" reads as a filename hint to the model, which has caused
+it to write `fix-result.json` instead of resolving the env var. The host then
+fails to find the expected file and the review pipeline stalls at NO-GO with
+no human-actionable signal.
+
+These tests enforce the lessons:
+  1. No fixer prompt may contain the phrase `fix-result JSON` (the bug-prone
+     phrasing that caused the original incident).
+  2. The output contract section must reference `$OUTPUT_PATH` and must not
+     hard-code a literal `.review-output/...result.json` path. Hard-coding a
+     literal filename anywhere near the contract block invites the same
+     misread.
+
+Scope: `.github/scripts/review/prompts/fixer*.md`. Reviewer prompts don't
+exhibit this bug class (different schema basename, different prose) and are
+out of scope.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).parent.parent.parent
+_PROMPTS_DIR = _REPO_ROOT / ".github" / "scripts" / "review" / "prompts"
+
+# Matches "fix-result JSON" with arbitrary whitespace between the two tokens,
+# case-insensitive. Crucially does NOT match the schema reference
+# "fix-result-v1.json" — that has a hyphenated version suffix, not whitespace.
+_BUG_PRONE_PHRASE = re.compile(r"\bfix-result\s+JSON\b", re.IGNORECASE)
+
+# Matches any hard-coded .review-output/*.json filename in the prompt prose.
+# The contract should always reference $OUTPUT_PATH instead.
+_HARD_CODED_OUTPUT_PATH = re.compile(r"\.review-output/[A-Za-z0-9_-]+\.json")
+
+
+def _fixer_prompt_files() -> list[Path]:
+    return sorted(_PROMPTS_DIR.glob("fixer*.md"))
+
+
+def test_fixer_prompts_exist() -> None:
+    """Guard against accidentally moving or deleting the prompts this lint covers."""
+    files = _fixer_prompt_files()
+    names = {f.name for f in files}
+    assert "fixer.md" in names, f"fixer.md missing from {_PROMPTS_DIR}"
+    assert "fixer-resume.md" in names, f"fixer-resume.md missing from {_PROMPTS_DIR}"
+
+
+@pytest.mark.parametrize("prompt_path", _fixer_prompt_files(), ids=lambda p: p.name)
+def test_no_bug_prone_phrase(prompt_path: Path) -> None:
+    """`fix-result JSON` reads as a filename hint; ban it from fixer prompts."""
+    text = prompt_path.read_text()
+    matches = _BUG_PRONE_PHRASE.findall(text)
+    assert not matches, (
+        f"{prompt_path.name} contains the bug-prone phrase 'fix-result JSON' "
+        f"({len(matches)} occurrence(s)). The model latches onto this as a "
+        f"filename and writes fix-result.json instead of $OUTPUT_PATH. Replace "
+        f"with 'the result as JSON' or similar."
+    )
+
+
+@pytest.mark.parametrize("prompt_path", _fixer_prompt_files(), ids=lambda p: p.name)
+def test_no_hard_coded_output_filename(prompt_path: Path) -> None:
+    """The output contract must reference $OUTPUT_PATH, not a literal path."""
+    text = prompt_path.read_text()
+    matches = _HARD_CODED_OUTPUT_PATH.findall(text)
+    assert not matches, (
+        f"{prompt_path.name} hard-codes an output filename: {matches!r}. "
+        f"This conflicts with $OUTPUT_PATH and risks the same misread that "
+        f"caused PR #574 to stall. Reference $OUTPUT_PATH only."
+    )


### PR DESCRIPTION
## Summary

- Tighten `fixer.md` + `fixer-resume.md` so the agent sees `$OUTPUT_PATH` as the unambiguous write target (prior wording "Write fix-result JSON" collided with the schema basename `fix-result-v1.json` and was read as a filename hint).
- Add a bounded salvage block to the three v2 container scripts (`review-claude-run`, `review-claude-resume`, `review-codex-resume`) that `mv`s a near-miss filename into `$OUTPUT_PATH` with a `::warning::` if the agent ever drifts again — loud canary, not silent cure.
- Add `tests/unit/test_fixer_prompt_output_path.py` — a structural lint that fails fast if the bug-prone phrase or hard-coded output filename reappears in any fixer prompt.

## Why

PR #574 stalled at NO-GO last cycle for a non-obvious reason: cycle-2 reviewers flagged four blockers; the Claude fallback fixer made the edits in-container; then it wrote `.review-output/fix-result.json` instead of `.review-output/fixer-result.json`. The host saw no file at `$OUTPUT_PATH`, the action errored, the host commit step never ran, judge skipped, verdict NO-GO, `needs-human-review` label applied. The fixes themselves were fine — they just never landed because the agent named the file from the prose ("Write fix-result JSON ... conforming to fix-result-v1.json") instead of resolving the env var.

This trap is open for every human-authored PR that takes the `fallback` branch of `review-fixer.yml`. The reviewer prompts don't hit it because their prose word ("verdict") and schema basename (`reviewer-v1`) don't combine into a plausible filename. The fixer prompts were the outlier.

## Test plan

- [x] `pytest tests/unit/test_fixer_prompt_output_path.py -v` — 7/7 pass
- [x] `pytest tests/unit/ -x -q` — 181/181 pass
- [x] `ruff check` clean, `mypy app/` clean
- [x] `bash -n` clean on all three modified container scripts
- [ ] After merge: confirm the next fixer-invoking PR converges without the misnamed-file failure mode. The salvage block's `::warning::` is the canary — if it ever fires post-merge, the prompt has drifted again and the workflow summary will surface it.

## Scope notes

- Schema file `fix-result-v1.json` is NOT renamed — referenced from `aggregate.mjs`, `judge.mjs`, `review-fixer.yml`, and docs; rename would be large and orthogonal. The prompt swap is the cheaper, targeted fix.
- `fixer-claude-smoke.md` is untouched — short, unambiguous, and doesn't exhibit this bug class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)