### PR TITLE
Add Signal read receipts and typing indicators

### DIFF
--- a/DEV-AGENTS.md
+++ b/DEV-AGENTS.md
@@ -61,7 +61,7 @@ The Python/LangGraph application. Safe to edit via PRs.
 - `app/scheduler/scheduler.py` — APScheduler v3 wiring with PostgresJobStore
 - `app/scheduler/jobs.py` — Declarative SCHEDULED_JOBS list + reconcile_jobstore; jobs: `reminder_dispatcher`, `notion_health`, `ops_alerts_drain`, `state_audit`, `check_in_dispatcher`, `weekly_recap`
 - `app/scheduler/reminder_worker.py` — SELECT FOR UPDATE SKIP LOCKED worker
-- `app/ingress/signal_listener.py` — WebSocket consumer routing to graph
+- `app/ingress/signal_listener.py` — Authorized Signal WebSocket consumer; routes reactions to reward feedback, schedules read receipts, maintains typing indicators around graph execution, and invokes the graph for text messages
 - `app/prompts/` — Jinja2 prompt templates (`*.md.j2`) for each intent
 - `app/observability/__init__.py` — Package marker for the observability module
 - `app/observability/llm_callback.py` — `LLMObservabilityCallback` (LangChain AsyncCallbackHandler); emits `llm.call.start` / `llm.call.end` / `llm.call.error` events via structlog with tier + caller + token counts + duration. Always on in production. See `docs/python-rewrite/llm-observability.md`.

--- a/app/ingress/signal_listener.py
+++ b/app/ingress/signal_listener.py
@@ -13,14 +13,18 @@ This module is one of three authorised sites for httpx.AsyncClient usage.
 """
 from __future__ import annotations
 
+import asyncio
 import os
+from collections.abc import Coroutine
 from typing import Any
 
 import structlog
 
-from app.tools.signal_client import receive_messages
+from app.tools.signal_client import receive_messages, send_read_receipt, send_typing_indicator
 
 log = structlog.get_logger(__name__)
+
+_TYPING_REFRESH_SECONDS = 10.0
 
 
 def _load_authorized_peers() -> frozenset[str]:
@@ -42,24 +46,66 @@ def _load_authorized_peers() -> frozenset[str]:
     return peers
 
 
-def _extract_peer_and_text(envelope: dict[str, Any]) -> tuple[str, str] | None:
-    """Extract (sender_e164, text) from a signal-cli envelope dict.
+def _extract_peer_and_text(envelope: dict[str, Any]) -> tuple[str, str, int | None] | None:
+    """Extract (sender_e164, text, timestamp) from a signal-cli envelope dict.
 
     Returns None if the envelope is not a text message from a peer.
     """
-    data_message = (
-        envelope.get("envelope", {})
-        .get("dataMessage", {})
-    )
+    outer = envelope.get("envelope", {})
+    data_message = outer.get("dataMessage", {})
     text = data_message.get("message", "")
     if not text:
         return None
 
-    source = envelope.get("envelope", {}).get("source", "")
+    source = outer.get("source", "")
     if not source:
         return None
 
-    return source, text
+    timestamp = outer.get("timestamp")
+    if not isinstance(timestamp, int):
+        timestamp = data_message.get("timestamp")
+    if not isinstance(timestamp, int):
+        timestamp = None
+
+    return source, text, timestamp
+
+
+def _log_background_task_result(task: asyncio.Task[None]) -> None:
+    """Consume unexpected background task exceptions without leaking content."""
+    try:
+        task.result()
+    except asyncio.CancelledError:
+        return
+    except Exception as exc:
+        log.warning("signal_listener.background_task_failed", error_type=type(exc).__name__)
+
+
+def _start_background_task(coro: Coroutine[Any, Any, None]) -> None:
+    """Schedule a best-effort coroutine and log unexpected failures."""
+    task = asyncio.create_task(coro)
+    task.add_done_callback(_log_background_task_result)
+
+
+async def _maintain_typing_indicator(
+    *,
+    peer: str,
+    stop_event: asyncio.Event,
+    base_url: str | None,
+    account: str | None,
+    refresh_seconds: float = _TYPING_REFRESH_SECONDS,
+) -> None:
+    """Refresh Signal typing indicator until stop_event is set."""
+    while not stop_event.is_set():
+        await send_typing_indicator(
+            peer,
+            started=True,
+            base_url=base_url,
+            account=account,
+        )
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=refresh_seconds)
+        except TimeoutError:
+            continue
 
 
 def _extract_reaction(envelope: dict[str, Any]) -> tuple[str, str, int, str] | None:
