### PR TITLE
feat(models): switch LLM tiers to gemma4-small via LiteLLM proxy

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -4,10 +4,20 @@ Reads model tier assignments from setup/model-tiers.json and exposes
 a single llm(tier) factory function. Validates model IDs at startup.
 
 Tiers:
-  expensive -> claude-opus-4-6 (complex reasoning: GET_TASK scoring)
-  medium    -> claude-sonnet-4-6 (intent classification, most nodes)
-  cheap     -> claude-haiku-4-5 (lightweight tasks)
-  reminder  -> claude-haiku-4-5 (reminder delivery cron)
+  expensive -> gemma4-small (complex reasoning: GET_TASK scoring)
+  medium    -> gemma4-small (intent classification, most nodes)
+  cheap     -> gemma4-small (lightweight tasks)
+  reminder  -> gemma4-small (reminder delivery cron)
+
+All tiers currently collapse onto a single alias because the LLM host
+can only hold one Gemma model in RAM at a time; reintroducing distinct
+tiers is a one-line edit per tier in setup/model-tiers.json.
+
+Model IDs are sent as OpenAI-format chat-completion requests to the
+LiteLLM proxy at ANTHROPIC_BASE_URL (the env var name is retained for
+compose/devcontainer continuity even though the wire protocol is now
+OpenAI, not Anthropic). Adding a new provider family is just adding
+its prefix to _VALID_MODEL_PREFIXES.
 
 LangSmith guard: refuses boot when LANGSMITH_TRACING=true unless
 ALLOW_PRIVATE_TRACE_EXPORT=true is also set. Private user data (task titles,
@@ -27,7 +37,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any, Literal
 
-from langchain_anthropic import ChatAnthropic
+from langchain_openai import ChatOpenAI
 
 from app.observability.llm_callback import LLMObservabilityCallback
 
@@ -38,8 +48,9 @@ Tier = Literal["expensive", "medium", "cheap", "reminder"]
 
 _VALID_TIERS: frozenset[str] = frozenset(["expensive", "medium", "cheap", "reminder"])
 
-# Anthropic model prefix for validation
-_ANTHROPIC_PREFIX = "claude-"
+# Known model-ID prefixes accepted by the LiteLLM proxy. A startup-time
+# allowlist catches typos in setup/model-tiers.json before the first call.
+_VALID_MODEL_PREFIXES: tuple[str, ...] = ("claude-", "gemma", "gpt-")
 
 
 def _check_langsmith_guard() -> None:
@@ -83,24 +94,31 @@ def _load_model_tiers() -> dict[str, str]:
             f"Expected tiers: {sorted(_VALID_TIERS)}"
         )
 
-    # Validate model IDs — must be Anthropic models for langchain-anthropic
+    # Validate model IDs against the known-prefix allowlist. The proxy is the
+    # source of truth for which aliases actually resolve; this check only
+    # catches obvious typos at startup.
     for tier, model_id in data.items():
         if tier not in _VALID_TIERS:
             continue  # Extra keys are ignored
-        if not isinstance(model_id, str) or not model_id.startswith(_ANTHROPIC_PREFIX):
+        if not isinstance(model_id, str) or not any(
+            model_id.startswith(p) for p in _VALID_MODEL_PREFIXES
+        ):
             raise RuntimeError(
                 f"setup/model-tiers.json tier '{tier}' has invalid model ID '{model_id}'. "
-                f"Anthropic models must start with '{_ANTHROPIC_PREFIX}'."
+                f"Model IDs must start with one of: {_VALID_MODEL_PREFIXES}."
             )
 
     return data
 
 
-def llm(tier: Tier, *, temperature: float = 0.0, caller: str | None = None) -> ChatAnthropic:
-    """Return a LangChain ChatAnthropic instance for the given tier.
+def llm(tier: Tier, *, temperature: float = 0.0, caller: str | None = None) -> ChatOpenAI:
+    """Return a LangChain ChatOpenAI instance pointing at the LiteLLM proxy.
 
     Model IDs are resolved from setup/model-tiers.json, validated at first call.
