### PR TITLE
feat(models): tier-based thinking control; route classify to cheap tier

### DIFF
--- a/app/graph/routing.py
+++ b/app/graph/routing.py
@@ -53,8 +53,9 @@ Examples:
 async def classify_intent(state: State) -> dict[str, Intent | None]:
     """Classify the incoming message intent using an LLM.
 
-    Uses the medium-tier model to classify intent.
-    Defaults low-confidence to CHAT as a prompt-injection mitigation.
+    Uses the cheap tier, which routes to a think=false model configuration
+    in app/models.py — classification needs a label, not reasoning. Defaults
+    low-confidence to CHAT as a prompt-injection mitigation.
     """
     incoming = state.get("incoming", "").strip()
     if not incoming:
@@ -65,7 +66,7 @@ async def classify_intent(state: State) -> dict[str, Intent | None]:
 
         from app.models import llm
 
-        model = llm("medium", caller="classify")
+        model = llm("cheap", caller="classify")
 
         # Pull a small window of prior turns so short follow-ups can resolve
         # against the active discussion (e.g. "by Friday" after an ADD_TASK turn).

--- a/app/models.py
+++ b/app/models.py
@@ -9,8 +9,8 @@ behavior is set here):
   medium    -> gemma4-small, think=on  (user-facing replies; shame-safety
                                         contract depends on careful phrasing)
   cheap     -> gemma4-small, think=off (label-only classification; reasoning
-                                        is wasted overhead — ~29x fewer
-                                        output tokens at equivalent accuracy)
+                                        is wasted overhead — significant token
+                                        reduction at equivalent accuracy)
   reminder  -> gemma4-small, think=on  (reminder cron; currently no caller)
 
 All tiers point at the same model alias because the LLM host can only
@@ -59,7 +59,7 @@ _VALID_MODEL_PREFIXES: tuple[str, ...] = ("claude-", "gemma", "gpt-")
 # Per-tier extra request body forwarded to the LiteLLM proxy. The proxy
 # passes `think` straight through to the Ollama backend. Cheap tier turns
 # reasoning off because its sole caller (intent classifier) only needs a