@@ -163,7 +209,7 @@ class SignalListener:
             if result is None:
                 continue
 
-            peer, text = result
+            peer, text, timestamp = result
 
             if peer not in self._authorized_peers:
                 log.warning("signal_listener.unauthorized_peer_dropped")
@@ -171,6 +217,27 @@ class SignalListener:
 
             log.info("signal_listener.message_received", peer=peer[:4] + "***")
 
+            if timestamp is not None:
+                _start_background_task(
+                    send_read_receipt(
+                        peer,
+                        timestamp,
+                        base_url=self._base_url,
+                        account=self._account,
+                    )
+                )
+            else:
+                log.warning("signal_listener.receipt_skipped_missing_timestamp")
+
+            typing_stop = asyncio.Event()
+            _start_background_task(
+                _maintain_typing_indicator(
+                    peer=peer,
+                    stop_event=typing_stop,
+                    base_url=self._base_url,
+                    account=self._account,
+                )
+            )
             try:
                 if graph is None:
                     graph = self._get_graph()
@@ -180,3 +247,13 @@ class SignalListener:
                 )
             except Exception:
                 log.exception("signal_listener.graph_error", peer=peer[:4] + "***")
+            finally:
+                typing_stop.set()
+                _start_background_task(
+                    send_typing_indicator(
+                        peer,
+                        started=False,
+                        base_url=self._base_url,
+                        account=self._account,
+                    )
+                )