-    The ANTHROPIC_API_KEY environment variable must be set.
+    ANTHROPIC_BASE_URL must point at the proxy (OpenAI-compatible endpoint, i.e.
+    include the /v1 suffix); ANTHROPIC_API_KEY is forwarded as the bearer token
+    when present and falls back to a placeholder when the proxy doesn't require
+    auth.
 
     An LLMObservabilityCallback is attached automatically, emitting
     llm.call.start / llm.call.end / llm.call.error events to structlog with
@@ -116,7 +134,7 @@ def llm(tier: Tier, *, temperature: float = 0.0, caller: str | None = None) -> C
             None is valid for callsites that don't pass a caller.
 
     Returns:
-        ChatAnthropic configured for the specified tier, with observability
+        ChatOpenAI configured for the specified tier, with observability
         callback attached.
 
     Raises:
@@ -133,11 +151,13 @@ def llm(tier: Tier, *, temperature: float = 0.0, caller: str | None = None) -> C
     model_id = tiers[tier]
 
     kwargs: dict[str, Any] = {
-        "model_name": model_id,
+        "model": model_id,
         "temperature": temperature,
-        "max_tokens_to_sample": 1024,
+        "max_tokens": 1024,
+        "base_url": os.environ.get("ANTHROPIC_BASE_URL"),
+        "api_key": os.environ.get("ANTHROPIC_API_KEY") or "placeholder",
     }
-    base_model = ChatAnthropic(**kwargs)
+    base_model = ChatOpenAI(**kwargs)
 
     # Attach observability callback (one instance per llm() call so tier + caller
     # are baked into the handler and appear as fields on every log event).

--- a/app/models.py
+++ b/app/models.py
@@ -116,9 +116,10 @@ def llm(tier: Tier, *, temperature: float = 0.0, caller: str | None = None) -> C
 
     Model IDs are resolved from setup/model-tiers.json, validated at first call.
     ANTHROPIC_BASE_URL must point at the proxy (OpenAI-compatible endpoint, i.e.
-    include the /v1 suffix); ANTHROPIC_API_KEY is forwarded as the bearer token
-    when present and falls back to a placeholder when the proxy doesn't require
-    auth.
+    include the /v1 suffix); ANTHROPIC_API_KEY is forwarded as the bearer token.
+    Both env vars are required — startup fails if either is unset or empty. If the
+    proxy does not require auth, set ANTHROPIC_API_KEY to any non-empty placeholder
+    value in the runtime environment.
 
     An LLMObservabilityCallback is attached automatically, emitting
     llm.call.start / llm.call.end / llm.call.error events to structlog with
@@ -138,8 +139,9 @@ def llm(tier: Tier, *, temperature: float = 0.0, caller: str | None = None) -> C
         callback attached.
 
     Raises:
