### PR TITLE
fix(review-judge): gate synthesized security upload on step output

### DIFF
--- a/.github/scripts/review/judge.mjs
+++ b/.github/scripts/review/judge.mjs
@@ -55,6 +55,7 @@ for (const entry of readdirSync(REVIEWER_DIR, { withFileTypes: true })) {
 // exclusion filter, and confidence demotion deterministically.
 const breadthArtifact = reviewers.find((r) => r.role === "security-breadth");
 const narrowArtifact = reviewers.find((r) => r.role === "security-narrow");
+let synthesizedSecurityPath = "";
 if (breadthArtifact || narrowArtifact) {
   // Sanity check: both lenses must agree on reviewed_sha and cycle, or
   // the orchestration is broken (mixed epochs). aggregate() catches this
@@ -70,6 +71,7 @@ if (breadthArtifact || narrowArtifact) {
 
   if (MERGED_SECURITY_OUTPUT_PATH) {
     writeFileSync(MERGED_SECURITY_OUTPUT_PATH, JSON.stringify(merged, null, 2) + "\n");
+    synthesizedSecurityPath = MERGED_SECURITY_OUTPUT_PATH;
   }
 }
 
@@ -80,8 +82,17 @@ const verdict = aggregate(reviewers, fixResult);
 console.log(JSON.stringify(verdict, null, 2));
 writeFileSync(VERDICT_OUTPUT_PATH, JSON.stringify(verdict, null, 2) + "\n");
 
-// Emit GitHub Actions step output if running inside Actions.
+// Emit GitHub Actions step outputs if running inside Actions.
+// `synthesized_security_artifact` gates the workflow's upload step
+// for the merged security artifact — using a step output here avoids
+// the `hashFiles(absolute_path)` foot-gun (hashFiles silently returns
+// empty for non-workspace-relative paths, which caused PR #592's
+// upload to be skipped and the agent table to render `did not run`).
 const ghOut = process.env.GITHUB_OUTPUT;
 if (ghOut) {
-  writeFileSync(ghOut, `verdict=${verdict.verdict}\n`, { flag: "a" });
+  writeFileSync(
+    ghOut,
+    `verdict=${verdict.verdict}\nsynthesized_security_artifact=${synthesizedSecurityPath}\n`,
+    { flag: "a" }
+  );
 }

--- a/.github/workflows/review-judge.yml
+++ b/.github/workflows/review-judge.yml
@@ -89,12 +89,18 @@ jobs:
         # lens artifact was present. Skip the upload otherwise — the
         # finalize renderer treats a missing security row as "did not
         # run" and uses the absence as a signal.
-        if: hashFiles(format('{0}/security-result.json', runner.temp)) != ''
+        #
+        # Gate on the step output emitted by judge.mjs, not on
+        # `hashFiles()`: hashFiles requires workspace-relative globs
+        # and silently returns empty for the absolute `${runner.temp}`
+        # path we write to, which would always skip the upload (see
+        # PR #592 for the smoke test that surfaced this).
+        if: steps.aggregate.outputs.synthesized_security_artifact != ''
         uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: reviewer-security-${{ inputs.reviewed_sha }}
-          path: ${{ runner.temp }}/security-result.json
+          path: ${{ steps.aggregate.outputs.synthesized_security_artifact }}
 
       - name: Write verdict commit status
         uses: ./.github/actions/review-state


### PR DESCRIPTION
## Summary

PR #592 (smoke test for §1.18) revealed that the synthesized \`reviewer-security-<sha>\` artifact was never uploaded by the judge: the upload step's gate used \`hashFiles(format('{0}/security-result.json', runner.temp))\`, but \`hashFiles()\` only accepts workspace-relative globs and silently returns empty for the absolute \`\${runner.temp}\` path. The step was \`skipped\` on every run.

Symptom: agent table renders the 🔐 security row as \"_did not run_\" even when both lens reviewers ran and approved cleanly.

## Fix

- \`judge.mjs\` now emits a \`synthesized_security_artifact=<path>\` step output (empty string when no lens artifacts were merged).
- \`review-judge.yml\` gates the upload step on that step output and uses the same value for the upload path.

## Test plan

- [x] \`node --test\` against existing 47 unit tests passes.
- [ ] After this merges, re-push PR #592 (or open a new smoke PR) and confirm the agent table shows ✅ approve for the 🔐 security row, plus a \`reviewer-security-<sha>\` artifact attached to the workflow run with \`summary_metadata.merged_from: [\"security-breadth\", \"security-narrow\"]\`.

Fixes the bug surfaced by #592.

🤖 Generated with [Claude Code](https://claude.com/claude-code)