--- a/app/tools/signal_client.py
+++ b/app/tools/signal_client.py
@@ -1,7 +1,8 @@
 """Signal CLI REST API client.
 
 Async HTTP + WebSocket client wrapping bbernhard/signal-cli-rest-api.
-Provides message send and inbound message streaming via WebSocket.
+Provides outbound message sends, read receipts, typing indicators, and
+inbound message streaming via WebSocket.
 
 This module is one of three authorised sites for httpx.AsyncClient usage
 (alongside app/tools/notion.py and app/ingress/signal_listener.py).

--- a/app/tools/signal_client.py
+++ b/app/tools/signal_client.py
@@ -23,7 +23,7 @@ import asyncio
 import base64
 import json
 import os
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from pathlib import Path
 from typing import Any
 
@@ -50,7 +50,7 @@ def _account() -> str:
 
 
 # ---------------------------------------------------------------------------
-# Send
+# Send / UX signals
 # ---------------------------------------------------------------------------
 
 
@@ -195,6 +195,99 @@ async def send_message(
                 await asyncio.sleep(delay)
                 delay = min(delay * 2, 60.0)
         raise RuntimeError(f"send_message failed after {_MAX_RETRIES} attempts") from last_exc
+
+
+async def _best_effort_signal_request(
+    request: Callable[[], Awaitable[httpx.Response]],
+    *,
+    event: str,
+) -> None:
+    """Run a signal-cli request with send_message retry timing, never raising."""
+    delay = _RETRY_BASE_DELAY
+    for attempt in range(_MAX_RETRIES):
+        try:
+            resp = await request()
+            resp.raise_for_status()
+            log.info(f"{event}.ok")
+            return
+        except (httpx.TransportError, httpx.HTTPStatusError) as exc:
+            retryable = not (
+                isinstance(exc, httpx.HTTPStatusError)
+                and exc.response.status_code < 500
+            )
+            log.warning(
+                f"{event}.failed" if not retryable else f"{event}.retry",
+                attempt=attempt + 1,
+                error_type=type(exc).__name__,
+            )
+            if not retryable or attempt == _MAX_RETRIES - 1:
+                return
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, 60.0)
+        except Exception as exc:
+            log.warning(f"{event}.failed", error_type=type(exc).__name__)
+            return
+
+
+async def send_read_receipt(
+    peer: str,
+    timestamp: int,
+    *,
+    base_url: str | None = None,
+    account: str | None = None,
+) -> None:
+    """Best-effort Signal read receipt for a received peer message."""
+    try:
+        url_base = base_url or _signal_base_url()
+        acct = account or _account()
+    except Exception as exc:
+        log.warning("signal_client.receipt.failed", error_type=type(exc).__name__)
+        return
+
+    payload = {
+        "recipient": peer,
+        "receipt_type": "read",
+        "timestamp": timestamp,
+    }
+
+    async with httpx.AsyncClient(
+        base_url=url_base,
+        timeout=httpx.Timeout(connect=_CONNECT_TIMEOUT, read=_READ_TIMEOUT, write=30.0, pool=10.0),
+    ) as client:
+        await _best_effort_signal_request(
+            lambda: client.post(f"/v1/receipts/{acct}", json=payload),
+            event="signal_client.receipt",
+        )
+
+
+async def send_typing_indicator(
+    peer: str,
+    *,
+    started: bool = True,
+    base_url: str | None = None,
+    account: str | None = None,
+) -> None:
+    """Best-effort Signal typing indicator start/stop for a peer."""
+    try:
+        url_base = base_url or _signal_base_url()
+        acct = account or _account()
+    except Exception as exc:
+        log.warning("signal_client.typing.failed", error_type=type(exc).__name__)
+        return
+
+    payload = {"recipient": peer}
+    async with httpx.AsyncClient(
+        base_url=url_base,
+        timeout=httpx.Timeout(connect=_CONNECT_TIMEOUT, read=_READ_TIMEOUT, write=30.0, pool=10.0),
+    ) as client:
+        await _best_effort_signal_request(
+            lambda: client.request(
+                "PUT" if started else "DELETE",
+                f"/v1/typing-indicator/{acct}",
+                json=payload,
+            ),
+            event="signal_client.typing.start" if started else "signal_client.typing.stop",
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,8 +71,12 @@ flowchart TB
 The app container runs four concurrent async tasks:
 
 1. **Signal ingress** (`app/ingress/signal_listener.py`) — WebSocket consumer on
-   signal-cli REST API. Maps `(peer, text)` → `graph.ainvoke(...)` with
-   `thread_id = peer` for per-peer conversation isolation.
+   signal-cli REST API. For authorized text messages, extracts `(peer, text,
+   timestamp)`, schedules a best-effort read receipt for the received timestamp,
+   maintains a refreshed typing indicator while graph execution is active, and
+   maps `(peer, text)` → `graph.ainvoke(...)` with `thread_id = peer` for
+   per-peer conversation isolation. Typing stop is scheduled after graph
+   completion or graph error.
 
 2. **LangGraph graph** (`app/graph/graph.py`) — Eight intent nodes (`ADD_TASK`,
    `GET_TASK`, `COMPLETE`, `REJECT`, `CANNOT_FINISH`, `CHECK_IN`, `NEED_HELP`,

--- a/tests/integration/test_signal_listener_ux.py
+++ b/tests/integration/test_signal_listener_ux.py
@@ -1,0 +1,140 @@
+"""Integration coverage for Signal listener UX side effects."""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+class _FakeResponse:
+    def raise_for_status(self) -> None:
+        return None
+
+
+class _FakeAsyncClient:
+    calls: list[dict[str, Any]] = []
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.base_url = kwargs.get("base_url")
+
+    async def __aenter__(self) -> "_FakeAsyncClient":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
+    async def post(self, url: str, *, json: dict[str, Any]) -> _FakeResponse:
+        self.calls.append(
+            {
+                "kind": "receipt",
+                "base_url": self.base_url,
+                "url": url,
+                "json": json,
+            }
+        )
+        return _FakeResponse()
+
+    async def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        json: dict[str, Any],
+    ) -> _FakeResponse:
+        self.calls.append(
+            {
+                "kind": "typing",
+                "method": method,
+                "base_url": self.base_url,
+                "url": url,
+                "json": json,
+            }
+        )
+        return _FakeResponse()
+
+
+async def _async_gen(envelopes: list[dict[str, Any]]):
+    for envelope in envelopes:
+        yield envelope
+
+
+async def _wait_for_call_count(expected: int) -> None:
+    for _ in range(20):
+        if len(_FakeAsyncClient.calls) >= expected:
+            return
+        await asyncio.sleep(0)
+    raise AssertionError(f"expected {expected} Signal UX calls")
+
+
+@pytest.mark.asyncio
+async def test_authorized_inbound_text_reaches_receipt_and_typing_tools() -> None:
+    """Authorized text drives listener through public Signal UX tool functions."""
+    from app.ingress.signal_listener import SignalListener
+
+    _FakeAsyncClient.calls = []
+    events: list[str] = []
+
+    async def fake_graph_ainvoke(*args: Any, **kwargs: Any) -> None:
+        await asyncio.sleep(0)
+        events.append("graph")
+        await asyncio.sleep(0)
+
+    graph = AsyncMock()
+    graph.ainvoke.side_effect = fake_graph_ainvoke
+
+    listener = SignalListener(
+        graph=graph,
+        base_url="http://signal-cli-test:8080",
+        account="<test-account>",
+        authorized_peers=frozenset({"<test-recipient>"}),
+    )
+    envelopes = [
+        {
+            "envelope": {
+                "source": "<test-recipient>",
+                "timestamp": 1_716_800_000_000,
+                "dataMessage": {"message": "Test message"},
+            }
+        }
+    ]
+
+    with (
+        patch("app.ingress.signal_listener.receive_messages", return_value=_async_gen(envelopes)),
+        patch("httpx.AsyncClient", _FakeAsyncClient),
+    ):
+        await listener.run()
+        await _wait_for_call_count(3)
+
+    assert graph.ainvoke.await_count == 1
+    assert events == ["graph"]
+
+    receipt_call = _FakeAsyncClient.calls[0]
+    typing_start_call = _FakeAsyncClient.calls[1]
+    typing_stop_call = _FakeAsyncClient.calls[2]
+
+    assert receipt_call == {
+        "kind": "receipt",
+        "base_url": "http://signal-cli-test:8080",
+        "url": "/v1/receipts/<test-account>",
+        "json": {
+            "recipient": "<test-recipient>",
+            "receipt_type": "read",
+            "timestamp": 1_716_800_000_000,
+        },
+    }
+    assert typing_start_call == {
+        "kind": "typing",
+        "method": "PUT",
+        "base_url": "http://signal-cli-test:8080",
+        "url": "/v1/typing-indicator/<test-account>",
+        "json": {"recipient": "<test-recipient>"},
+    }
+    assert typing_stop_call == {
+        "kind": "typing",
+        "method": "DELETE",
+        "base_url": "http://signal-cli-test:8080",
+        "url": "/v1/typing-indicator/<test-account>",
+        "json": {"recipient": "<test-recipient>"},
+    }

--- a/tests/unit/test_signal_client_receipts_typing.py
+++ b/tests/unit/test_signal_client_receipts_typing.py
@@ -1,0 +1,131 @@
+"""Tests for Signal receipt and typing-indicator client primitives."""
+from __future__ import annotations
+
+import os
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+
+def _mock_httpx_response(json_data: dict[str, Any] | None = None) -> MagicMock:
+    resp = MagicMock()
+    resp.json.return_value = json_data or {}
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_send_read_receipt_posts_read_receipt_payload() -> None:
+    from app.tools import signal_client
+
+    captured: dict[str, Any] = {}
+
+    async def fake_post(url: str, *, json: dict[str, Any]) -> MagicMock:
+        captured["url"] = url
+        captured["json"] = json
+        return _mock_httpx_response()
+
+    mock_client = AsyncMock()
+    mock_client.post = fake_post
+
+    with (
+        patch.dict(os.environ, {"SIGNAL_ACCOUNT": "<test-account>"}),
+        patch("httpx.AsyncClient") as mock_httpx_cls,
+    ):
+        mock_httpx_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_httpx_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await signal_client.send_read_receipt(
+            "<test-recipient>",
+            1_716_800_000_000,
+            base_url="http://signal-cli-test:8080",
+            account="<test-account>",
+        )
+
+    assert captured == {
+        "url": "/v1/receipts/<test-account>",
+        "json": {
+            "recipient": "<test-recipient>",
+            "receipt_type": "read",
+            "timestamp": 1_716_800_000_000,
+        },
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("started", "method"),
+    [
+        (True, "PUT"),
+        (False, "DELETE"),
+    ],
+)
+async def test_send_typing_indicator_uses_start_stop_methods(
+    started: bool,
+    method: str,
+) -> None:
+    from app.tools import signal_client
+
+    captured: dict[str, Any] = {}
+
+    async def fake_request(
+        request_method: str,
+        url: str,
+        *,
+        json: dict[str, Any],
+    ) -> MagicMock:
+        captured["method"] = request_method
+        captured["url"] = url
+        captured["json"] = json
+        return _mock_httpx_response()
+
+    mock_client = AsyncMock()
+    mock_client.request = fake_request
+
+    with (
+        patch.dict(os.environ, {"SIGNAL_ACCOUNT": "<test-account>"}),
+        patch("httpx.AsyncClient") as mock_httpx_cls,
+    ):
+        mock_httpx_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_httpx_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await signal_client.send_typing_indicator(
+            "<test-recipient>",
+            started=started,
+            base_url="http://signal-cli-test:8080",
+            account="<test-account>",
+        )
+
+    assert captured == {
+        "method": method,
+        "url": "/v1/typing-indicator/<test-account>",
+        "json": {"recipient": "<test-recipient>"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_read_receipt_failure_is_best_effort() -> None:
+    from app.tools import signal_client
+
+    async def fake_post(url: str, *, json: dict[str, Any]) -> MagicMock:
+        raise httpx.ConnectError("bridge unavailable")
+
+    mock_client = AsyncMock()
+    mock_client.post = fake_post
+
+    with (
+        patch.dict(os.environ, {"SIGNAL_ACCOUNT": "<test-account>"}),
+        patch("asyncio.sleep", new=AsyncMock()),
+        patch("httpx.AsyncClient") as mock_httpx_cls,
+    ):
+        mock_httpx_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_httpx_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await signal_client.send_read_receipt(
+            "<test-recipient>",
+            1_716_800_000_000,
+            base_url="http://signal-cli-test:8080",
+            account="<test-account>",
+        )

--- a/tests/unit/test_signal_listener_auth.py
+++ b/tests/unit/test_signal_listener_auth.py
@@ -7,20 +7,28 @@ closed default).
 """
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 
-def _envelope(source: str, message: str) -> dict[str, Any]:
+def _envelope(
+    source: str,
+    message: str,
+    timestamp: int | None = 1_716_800_000_000,
+) -> dict[str, Any]:
     """Build a minimal signal-cli envelope for tests."""