-        RuntimeError: If model-tiers.json is missing or malformed, or if
-            LANGSMITH_TRACING=true without ALLOW_PRIVATE_TRACE_EXPORT.
+        RuntimeError: If model-tiers.json is missing or malformed, if
+            LANGSMITH_TRACING=true without ALLOW_PRIVATE_TRACE_EXPORT, or if
+            ANTHROPIC_BASE_URL is unset or empty.
         ValueError: If tier is not a valid tier name.
     """
     if tier not in _VALID_TIERS:
@@ -150,12 +152,18 @@ def llm(tier: Tier, *, temperature: float = 0.0, caller: str | None = None) -> C
     tiers = _load_model_tiers()
     model_id = tiers[tier]
 
+    base_url = os.environ.get("ANTHROPIC_BASE_URL")
+    if not base_url:
+        raise RuntimeError(
+            "ANTHROPIC_BASE_URL must point at the OpenAI-compatible LiteLLM /v1 endpoint"
+        )
+
     kwargs: dict[str, Any] = {
         "model": model_id,
         "temperature": temperature,
         "max_tokens": 1024,
-        "base_url": os.environ.get("ANTHROPIC_BASE_URL"),
-        "api_key": os.environ.get("ANTHROPIC_API_KEY") or "placeholder",
+        "base_url": base_url,
+        "api_key": os.environ["ANTHROPIC_API_KEY"],
     }
     base_model = ChatOpenAI(**kwargs)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,7 +47,7 @@ flowchart TB
     end
 
     subgraph External["External Services"]
-        Anthropic[Anthropic API<br/>LLM]
+        LiteLLM[LiteLLM Proxy<br/>LLM]
         OpenAI[OpenAI API<br/>Image Generation]
     end
 
@@ -62,7 +62,7 @@ flowchart TB
     Worker --> Signal
     Worker --> Notion
 
-    Graph --> Anthropic
+    Graph --> LiteLLM
     Graph --> OpenAI
 ```
 
@@ -120,7 +120,11 @@ duplicate delivery over loss.
 ## Model Routing
 
 `app/models.py` reads `setup/model-tiers.json` at startup and validates all
-model IDs. No LiteLLM proxy — LangChain provider adapters directly.
+model IDs. All LLM calls go through a LiteLLM proxy via `ChatOpenAI` with
+`ANTHROPIC_BASE_URL` as the OpenAI-compatible `/v1` endpoint. LiteLLM
+dispatches by model alias; the app has no direct connection to any provider
+API. `ANTHROPIC_API_KEY` is forwarded as the bearer token (set to any
+non-empty placeholder when the proxy does not require auth).
 
 ## Security
 
@@ -138,7 +142,8 @@ model IDs. No LiteLLM proxy — LangChain provider adapters directly.
 |----------|---------|
 | `NOTION_API_KEY` | Notion integration token |
 | `NOTION_DATABASE_ID` | Tasks database identifier |
-| `ANTHROPIC_API_KEY` | Primary LLM |
+| `ANTHROPIC_BASE_URL` | LiteLLM proxy OpenAI-compatible `/v1` endpoint (required) |
+| `ANTHROPIC_API_KEY` | Bearer token for LiteLLM proxy (required; use placeholder if proxy needs no auth) |
 | `OPENAI_API_KEY` | Reward image generation |
 | `DATABASE_URL` | Postgres connection string |
 | `SIGNAL_CLI_URL` | signal-cli REST API base URL |
@@ -151,7 +156,7 @@ model IDs. No LiteLLM proxy — LangChain provider adapters directly.
 For the infra operator / VM-isolation configuration:
 
 - `api.notion.com` — Notion CRUD
-- `api.anthropic.com` — primary LLM
+- LiteLLM proxy (`ANTHROPIC_BASE_URL`) — all LLM calls; proxy handles provider dispatch
 - `api.openai.com` — reward image generation
 - Signal infrastructure — managed by the `signal-cli` container
 

--- a/docs/python-rewrite/llm-observability.md
+++ b/docs/python-rewrite/llm-observability.md
@@ -82,7 +82,7 @@ processor in `app/main.py` is a safety net; the callback does not rely on it.
 
 `app/models.py:llm(tier, *, caller=None)` constructs one
 `LLMObservabilityCallback` per call and attaches it via
-`ChatAnthropic(...).with_config(callbacks=[handler])`. The callback captures
+`ChatOpenAI(...).with_config(callbacks=[handler])`. The callback captures
 tier + model + caller at construction time so each log event is self-describing.
 
 Every graph node passes `caller=` to `llm()`:
@@ -112,7 +112,8 @@ without running the full behavioral eval rig.
 
 ```bash
 ENABLE_LLM_PERF=true \
-ANTHROPIC_API_KEY=<key> \
+ANTHROPIC_BASE_URL=<proxy-url>/v1 \
+ANTHROPIC_API_KEY=<key-or-placeholder> \
 pytest tests/perf/test_llm_perf.py -v
 ```
 
@@ -133,9 +134,8 @@ with 3 runs per prompt across 13 synthetic prompts (39 calls per tier).
 To compare `gemma4-small` against the current medium tier:
 
 1. Update `setup/model-tiers.json` to point `medium` at the target model ID.
-   Note: `app/models.py` hardcodes `setup/model-tiers.json` with no `MODEL_TIERS_PATH`
-   override. Non-`claude-` model IDs require relaxing the prefix check in
-   `app/models.py` validation first (see follow-up note in PR description).
+   `app/models.py` accepts model IDs starting with `claude-`, `gemma`, or `gpt-`;
+   no code change is required for aliases in the allowlist.
 2. Run:
    ```bash
    ENABLE_LLM_PERF=true PERF_MODELS=medium PERF_RUNS_N=5 \

--- a/docs/python-rewrite/test-rig.md
+++ b/docs/python-rewrite/test-rig.md
@@ -213,25 +213,22 @@ meaning every reward image was silently discarded.
 hardcoded relative to the repo root. No `MODEL_TIERS_PATH` env override exists
 in the current runtime. The eval runner swaps model tiers by writing a modified
 `setup/model-tiers.json` into the test working tree before invoking the graph
-under test. In the eval harness, `ChatAnthropic` routes through a LiteLLM proxy at
-`ANTHROPIC_BASE_URL`; LiteLLM dispatches by model alias. The smoke harness boots the full stack and makes no LLM calls (no real API
-keys are required — compose smoke uses placeholder env values).
-The production app runtime connects directly to the Anthropic API without a
-LiteLLM proxy.
+under test.
 
-**Prerequisite for non-Claude swap:** `app/models.py` currently validates
-that every tier value starts with `claude-` (a Phase B leftover that was
-appropriate when only Claude models were in play). Before a `gemma4-small`
-swap can be tested, that validation must be relaxed — either drop the
-prefix check or extend it to accept LiteLLM-routed aliases. The eval runner
-will surface this gap on first run by failing to instantiate the model.
-Tracked separately from this rig PR; the rig itself does not modify
-`app/models.py`.
+The app runtime uses `ChatOpenAI` routed through a LiteLLM proxy at
+`ANTHROPIC_BASE_URL` (OpenAI-compatible `/v1` endpoint); LiteLLM dispatches
+by model alias. `ANTHROPIC_API_KEY` is forwarded as the bearer token. The
+smoke harness boots the full stack and makes no LLM calls — compose smoke
+uses placeholder values for both env vars.
 
-Once that prerequisite is met: swapping `cheap: claude-haiku-4-5` to
-`cheap: gemma4-small` is a one-line change in `setup/model-tiers.json`.
-No Python adapter branching. All LLM routing stays through
-`app/models.py:llm(tier)`.
+Model IDs are validated against a known-prefix allowlist (`claude-`, `gemma`,
+`gpt-`) at startup. Swapping a tier to any supported alias is a one-line
+change in `setup/model-tiers.json`; no Python adapter changes are required.
+All LLM routing stays through `app/models.py:llm(tier)`.
+
+Unit tests for provider-boundary behavior must assert the exact `ChatOpenAI`
+constructor payload (model id, temperature, max_tokens, base_url, api_key) to
+catch routing regressions that would still pass a class-assertion-only check.
 
 Three cost gates for eval runs:
 - `ENABLE_LIVE_LLM_EVALS=true` — required for any real LLM call; absent = `pytest.skip`

--- a/setup/README.md
+++ b/setup/README.md
@@ -50,7 +50,8 @@ signal-cli volume management or registration carry-over. The `signal-cli` servic
 | `NOTION_DATABASE_ID` | Yes | ID of the tasks database |
 | `SIGNAL_ACCOUNT` | Yes | E.164 phone number registered with signal-cli |
 | `AUTHORIZED_PEERS` | Yes | Comma-separated E.164 numbers allowed to send inbound messages; empty or unset refuses startup |
-| `ANTHROPIC_API_KEY` | Yes | Primary LLM (Claude via langchain-anthropic) |
+| `ANTHROPIC_BASE_URL` | Yes | LiteLLM proxy OpenAI-compatible `/v1` endpoint (e.g. `https://proxy.host/v1`) |
+| `ANTHROPIC_API_KEY` | Yes | Bearer token for LiteLLM proxy; use any non-empty placeholder if proxy needs no auth |
 | `DATABASE_URL` | Compose-managed | Postgres DSN; hardcoded in `docker/compose.yaml` for the compose network. Override only for non-compose runs. |
 | `SIGNAL_CLI_URL` | Compose-managed | WebSocket URL of the signal-cli bridge; hardcoded in `docker/compose.yaml`. Override only for non-compose runs. |
 | `USER_TZ` | No | IANA timezone identifier (default `America/Chicago`) |
@@ -75,18 +76,19 @@ The app uses APScheduler v3 with PostgresJobStore for durable scheduled jobs:
 ## Model Tiers
 
 Model assignments use a tier system defined in `setup/model-tiers.json`. Read by `app/models.py`
-at startup to validate all model references. Models are used directly via `langchain-anthropic`
-with `ANTHROPIC_API_KEY` — no LiteLLM proxy required.
+at startup to validate all model references. All tiers are routed through `ChatOpenAI` to the
+LiteLLM proxy at `ANTHROPIC_BASE_URL`; LiteLLM dispatches by model alias.
 
 | Tier | Role |
 |------|------|
-| `expensive` | Primary interactive agent (graph nodes) |
-| `medium` | Available for fallback opt-in |
-| `cheap` | Scheduled background jobs |
+| `expensive` | Complex reasoning (e.g. GET_TASK scoring) |
+| `medium` | Intent classification and most graph nodes |
+| `cheap` | Lightweight tasks |
+| `reminder` | Reminder delivery cron |
 
 To remap tiers: edit `setup/model-tiers.json` values to point at your model IDs, then restart
-the stack. `app/models.py` validates the mapping at startup and logs an error if any tier is
-missing or uses a non-Anthropic model ID.
+the stack. `app/models.py` validates the mapping at startup and raises if any tier is missing
+or uses a model ID prefix not in the accepted allowlist (`claude-`, `gemma`, `gpt-`).
 
 ## Contributor Hooks
 

--- a/setup/model-tiers.json
+++ b/setup/model-tiers.json
@@ -1,6 +1,6 @@
 {
-  "expensive": "claude-opus-4-6",
-  "medium": "claude-sonnet-4-6",
-  "cheap": "claude-haiku-4-5",
-  "reminder": "claude-haiku-4-5"
+  "expensive": "gemma4-small",
+  "medium": "gemma4-small",
+  "cheap": "gemma4-small",
+  "reminder": "gemma4-small"
 }

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -130,6 +130,70 @@ def test_valid_tier_returns_llm_instance() -> None:
     models_module._load_model_tiers.cache_clear()
 
 
+def test_llm_constructs_chatopenai_with_expected_kwargs() -> None:
+    """llm() must pass tier model id, temperature, max_tokens, base_url, and api_key to ChatOpenAI."""
+    import json
+    from pathlib import Path
+    from unittest.mock import MagicMock, patch
+
+    from app import models as models_module
+    models_module._load_model_tiers.cache_clear()
+
+    tiers_path = Path(__file__).parent.parent.parent / "setup" / "model-tiers.json"
+    expected_model = json.loads(tiers_path.read_text(encoding="utf-8"))["medium"]
+
+    fake_instance = MagicMock()
+    fake_instance.with_config.return_value = fake_instance
+
+    env = {k: v for k, v in os.environ.items() if k not in ("LANGSMITH_TRACING",)}
+    env["ANTHROPIC_BASE_URL"] = "https://proxy.test/v1"
+    env["ANTHROPIC_API_KEY"] = "test-key"
+
+    with patch.dict(os.environ, env, clear=True):
+        with patch("app.models.ChatOpenAI", return_value=fake_instance) as mock_cls:
+            models_module.llm("medium", temperature=0.0, caller="test")
+            call_kwargs = mock_cls.call_args.kwargs
+            assert call_kwargs["model"] == expected_model
+            assert call_kwargs["temperature"] == 0.0
+            assert call_kwargs["max_tokens"] == 1024
+            assert call_kwargs["base_url"] == "https://proxy.test/v1"
+            assert call_kwargs["api_key"] == "test-key"
+
+    models_module._load_model_tiers.cache_clear()
+
+
+def test_llm_raises_when_anthropic_base_url_missing() -> None:
+    """llm() must raise RuntimeError when ANTHROPIC_BASE_URL is unset."""
+    from app import models as models_module
+    models_module._load_model_tiers.cache_clear()
+
+    env = {k: v for k, v in os.environ.items() if k not in ("LANGSMITH_TRACING", "ANTHROPIC_BASE_URL")}
+    env.pop("ANTHROPIC_BASE_URL", None)
+    env["ANTHROPIC_API_KEY"] = "test-key"
+
+    with patch.dict(os.environ, env, clear=True):
+        with pytest.raises(RuntimeError, match="ANTHROPIC_BASE_URL"):
+            models_module.llm("medium")
+
+    models_module._load_model_tiers.cache_clear()
+
+
+def test_llm_raises_when_anthropic_api_key_missing() -> None:
+    """llm() must raise KeyError when ANTHROPIC_API_KEY is unset."""
+    from app import models as models_module
+    models_module._load_model_tiers.cache_clear()
+
+    env = {k: v for k, v in os.environ.items() if k not in ("LANGSMITH_TRACING", "ANTHROPIC_API_KEY")}
+    env.pop("ANTHROPIC_API_KEY", None)
+    env["ANTHROPIC_BASE_URL"] = "https://proxy.test/v1"
+
+    with patch.dict(os.environ, env, clear=True):
+        with pytest.raises(KeyError):
+            models_module.llm("medium")
+
+    models_module._load_model_tiers.cache_clear()
+
+
 def test_invalid_tier_raises_value_error() -> None:
     """llm() with unknown tier must raise ValueError."""
     from app import models as models_module

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -21,16 +21,24 @@ def test_model_tiers_json_exists() -> None:
     assert not missing, f"model-tiers.json missing tiers: {sorted(missing)}"
 
 
-def test_all_tiers_have_anthropic_model_ids() -> None:
-    """All model IDs in model-tiers.json must start with 'claude-'."""
+def test_all_tiers_have_known_model_id_prefix() -> None:
+    """All model IDs in model-tiers.json must use a known provider prefix.
+
+    The allowlist mirrors app.models._VALID_MODEL_PREFIXES — the proxy is the
+    source of truth for which aliases actually resolve; this check only catches
+    typos at startup. Importing the constant keeps the two in lockstep.
+    """
     import json
+
+    from app.models import _VALID_MODEL_PREFIXES
     tiers_path = Path(__file__).parent.parent.parent / "setup" / "model-tiers.json"
     data = json.loads(tiers_path.read_text(encoding="utf-8"))
 
     for tier, model_id in data.items():
         if tier in {"expensive", "medium", "cheap", "reminder"}:
-            assert model_id.startswith("claude-"), (
-                f"Tier '{tier}' model '{model_id}' must start with 'claude-'"
+            assert any(model_id.startswith(p) for p in _VALID_MODEL_PREFIXES), (
+                f"Tier '{tier}' model '{model_id}' must start with one of "
+                f"{_VALID_MODEL_PREFIXES}"
             )
 
 
@@ -97,11 +105,11 @@ def test_langsmith_guard_passes_when_tracing_disabled() -> None:
 
 
 def test_valid_tier_returns_llm_instance() -> None:
-    """llm(tier) must return a runnable wrapping ChatAnthropic for valid tiers.
+    """llm(tier) must return a runnable wrapping ChatOpenAI for valid tiers.
 
     The returned object is a RunnableBinding (from with_config) that wraps a
-    ChatAnthropic instance with the observability callback attached. We verify
-    that the inner bound model is a ChatAnthropic.
+    ChatOpenAI instance with the observability callback attached. We verify
+    that the inner bound model is a ChatOpenAI.
     """
     from app import models as models_module
     models_module._load_model_tiers.cache_clear()
