### PR TITLE
fix(fixer): install yamllint+ruff+pytest before host commit

### DIFF
--- a/.github/workflows/review-fixer.yml
+++ b/.github/workflows/review-fixer.yml
@@ -372,6 +372,24 @@ jobs:
             rm -f "$TEMP_SCHEMA"
           fi
 
+      # Install the tools that .githooks/pre-commit invokes via
+      # scripts/run-required-checks.sh. The host commit step below sets
+      # core.hooksPath=.githooks, which activates the same hook a
+      # developer runs locally — and the hook hard-fails when any of its
+      # required commands are missing. GH Actions runners don't ship
+      # yamllint / ruff / pytest, so without this step the hook aborts
+      # the commit with "required command 'yamllint' is not installed"
+      # the moment the fixer stages a workflow file. shellcheck is
+      # already on ubuntu-latest; python3 is too.
+      - name: Install pre-commit hook tooling
+        run: |
+          set -euo pipefail
+          python3 -m pip install --quiet --user \
+            yamllint==1.37.1 \
+            ruff==0.15.13 \
+            pytest==9.0.3
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       # Lint gate: run ruff against the full Python tree in the PR
       # workspace before committing. The pre-commit hook in .githooks/
       # only covers *staged* files, so it cannot catch violations that

--- a/tests/unit/test_fixer_lint_gate.py
+++ b/tests/unit/test_fixer_lint_gate.py
@@ -54,6 +54,38 @@ def test_lint_gate_precedes_commit_step() -> None:
     )
 
 
+def test_install_step_precedes_lint_gate() -> None:
+    """An 'Install pre-commit hook tooling' step must precede the ruff lint gate.
+
+    The host commit step sets core.hooksPath=.githooks, which activates
+    .githooks/pre-commit on every fixer commit. The hook calls
+    scripts/run-required-checks.sh, which hard-fails when yamllint / ruff /
+    pytest are missing — and GH Actions hosts don't ship them by default.
+    Without the install step, the fixer aborts every commit on a workflow PR
+    with "required command 'yamllint' is not installed".
+    """
+    text = _workflow_text()
+    install_pos = text.find("Install pre-commit hook tooling")
+    lint_pos = text.find("Ruff lint gate")
+    commit_pos = text.find("Commit fixer working-tree changes")
+    assert install_pos != -1, (
+        "Expected an 'Install pre-commit hook tooling' step in review-fixer.yml. "
+        "The host commit's pre-commit hook needs yamllint / ruff / pytest on PATH; "
+        "GH Actions runners don't provide them."
+    )
+    assert install_pos < lint_pos < commit_pos, (
+        "Install step must run before the ruff lint gate (which uses ruff) and "
+        "before the commit step (whose hook uses yamllint / ruff / pytest)."
+    )
+    install_block_end = text.find("\n      - name:", install_pos + 1)
+    install_block = text[install_pos:install_block_end] if install_block_end != -1 else text[install_pos:]
+    for tool in ("yamllint", "ruff", "pytest"):
+        assert tool in install_block, (
+            f"Install step must install '{tool}'. The pre-commit hook requires it "
+            f"whenever the fixer stages a file in its scope."
+        )
+
+
 def test_commit_step_activates_pre_commit_hook() -> None:
     """The commit step must set GIT_CONFIG_COUNT so core.hooksPath is active."""
     text = _workflow_text()


### PR DESCRIPTION
## Summary

Stacks on PR #596. Fixes the self-inflicted CI failure that broke #596's own fixer run:

```
ERROR: required command 'yamllint' is not installed.
Install the repo devcontainer or the local tooling before committing/pushing.
```

PR #596 activated `core.hooksPath=.githooks` on the host commit step so the developer pre-commit hook also gates the fixer's auto-commit. The hook calls `scripts/run-required-checks.sh`, which **hard-fails** when its required tools are missing — and GH Actions hosts don't ship yamllint / ruff / pytest. Result: every fixer commit that stages a workflow file aborts at the hook with the error above.

## Changes

1. **New step `Install pre-commit hook tooling`** in `.github/workflows/review-fixer.yml`, placed before the existing `Ruff lint gate (full tree, pre-commit)` step. pip-installs:
   - `yamllint==1.37.1` — required by `run_pre_commit_workflow_checks` whenever the fixer stages a workflow YAML file
   - `ruff==0.15.13` — required by `run_pre_commit_python_checks`, also makes the existing ruff gate non-skipping
   - `pytest==9.0.3` — required by `run_pre_commit_python_checks`
   
   Versions match `pyproject.toml`'s `[project.optional-dependencies].dev`. `shellcheck` and `python3` are already on `ubuntu-latest`.

2. **New structural test** `test_install_step_precedes_lint_gate` in `tests/unit/test_fixer_lint_gate.py` — locks in the install-step → lint-gate → commit-step ordering and verifies all three tools appear in the install step.

## Why pip rather than apt

`apt-get install yamllint` works but needs `sudo` and pulls in the Ubuntu-pinned version (older). pip lets us pin to a known version and skip `sudo`. Same approach `python-validation.yml` uses for ruff/pytest.

## Test plan

- [x] `pytest tests/unit/test_fixer_lint_gate.py` — all 5 tests pass (4 existing + 1 new)
- [x] `yamllint -c .yamllint .github/workflows/review-fixer.yml` — clean
- [x] `ruff check app/ tests/ scripts/` — clean
- [ ] CI confirms the fixer's `Apply reviewer-requested fixes` job now completes when staging workflow files

🤖 Generated with [Claude Code](https://claude.com/claude-code)