### PR TITLE
fix(tests): repair main-branch breakage from #589 + #590

### DIFF
--- a/tests/integration/test_signal_listener_ux.py
+++ b/tests/integration/test_signal_listener_ux.py
@@ -19,7 +19,7 @@ class _FakeAsyncClient:
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.base_url = kwargs.get("base_url")
 
-    async def __aenter__(self) -> "_FakeAsyncClient":
+    async def __aenter__(self) -> _FakeAsyncClient:
         return self
 
     async def __aexit__(self, *args: Any) -> None:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -214,8 +214,8 @@ def test_cheap_tier_sets_think_false_extra_body() -> None:
 
     env = dict(os.environ)
     env.pop("LANGSMITH_TRACING", None)
-    env.setdefault("ANTHROPIC_API_KEY", "test-key-not-used")
-    env.setdefault("ANTHROPIC_BASE_URL", "https://proxy.test/v1")
+    env.setdefault("LLM_PROXY_API_KEY", "test-key-not-used")
+    env.setdefault("LLM_PROXY_BASE_URL", "https://proxy.test/v1")
 
     with patch.dict(os.environ, env, clear=True):
         cheap = models_module.llm("cheap").bound  # unwrap RunnableBinding


### PR DESCRIPTION
## Summary

Two tests on `main` HEAD are red and block every downstream PR (surfaced by #594):

- **`tests/unit/test_models.py::test_cheap_tier_sets_think_false_extra_body`** — broken by #590. That PR renamed `ANTHROPIC_BASE_URL` / `ANTHROPIC_API_KEY` → `LLM_PROXY_BASE_URL` / `LLM_PROXY_API_KEY` and made the new names required (`_require_llm_proxy_config()` raises `RuntimeError` otherwise), but this one test was missed. Updated to use the new names.
- **`tests/integration/test_signal_listener_ux.py:22`** — broken by #589. Ruff `UP037`: the `__aenter__` return annotation `"_FakeAsyncClient"` is quoted, but the file already has `from __future__ import annotations`, so the quotes are dead weight. Unquoted.

No behavior change, no production code touched.

## Test plan

- [x] `ruff check app/ tests/ scripts/` — passes
- [x] `pytest tests/unit/` — 210 pass
- [ ] CI confirms

🤖 Generated with [Claude Code](https://claude.com/claude-code)