@@ -109,14 +117,15 @@ def test_valid_tier_returns_llm_instance() -> None:
     env = dict(os.environ)
     env.pop("LANGSMITH_TRACING", None)
     env.setdefault("ANTHROPIC_API_KEY", "test-key-not-used")
+    env.setdefault("ANTHROPIC_BASE_URL", "https://proxy.test/v1")
 
     with patch.dict(os.environ, env, clear=True):
-        from langchain_anthropic import ChatAnthropic
         from langchain_core.runnables import RunnableBinding
+        from langchain_openai import ChatOpenAI
         result = models_module.llm("medium")
         # with_config wraps the model in a RunnableBinding
         assert isinstance(result, RunnableBinding)
-        assert isinstance(result.bound, ChatAnthropic)
+        assert isinstance(result.bound, ChatOpenAI)
 
     models_module._load_model_tiers.cache_clear()
 
@@ -129,6 +138,7 @@ def test_invalid_tier_raises_value_error() -> None:
     env = dict(os.environ)
     env.pop("LANGSMITH_TRACING", None)
     env.setdefault("ANTHROPIC_API_KEY", "test-key-not-used")
+    env.setdefault("ANTHROPIC_BASE_URL", "https://proxy.test/v1")
 
     with patch.dict(os.environ, env, clear=True):
         with pytest.raises(ValueError, match="Unknown model tier"):


