### PR TITLE
[smoke] exercise two-lens security orchestrator end-to-end

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,10 @@
 """Entry point for the hide-my-list Python + LangGraph app.
 
 LangSmith guard: refuses to boot when LANGSMITH_TRACING=true unless
-ALLOW_PRIVATE_TRACE_EXPORT=true is also set.
+ALLOW_PRIVATE_TRACE_EXPORT=true is also set. The guard runs before any
+LangGraph wiring so a misconfigured deploy fails closed at startup
+rather than silently exporting private state to the LangSmith hosted
+backend.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
## Smoke test for §1.18 (two-lens security orchestrator)

Trivial docstring-only change to `app/main.py`. Purpose: exercise the deployed orchestrator end-to-end on a real PR run and confirm the wiring is correct after #585.

## What I'm verifying

- [ ] `review-classify` emits `security-breadth` + `security-narrow` (not legacy `security`) for a Python-touching diff
- [ ] Both lens reviewer jobs run and post their own PR Review comments
- [ ] `judge.mjs` imports `security-merge.mjs` from main and synthesizes a `role=security` artifact
- [ ] `review-judge.yml` re-uploads the synthesized artifact as `reviewer-security-<sha>`
- [ ] `render-finalize-comment.sh` shows **one** 🔐 security row in the agent table (not two lens rows, and not "did not run")
- [ ] The artifact carries a `summary_metadata` block with `merged_from: ["security-breadth", "security-narrow"]`

**Will close without merging** once the verdict shape is confirmed. No production impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)