-    return {
+    envelope: dict[str, Any] = {
         "envelope": {
             "source": source,
             "dataMessage": {"message": message},
         }
     }
+    if timestamp is not None:
+        envelope["envelope"]["timestamp"] = timestamp
+    return envelope
 
 
 def _reaction_envelope(
@@ -134,6 +142,102 @@ async def test_authorized_peer_invokes_graph() -> None:
     assert args[0]["peer"] == "+15551234567"
     assert args[0]["incoming"] == "hello"
     assert kwargs["config"]["configurable"]["thread_id"] == "+15551234567"
+
+
+@pytest.mark.asyncio
+async def test_authorized_peer_schedules_receipt_and_typing_around_graph() -> None:
+    """Receipt and typing UX signals are scheduled around graph invocation."""
+    from app.ingress.signal_listener import SignalListener
+
+    events: list[str] = []
+
+    async def fake_graph_ainvoke(*args: Any, **kwargs: Any) -> None:
+        events.append("graph")
+
+    def fake_start_background_task(coro: Any) -> None:
+        name = getattr(getattr(coro, "cr_code", None), "co_name", "")
+        events.append(name)
+        coro.close()
+
+    graph = AsyncMock()
+    graph.ainvoke.side_effect = fake_graph_ainvoke
+    listener = SignalListener(
+        graph=graph,
+        base_url="http://signal-cli-test:8080",
+        account="<test-account>",
+        authorized_peers=frozenset({"+15551234567"}),
+    )
+
+    envelopes = [_envelope("+15551234567", "hello", timestamp=1_716_800_000_000)]
+    with (
+        patch("app.ingress.signal_listener.receive_messages", return_value=_async_gen(envelopes)),
+        patch(
+            "app.ingress.signal_listener._start_background_task",
+            new=fake_start_background_task,
+        ),
+    ):
+        await listener.run()
+
+    assert events == [
+        "send_read_receipt",
+        "_maintain_typing_indicator",
+        "graph",
+        "send_typing_indicator",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_typing_indicator_refreshes_until_stopped() -> None:
+    """Long graph work gets repeated typing-start refreshes."""
+    from app.ingress import signal_listener
+
+    calls: list[dict[str, Any]] = []
+    stop_event = asyncio.Event()
+
+    async def fake_send_typing_indicator(
+        peer: str,
+        *,
+        started: bool = True,
+        base_url: str | None = None,
+        account: str | None = None,
+    ) -> None:
+        calls.append(
+            {
+                "peer": peer,
+                "started": started,
+                "base_url": base_url,
+                "account": account,
+            }
+        )
+        if len(calls) == 2:
+            stop_event.set()
+
+    with patch(
+        "app.ingress.signal_listener.send_typing_indicator",
+        new=fake_send_typing_indicator,
+    ):
+        await signal_listener._maintain_typing_indicator(
+            peer="+15551234567",
+            stop_event=stop_event,
+            base_url="http://signal-cli-test:8080",
+            account="<test-account>",
+            refresh_seconds=0,
+        )
+
+    assert calls == [
+        {
+            "peer": "+15551234567",
+            "started": True,
+            "base_url": "http://signal-cli-test:8080",
+            "account": "<test-account>",
+        },
+        {
+            "peer": "+15551234567",
+            "started": True,
+            "base_url": "http://signal-cli-test:8080",
+            "account": "<test-account>",
+        },
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Resolves #587

## Summary
- Added best-effort Signal read receipt and typing indicator primitives with shared retry/timeout behavior.
- Wired authorized inbound text messages to schedule a receipt before graph invocation and keep typing indicators refreshed while the graph runs.
- Added unit coverage for Signal REST payloads, listener ordering, and typing refresh behavior.

## Test Plan
- ruff check app/ tests/
- mypy app/
- pytest tests/unit/ -x
- pytest tests/integration/ -x skipped because DATABASE_URL is not set

## Review Pipeline Fallback
If review pipeline checks do not appear within 2 minutes of opening this PR,
comment `/review` on the PR to manually trigger a fresh review cycle.

Generated with Codex

Author-Session: codex/26545041732