### PR DESCRIPTION
## Summary

- Switch `app/models.py` from `langchain-anthropic` `ChatAnthropic` to `langchain-openai` `ChatOpenAI`. The factory still returns a runnable wrapping a chat model with the existing `LLMObservabilityCallback` attached; only the wire protocol to the LiteLLM proxy changes (Anthropic → OpenAI).
- Collapse all four tiers in `setup/model-tiers.json` onto `gemma4-small`. The LLM host can only hold one Gemma model in RAM at a time — follow-up issue to restore tier diversity once the host can swap or grow.
- Reuse existing `ANTHROPIC_BASE_URL` / `ANTHROPIC_API_KEY` env var names as the proxy URL + auth so compose, devcontainer, and CI config are untouched in this PR. Follow-up issue tracks renaming to provider-neutral names.

## Why ChatOpenAI

Probed the proxy directly during planning. Same prompt, same model:

| | ChatOpenAI (`/v1/chat/completions`) | ChatAnthropic (`/v1/messages`) |
|---|---|---|
| `content` shape | `'hello'` (string) | `[{type:'thinking',len:1160}, {type:'text',len:5}]` |
| `output_tokens` | 315 | 315 |

Every graph node does `str(response.content).strip()`. On the Anthropic path that would ship the raw Python repr of the block list (including the reasoning trace) as the user's Signal reply. The OpenAI path returns plain string content, so no node-side changes are required.

