### PR TITLE
fix(lint): restore ruff I001 fix lost during PR #594 force-merge

### DIFF
--- a/tests/integration/test_notion_due_at.py
+++ b/tests/integration/test_notion_due_at.py
@@ -18,7 +18,6 @@ from pytest_httpserver import HTTPServer
 
 import app.tools.notion as notion_module
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root cause

PR #594 introduced `tests/integration/test_notion_due_at.py` with an extra blank line after the third-party import block (between `import app.tools.notion as notion_module` and the `# ---` separator comment at line 21). Ruff flags this as I001 (unsorted/unformatted import block).

PR #595 had previously fixed an analogous I001 violation in a different file (`tests/integration/test_signal_listener_ux.py`). PR #594's branch was created **before** #595 landed and was force-merged without the two PRs' import-block styles being cross-checked. The new file in #594 was not covered by #595's fix, so the violation shipped to main on the merge commit `00f39cf`.

This is **Possibility 2** from the diagnosis: PR #594 itself introduced a new ruff violation (in a new file it added) that wasn't caught locally, compounded by the force-merge bypassing the required CI gate.

## What changed

Removed one trailing blank line in `tests/integration/test_notion_due_at.py` (line 21 in the original), so the import block ends cleanly before the first separator comment.

```diff
 import app.tools.notion as notion_module

-
 # ---------------------------------------------------------------------------
 # Fixtures
```

## Verification

- `ruff check app/ tests/ scripts/` → `All checks passed!`
- `pytest tests/unit -x -q` (excluding the `test_reviewer_schema.py` dep-gap which is pre-existing and passes in CI where `jsonschema` is installed via `pip install -e ".[dev]"`) → 194 passed

## Why it happened

Force-merging PR #594 skipped the required `Python Validation Required` CI gate. Without branch protection on main preventing force-merges of red code, this class of regression can land. PR #596 (https://github.com/NickBorgersProbably/hide-my-list/pull/596) addresses the upstream gap in the pre-merge gate enforcement.

## Test plan

- [ ] CI ruff lint gate passes on this PR
- [ ] CI pytest-unit gate passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)