-# label — measured 29x token reduction with no accuracy loss on the
+# label — significant token reduction with no accuracy loss on the
 # classify prompt.
 _TIER_EXTRA_BODY: dict[str, dict[str, Any]] = {
     "cheap": {"think": False},

--- a/app/models.py
+++ b/app/models.py
@@ -3,15 +3,19 @@
 Reads model tier assignments from setup/model-tiers.json and exposes
 a single llm(tier) factory function. Validates model IDs at startup.
 
-Tiers:
-  expensive -> gemma4-small (complex reasoning: GET_TASK scoring)
-  medium    -> gemma4-small (intent classification, most nodes)
-  cheap     -> gemma4-small (lightweight tasks)
-  reminder  -> gemma4-small (reminder delivery cron)
+Tiers (model alias resolves via setup/model-tiers.json; per-tier reasoning
+behavior is set here):
+  expensive -> gemma4-small, think=on  (GET_TASK scoring; nuance matters)
+  medium    -> gemma4-small, think=on  (user-facing replies; shame-safety
+                                        contract depends on careful phrasing)
+  cheap     -> gemma4-small, think=off (label-only classification; reasoning
+                                        is wasted overhead — ~29x fewer
+                                        output tokens at equivalent accuracy)
+  reminder  -> gemma4-small, think=on  (reminder cron; currently no caller)
 
-All tiers currently collapse onto a single alias because the LLM host
-can only hold one Gemma model in RAM at a time; reintroducing distinct
-tiers is a one-line edit per tier in setup/model-tiers.json.
+All tiers point at the same model alias because the LLM host can only
+hold one Gemma model in RAM at a time. Differentiation lives entirely
+in the think flag for now.
 
 Model IDs are sent as OpenAI-format chat-completion requests to the
 LiteLLM proxy at ANTHROPIC_BASE_URL (the env var name is retained for
@@ -51,6 +55,15 @@ _VALID_TIERS: frozenset[str] = frozenset(["expensive", "medium", "cheap", "remin
 # Known model-ID prefixes accepted by the LiteLLM proxy. A startup-time
 # allowlist catches typos in setup/model-tiers.json before the first call.
 _VALID_MODEL_PREFIXES: tuple[str, ...] = ("claude-", "gemma", "gpt-")
+
+# Per-tier extra request body forwarded to the LiteLLM proxy. The proxy
+# passes `think` straight through to the Ollama backend. Cheap tier turns
+# reasoning off because its sole caller (intent classifier) only needs a
+# label — measured 29x token reduction with no accuracy loss on the
+# classify prompt.
+_TIER_EXTRA_BODY: dict[str, dict[str, Any]] = {
+    "cheap": {"think": False},
+}
 
 
 def _check_langsmith_guard() -> None:
@@ -165,6 +178,9 @@ def llm(tier: Tier, *, temperature: float = 0.0, caller: str | None = None) -> C
         "base_url": base_url,
         "api_key": os.environ["ANTHROPIC_API_KEY"],
     }
+    extra_body = _TIER_EXTRA_BODY.get(tier)
+    if extra_body:
+        kwargs["extra_body"] = extra_body
     base_model = ChatOpenAI(**kwargs)
 
     # Attach observability callback (one instance per llm() call so tier + caller

--- a/docs/python-rewrite/test-rig.md
+++ b/docs/python-rewrite/test-rig.md
@@ -227,8 +227,11 @@ change in `setup/model-tiers.json`; no Python adapter changes are required.
 All LLM routing stays through `app/models.py:llm(tier)`.
 
 Unit tests for provider-boundary behavior must assert the exact `ChatOpenAI`
-constructor payload (model id, temperature, max_tokens, base_url, api_key) to
-catch routing regressions that would still pass a class-assertion-only check.
+constructor payload (model id, temperature, max_tokens, base_url, api_key, and
+tier-specific `extra_body`) to catch routing regressions that would still pass
+a class-assertion-only check. Tests must assert that the `cheap` tier includes
+`extra_body={'think': False}` and that all other tiers do not set `think` unless
+a deliberate future change adds it.
 
 Three cost gates for eval runs:
 - `ENABLE_LIVE_LLM_EVALS=true` — required for any real LLM call; absent = `pytest.skip`

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -198,8 +198,8 @@ def test_cheap_tier_sets_think_false_extra_body() -> None:
     """llm('cheap') must construct ChatOpenAI with extra_body={'think': False}.
 
     The proxy forwards `think` to Ollama; cheap is the label-only classifier
-    path where reasoning is wasted overhead (~29x output-token reduction
-    measured). Other tiers must NOT set think=false because their callers
+    path where reasoning is wasted overhead (significant output-token
+    reduction measured). Other tiers must NOT set think=false because their callers
     (chat, rejection, breakdown coaching, selection) rely on reasoning for
     shame-safe phrasing and scoring nuance.
     """

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -194,6 +194,40 @@ def test_llm_raises_when_anthropic_api_key_missing() -> None:
     models_module._load_model_tiers.cache_clear()
 
 
+def test_cheap_tier_sets_think_false_extra_body() -> None:
+    """llm('cheap') must construct ChatOpenAI with extra_body={'think': False}.
+
+    The proxy forwards `think` to Ollama; cheap is the label-only classifier
+    path where reasoning is wasted overhead (~29x output-token reduction
+    measured). Other tiers must NOT set think=false because their callers
+    (chat, rejection, breakdown coaching, selection) rely on reasoning for
+    shame-safe phrasing and scoring nuance.
+    """
+    from app import models as models_module
+    models_module._load_model_tiers.cache_clear()
+
+    env = dict(os.environ)
+    env.pop("LANGSMITH_TRACING", None)
+    env.setdefault("ANTHROPIC_API_KEY", "test-key-not-used")
+    env.setdefault("ANTHROPIC_BASE_URL", "https://proxy.test/v1")
+
+    with patch.dict(os.environ, env, clear=True):
+        cheap = models_module.llm("cheap").bound  # unwrap RunnableBinding
+        assert getattr(cheap, "extra_body", None) == {"think": False}, (
+            f"cheap tier must send think=false; got extra_body={getattr(cheap, 'extra_body', None)!r}"
+        )
+
+        for tier in ("medium", "expensive", "reminder"):
+            other = models_module.llm(tier).bound
+            extra = getattr(other, "extra_body", None) or {}
+            assert "think" not in extra, (
+                f"{tier} tier must NOT set think (defaults to thinking=on); "
+                f"got extra_body={extra!r}"
+            )
+
+    models_module._load_model_tiers.cache_clear()
+
+
 def test_invalid_tier_raises_value_error() -> None:
     """llm() with unknown tier must raise ValueError."""
     from app import models as models_module


### PR DESCRIPTION
## Summary

- Adds per-tier `extra_body` plumbing in `app/models.py` and routes the intent classifier (`app/graph/routing.py`) from the `medium` tier to the `cheap` tier.
- The `cheap` tier sends `think: false` to the LiteLLM proxy (forwarded straight through to Ollama). All other tiers default to thinking-on so shame-safe user-facing replies and GET_TASK scoring keep their reasoning budget.
- Tier names finally map to actual behavior. Before this PR, `cheap` had zero callers — pure stub. Now `cheap` is the "fast label-only" lane, and `medium` is reserved for the user-facing reply path where reasoning matters.

## What the proxy does with `think`

LiteLLM forwards the `think` kwarg straight to the Ollama backend. With `think: false`, Gemma stops emitting chain-of-thought reasoning tokens before its visible answer.

## Measured impact

Perf rig (`ENABLE_LLM_PERF=true PERF_MODELS=cheap,medium PERF_RUNS_N=2`):

| | cheap (`think:false`) | medium (`think:true`) | win |
|---|---|---|---|
| median latency | **0.93 s** | 8.58 s | **9.2× faster** |
| p95 latency | **3.84 s** | 20.48 s | **5.3× faster** |
| mean output tokens | **58** | 455 | **7.8× fewer** |

End-to-end smoke against the live classifier on the eight canonical inputs from `_INTENT_SYSTEM_PROMPT`:

| input | expected | got |
|---|---|---|
| "I need to call the dentist tomorrow." | ADD_TASK | ✓ ADD_TASK |
| "What should I work on? I have 30 minutes." | GET_TASK | ✓ GET_TASK |
| "Done!" | COMPLETE | ✓ COMPLETE |
| "Not that one" | REJECT | ✓ REJECT |
| "This is way too big, I can't do all of this" | CANNOT_FINISH | ✓ CANNOT_FINISH |
| "How should I start? I'm stuck." | NEED_HELP | ✓ NEED_HELP |
| "Hello!" | CHAT | ✓ CHAT |
| "Good morning, how are you?" | CHAT | ✓ CHAT |

**8/8 classifier accuracy** with `think:false`. Per-call latency 1.8–3.3 s in the live run (vs. ~10 s with reasoning on).

## Tier semantics (model alias unchanged: `gemma4-small` for all four)

| Tier | think | Used by |
|---|---|---|
| `expensive` | on | `selection.py` (GET_TASK scoring; nuance matters) |
| `medium` | on | `chat`, `intake`, `rejection`, `cannot_finish`, `need_help`, `check_in` — shame-safety surface |
| `cheap` | **off** | `routing.py:classify_intent` (label-only) |
| `reminder` | on | no callers today (reminder cron delivers pre-stored outbox text) |

## Why not flip medium tier too

Shame-safety contract (`tests/unit/test_shame_safety.py` + `tests/evals/` shame_safe contracts) depends on careful phrasing in rejection / breakdown-coaching / chat replies. Turning thinking off there is a latency win at a quality risk. Classifier is the only `medium`-tier caller where the output is unambiguously safe to lose reasoning on (it returns one of seven enum labels), so it was promoted to its own lane.

## Test plan

- [x] `pytest tests/unit/` → 188/188 (new test `test_cheap_tier_sets_think_false_extra_body` pins the wiring and confirms other tiers don't accidentally inherit `think:false`).
- [x] Live perf rig: 9.2× median / 5.3× p95 latency win (numbers above).
- [x] Live classifier accuracy smoke: 8/8 correct intent labels.
- [ ] End-to-end via Signal once compose is configured against the proxy.

## Follow-ups to keep in mind

- If shame-safe quality regressions surface on the `medium` tier (now exclusively user-facing), the option of moving specific callers (e.g. `check_in`) to their own tier with bespoke `extra_body` is open.
- `reminder` tier currently has no callers — could be deleted entirely in a future cleanup, or left as a slot for the planned reminder-generation work.

Follow-up to #586.

🤖 Generated with [Claude Code](https://claude.com/claude-code)