## Verification

- `pytest tests/unit/` → 174/174 pass (only `tests/unit/test_models.py` needed updates: `isinstance ChatAnthropic` → `ChatOpenAI`, added `ANTHROPIC_BASE_URL` to patched env).
- Live smoke against the proxy (`ANTHROPIC_BASE_URL=https://llm.featherback-mermaid.ts.net/v1`) confirms `type(r.content).__name__ == 'str'` and observability events fire (`llm.call.start` / `llm.call.end` with model, tier, tokens, duration).
- `pytest tests/perf/test_llm_perf.py` (`ENABLE_LLM_PERF=true PERF_MODELS=medium PERF_RUNS_N=3`) → 39 calls, median **8.6 s**, p95 **22.6 s**. See follow-up issue for mitigation.

Out of scope (intentional):
- `app/tools/rewards.py` (`gpt-image-1` for image generation, pre-existing `_KNOWN_VIOLATIONS` entry, separate API surface).
- `tests/evals/judge.py` (own `ChatAnthropic` against same proxy with `claude-sonnet-4-6`; judge must remain stronger than candidate per rig spec).
- `docker/compose.yaml`, `.devcontainer/devcontainer.json`, infra config (env var names preserved).

## Test plan

- [x] Unit suite green locally (174/174).
- [x] Live smoke against proxy returns string content.
- [x] Perf harness completes against `gemma4-small` end-to-end.
- [ ] End-to-end via Signal (compose + bridge) — requires repo-root `.env` with `ANTHROPIC_BASE_URL=https://llm.featherback-mermaid.ts.net/v1`.
- [ ] (Optional) Eval suite with `EVAL_MODELS=gemma4-small` to check contract regressions vs. last nightly-eval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)