### PR TITLE
feat(scheduler): deadline_planner — milestone tiers + load-balancer + reminder summary

### DIFF
--- a/app/scheduler/deadline_planner.py
+++ b/app/scheduler/deadline_planner.py
@@ -1,0 +1,404 @@
+"""Deadline milestone planner — pure functions, no I/O.
+
+Computes a reminder schedule for a task with a deadline, balancing across
+existing scheduled reminders to avoid collisions. Used by:
+  - PR 4: intake node (inline scheduling immediately after task creation)
+  - PR 5: reminder_scheduler daemon (backstop for intake failures + deadline edits)
+
+No I/O, no DB, no async. Fully testable without infrastructure.
+
+Env-tunable defaults (read by callers via _env_defaults()):
+  REMINDER_SLOT_MINUTES      - time-slot bucket size (default 30)
+  REMINDER_SLOT_CAPACITY     - max reminders per slot bucket (default 2)
+  REMINDER_QUIET_START_HOUR  - quiet hours start (default 22, i.e. 10pm)
+  REMINDER_QUIET_END_HOUR    - quiet hours end   (default 8,  i.e. 8am)
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Literal
+from zoneinfo import ZoneInfo
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+Tier = Literal["dense", "standard", "sparse"]
+
+# ---------------------------------------------------------------------------
+# Tier table
+# ---------------------------------------------------------------------------
+
+_TIER_MILESTONES: dict[Tier, list[tuple[str, timedelta]]] = {
+    "dense": [
+        ("90d", timedelta(days=90)),
+        ("30d", timedelta(days=30)),
+        ("14d", timedelta(days=14)),
+        ("7d",  timedelta(days=7)),
+        ("3d",  timedelta(days=3)),
+        ("1d",  timedelta(days=1)),
+        ("4h",  timedelta(hours=4)),
+    ],
+    "standard": [
+        ("60d", timedelta(days=60)),
+        ("14d", timedelta(days=14)),
+        ("7d",  timedelta(days=7)),
+        ("3d",  timedelta(days=3)),
+        ("1d",  timedelta(days=1)),
+        ("4h",  timedelta(hours=4)),
+    ],
+    "sparse": [
+        ("60d", timedelta(days=60)),
+        ("14d", timedelta(days=14)),
+        ("3d",  timedelta(days=3)),
+        ("4h",  timedelta(hours=4)),
+    ],
+}
+
+# For end-of-day (17:00 local) deadlines: preferred local hour for
+# multi-day reminder ideal slots.  Sub-day milestones always use
+# deadline - offset so they anchor naturally to the clock time.
+_EOD_IDEAL_HOUR: dict[str, int] = {
+    "90d": 9,
+    "60d": 9,
+    "30d": 9,
+    "14d": 9,
+    "7d":  10,
+    "3d":  10,
+    "1d":  9,
+}
+
+# End-of-day sentinel: when deadline local time matches this hour/minute,
+# we treat the deadline as "end of day" and anchor ideal slots to morning times.
+_EOD_HOUR = 17
+_EOD_MINUTE = 0
+
+# Minimum lead time: a milestone is only included when it fires at least
+# this far in the future.
+_MIN_LEAD = timedelta(minutes=15)
+
+
+# ---------------------------------------------------------------------------
+# MilestoneSlot dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass
+class MilestoneSlot:
+    """A single planned reminder milestone.
+
+    Attributes:
+        label:    Human-readable offset string, e.g. "3d", "4h".
+        tier:     The tier that generated this milestone.
+        ideal_at: The ideal (unloaded) fire time, tz-aware.
+    """
+    label: str
+    tier: Tier
+    ideal_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def tier_for(urgency: int) -> Tier:
+    """Return the milestone tier for a given urgency score (0–100).
+
+    Args:
+        urgency: Integer urgency score. Values outside [0, 100] are accepted
+                 but clamped implicitly by the tier thresholds.
+
+    Returns:
+        "dense"    when urgency >= 80
+        "standard" when 40 <= urgency <= 79
+        "sparse"   when urgency < 40
+    """
+    if urgency >= 80:
+        return "dense"
+    if urgency >= 40:
+        return "standard"
+    return "sparse"
+
+
+def plan_milestones(
+    deadline_at: datetime,
+    urgency: int,
+    now: datetime,
+    *,
+    user_tz: str = "America/Chicago",
+) -> list[MilestoneSlot]:
+    """Compute ideal reminder slots for all milestones that fit in remaining time.
+
+    A milestone fits when ``(deadline_at - milestone_offset) > now + 15min``.
+
+    For clock-time deadlines (i.e. the deadline has a specific time other than
+    the end-of-day default of 17:00 local), ideal slots are anchored relative
+    to the clock time: ``ideal = deadline_at - offset``.
+
+    For end-of-day deadlines (17:00 local), multi-day milestones (>= 1d) use
+    a preferred morning hour in user-local time (see _EOD_IDEAL_HOUR), so the
+    reminder fires at a sensible time of day rather than 5pm-minus-offset.
+    Sub-day milestones (4h) always use ``deadline - 4h`` regardless.
+
+    Args:
+        deadline_at: Deadline datetime, must be tz-aware.
+        urgency:     Integer urgency score used to select the tier.
+        now:         Current time, must be tz-aware.
+        user_tz:     IANA timezone string for the user.
+
+    Returns:
+        List of MilestoneSlot, sorted by ideal_at ascending (earliest first).
+    """
+    tz = ZoneInfo(user_tz)
+    tier = tier_for(urgency)
+    milestones = _TIER_MILESTONES[tier]
+
+    # Determine whether the deadline is an end-of-day deadline.
+    deadline_local = deadline_at.astimezone(tz)
+    is_eod = (deadline_local.hour == _EOD_HOUR and deadline_local.minute == _EOD_MINUTE)
+
+    slots: list[MilestoneSlot] = []
+    for label, offset in milestones:
+        raw_ideal = deadline_at - offset
+
+        # Skip milestones that don't leave at least 15 min of lead time.
+        if raw_ideal <= now + _MIN_LEAD:
+            continue
+
+        # Determine the ideal fire time.
+        if is_eod and label in _EOD_IDEAL_HOUR:
+            # Anchor to a preferred morning hour on the milestone date.
+            milestone_date_local = raw_ideal.astimezone(tz).date()
+            preferred_hour = _EOD_IDEAL_HOUR[label]
+            ideal = datetime(
+                milestone_date_local.year,
+                milestone_date_local.month,
+                milestone_date_local.day,
+                preferred_hour,
+                0,
+                0,
+                tzinfo=tz,
+            )
+            # Safety: if the anchored time is in the past or too close to now,
+            # fall back to raw_ideal (offset-anchored).
+            if ideal <= now + _MIN_LEAD:
+                ideal = raw_ideal
+        else:
+            ideal = raw_ideal
+
+        slots.append(MilestoneSlot(label=label, tier=tier, ideal_at=ideal))
+
+    slots.sort(key=lambda s: s.ideal_at)
+    return slots
+
+
+def assign_slot(
+    ideal_slot: datetime,
+    existing_slots: list[datetime],
+    deadline_at: datetime,
+    *,
+    user_tz: str = "America/Chicago",
+    quiet_hours: tuple[int, int] = (22, 8),
+    slot_minutes: int = 30,
+    slot_capacity: int = 2,
+    max_drift_minutes: int = 720,
+    now: datetime | None = None,
+) -> tuple[datetime, bool]:
+    """Find an available slot near the ideal time.
+
+    Walks outward from the ideal slot in ``slot_minutes`` increments, trying
+    earlier times first (never in the past, never past deadline), skipping
+    quiet hours and over-capacity buckets.  Falls back to the ideal if no
+    open slot is found within ``max_drift_minutes``.
+
+    Args:
+        ideal_slot:       Desired fire time (tz-aware).
+        existing_slots:   Already-assigned reminder datetimes in the window.
+        deadline_at:      Task deadline (tz-aware); result must be < deadline_at.
+        user_tz:          IANA timezone for quiet-hours evaluation.
+        quiet_hours:      ``(start_hour, end_hour)`` in user-local time.
+                          Times in [start_hour, 24) ∪ [0, end_hour) are quiet.
+        slot_minutes:     Bucket granularity in minutes.
+        slot_capacity:    Maximum allowed reminders per bucket.
+        max_drift_minutes: Search radius around the ideal slot.
+        now:              "Never fire in past" cutoff.  Defaults to
+                          ``deadline_at - timedelta(hours=1)`` when None.
+
+    Returns:
+        ``(chosen_slot, used_fallback)`` where ``used_fallback`` is True when
+        no open slot was found and the caller should emit an ops_alert.
+    """
+    if now is None:
+        now = deadline_at - timedelta(hours=1)
+
+    tz = ZoneInfo(user_tz)
+    q_start, q_end = quiet_hours
+    step = timedelta(minutes=slot_minutes)
+    max_drift = timedelta(minutes=max_drift_minutes)
+
+    # Snap ideal_slot to nearest bucket boundary.
+    snapped_ideal = _snap_to_bucket(ideal_slot, slot_minutes)
+
+    def _bucket_key(dt: datetime) -> datetime:
+        return _snap_to_bucket(dt, slot_minutes)
+
+    def _occupancy(candidate: datetime) -> int:
+        key = _bucket_key(candidate)
+        return sum(1 for s in existing_slots if _bucket_key(s) == key)
+
+    def _in_quiet(candidate: datetime) -> bool:
+        local_h = candidate.astimezone(tz).hour
+        if q_start < q_end:
+            # Quiet window doesn't cross midnight
+            return q_start <= local_h < q_end
+        else:
+            # Crosses midnight: quiet when hour >= q_start OR hour < q_end
+            return local_h >= q_start or local_h < q_end
+
+    def _is_valid(candidate: datetime) -> bool:
+        """Candidate is valid if: > now+15min, < deadline, not quiet, not full."""
+        if candidate <= now + _MIN_LEAD:
+            return False
+        if candidate >= deadline_at:
+            return False
+        if _in_quiet(candidate):
+            return False
+        if _occupancy(candidate) >= slot_capacity:
+            return False
+        return True
+
+    if _is_valid(snapped_ideal):
+        return snapped_ideal, False
+
+    # Walk outward from snapped_ideal: try earlier steps (i=1,2,...) before
+    # the corresponding later step.  Stop when both sides exhaust max_drift.
+    steps = int(max_drift / step)
+    for i in range(1, steps + 1):
+        earlier = snapped_ideal - step * i
+        later   = snapped_ideal + step * i
+
+        if earlier >= snapped_ideal - max_drift:
+            if _is_valid(earlier):
+                return earlier, False
+
+        if later <= snapped_ideal + max_drift:
+            if _is_valid(later):
+                return later, False
+
+    # Nothing found within max_drift — return ideal with fallback flag.
+    return ideal_slot, True
+
+
+def format_reminder_summary(
+    slots: list[tuple[str, datetime]],
+    user_tz: str = "America/Chicago",
+) -> str:
+    """Format a human-readable reminder summary for task confirmations.
+
+    Args:
+        slots:    List of ``(milestone_label, assigned_slot)`` pairs, ordered
+                  as the caller wants them presented.
+        user_tz:  IANA timezone for display.
+
+    Returns:
+        A sentence like ``"I'll ping you Wed noon, Thu 9am, Thu 8am."``
+        Returns empty string when ``slots`` is empty.
+
+    Examples:
+        >>> format_reminder_summary([("3d", wed_noon), ("1d", thu_9am)], "America/Chicago")
+        "I'll ping you Wed noon, Thu 9am."
+        >>> format_reminder_summary([], "America/Chicago")
+        ""
+    """
+    if not slots:
+        return ""
+
+    tz = ZoneInfo(user_tz)
+    parts: list[str] = []
+    for _label, dt in slots:
+        local = dt.astimezone(tz)
+        parts.append(_format_datetime(local))
+
+    if len(parts) == 1:
+        return f"I'll ping you {parts[0]}."
+    return "I'll ping you " + ", ".join(parts) + "."
+
+
+# ---------------------------------------------------------------------------
+# Env defaults helper (callers do the env read; pure-function discipline)
+# ---------------------------------------------------------------------------
+
+def _env_defaults() -> dict[str, int | tuple[int, int]]:
+    """Read reminder scheduling defaults from environment variables.
+
+    Returns a dict of kwargs suitable for passing to assign_slot:
+      slot_minutes, slot_capacity, quiet_hours.
+
+    Callers pass these as **kwargs; assign_slot itself takes them as plain
+    parameters so it remains a pure function.
+
+    Example::
+
+        defaults = _env_defaults()
+        slot, fallback = assign_slot(ideal, existing, deadline, **defaults)
+    """
+    slot_minutes   = int(os.environ.get("REMINDER_SLOT_MINUTES",   "30"))
+    slot_capacity  = int(os.environ.get("REMINDER_SLOT_CAPACITY",  "2"))
+    quiet_start    = int(os.environ.get("REMINDER_QUIET_START_HOUR", "22"))
+    quiet_end      = int(os.environ.get("REMINDER_QUIET_END_HOUR",   "8"))
+    return {
+        "slot_minutes":  slot_minutes,
+        "slot_capacity": slot_capacity,
+        "quiet_hours":   (quiet_start, quiet_end),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _snap_to_bucket(dt: datetime, slot_minutes: int) -> datetime:
+    """Round dt down to the nearest slot_minutes boundary (UTC-based)."""
+    total_minutes = int(dt.timestamp() // 60)
+    snapped_minutes = (total_minutes // slot_minutes) * slot_minutes
+    return datetime.fromtimestamp(snapped_minutes * 60, tz=dt.tzinfo)
+
+
+def _format_datetime(local: datetime) -> str:
+    """Format a local datetime as a natural-language string.
+
+    Examples:
+        12:00 → "noon"
+        00:00 → "midnight"
+        08:00 → "8am"
+        13:00 → "1pm"
+        09:30 → "9:30am"
+        22:30 → "10:30pm"
+    """
+    h = local.hour
+    m = local.minute
+    day = local.strftime("%a")  # e.g. "Wed"
+
+    if h == 12 and m == 0:
+        return f"{day} noon"
+    if h == 0 and m == 0:
+        return f"{day} midnight"
+
+    # 12-hour format
+    if h == 0:
+        period = "am"
+        display_h = 12
+    elif h < 12:
+        period = "am"
+        display_h = h
+    elif h == 12:
+        period = "pm"
+        display_h = 12
+    else:
+        period = "pm"
+        display_h = h - 12
+
+    if m == 0:
+        return f"{day} {display_h}{period}"
+    return f"{day} {display_h}:{m:02d}{period}"

--- a/tests/integration/test_deadline_planner_smoke.py
+++ b/tests/integration/test_deadline_planner_smoke.py
@@ -1,0 +1,193 @@
+"""Integration smoke test for app.scheduler.deadline_planner.
+
+Exercises the full public API surface in an integration-shaped manner:
+computes a milestone plan, assigns slots for each milestone, and verifies
+no collisions emerge.  No DB or I/O — "integration" here means the functions
+compose correctly end-to-end, satisfying test-rig clause 1 for new public
+functions.
+
+Reachability for the DB-touching callers lands in:
+  - PR 4: tests/integration/test_intake.py (inline scheduling path)
+  - PR 5: tests/integration/test_reminder_scheduler.py (daemon path)
+
+Private data: all values use placeholders / synthetic datetimes.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from app.scheduler.deadline_planner import (
+    assign_slot,
+    format_reminder_summary,
+    plan_milestones,
+    tier_for,
+)
+
+_TZ_STR = "America/Chicago"
+_TZ = ZoneInfo(_TZ_STR)
+
+
+def _local(year: int, month: int, day: int, hour: int = 0, minute: int = 0) -> datetime:
+    return datetime(year, month, day, hour, minute, tzinfo=_TZ)
+
+
+class TestDeadlinePlannerSmoke:
+    """End-to-end composition: plan → assign → summarise → no collisions."""
+
+    def test_dense_plan_assign_no_collisions(self) -> None:
+        """Dense tier: plan all 7 milestones, assign slots, assert no bucket collisions."""
+        now = _local(2026, 1, 1, 10, 0)
+        deadline = _local(2026, 7, 20, 17, 0)   # ~200 days away
+
+        assert tier_for(85) == "dense"
+        milestones = plan_milestones(deadline, urgency=85, now=now, user_tz=_TZ_STR)
+        assert len(milestones) == 7
+
+        assigned: list[datetime] = []
+        fallback_count = 0
+        for m in milestones:
+            slot, used_fallback = assign_slot(
+                m.ideal_at,
+                assigned,
+                deadline,
+                user_tz=_TZ_STR,
+                quiet_hours=(22, 8),
+                slot_minutes=30,
+                slot_capacity=2,
+                max_drift_minutes=720,
+                now=now,
+            )
+            if used_fallback:
+                fallback_count += 1
+            assigned.append(slot)
+            # Slot must be before deadline
+            assert slot < deadline
+            # Slot must be after now (with 15-min lead)
+            assert slot > now + timedelta(minutes=15)
+
+        # All 7 milestones spaced far apart → no fallbacks expected
+        assert fallback_count == 0, f"Unexpected fallbacks: {fallback_count}"
+
+    def test_standard_plan_assign_summary_roundtrip(self) -> None:
+        """Standard tier: plan → assign → format_reminder_summary roundtrip."""
+        now = _local(2026, 6, 1, 10, 0)
+        deadline = _local(2026, 6, 30, 17, 0)   # 29 days away
+
+        milestones = plan_milestones(deadline, urgency=60, now=now, user_tz=_TZ_STR)
+        assert len(milestones) > 0
+
+        assigned: list[tuple[str, datetime]] = []
+        for m in milestones:
+            slot, _ = assign_slot(
+                m.ideal_at,
+                [s for _, s in assigned],
+                deadline,
+                user_tz=_TZ_STR,
+                quiet_hours=(22, 8),
+                slot_minutes=30,
+                slot_capacity=2,
+                max_drift_minutes=720,
+                now=now,
+            )
+            assigned.append((m.label, slot))
+
+        summary = format_reminder_summary(assigned, user_tz=_TZ_STR)
+        assert summary.startswith("I'll ping you ")
+        assert summary.endswith(".")
+
+    def test_sparse_short_deadline_single_reminder(self) -> None:
+        """Sparse tier + 2-day deadline → exactly 1 milestone (4h), valid slot."""
+        now = _local(2026, 6, 1, 10, 0)
+        deadline = _local(2026, 6, 3, 17, 0)   # 55h away
+
+        milestones = plan_milestones(deadline, urgency=20, now=now, user_tz=_TZ_STR)
+        assert len(milestones) == 1
+        assert milestones[0].label == "4h"
+
+        slot, fallback = assign_slot(
+            milestones[0].ideal_at,
+            [],
+            deadline,
+            user_tz=_TZ_STR,
+            quiet_hours=(22, 8),
+            slot_minutes=30,
+            slot_capacity=2,
+            max_drift_minutes=720,
+            now=now,
+        )
+        assert not fallback
+        assert slot < deadline
+        assert slot > now + timedelta(minutes=15)
+
+    def test_10_tasks_assign_no_slot_overflow(self) -> None:
+        """Simulate 10 tasks with 3d deadline each; assign all slots; bucket occupancy <= capacity."""
+        now = _local(2026, 6, 1, 10, 0)
+        deadline = _local(2026, 6, 4, 17, 0)   # 3 days away
+        capacity = 2
+
+        all_slots: list[datetime] = []
+        for task_i in range(10):
+            # Stagger urgency so we get a mix of sparse/standard
+            urgency = 30 + task_i * 5   # 30..75
+            milestones = plan_milestones(deadline, urgency=urgency, now=now, user_tz=_TZ_STR)
+            for m in milestones:
+                slot, _ = assign_slot(
+                    m.ideal_at,
+                    all_slots,
+                    deadline,
+                    user_tz=_TZ_STR,
+                    quiet_hours=(22, 8),
+                    slot_minutes=30,
+                    slot_capacity=capacity,
+                    max_drift_minutes=720,
+                    now=now,
+                )
+                all_slots.append(slot)
+
+        # Count occupancy per 30-min bucket
+        from collections import Counter
+
+        def _bucket(dt: datetime) -> int:
+            return int(dt.timestamp()) // (30 * 60)
+
+        counts = Counter(_bucket(s) for s in all_slots)
+        overflow = {k: v for k, v in counts.items() if v > capacity}
+        assert not overflow, f"Bucket(s) exceed capacity={capacity}: {overflow}"
+
+    def test_format_empty_returns_empty(self) -> None:
+        """Empty milestone list → empty summary string."""
+        now = _local(2026, 6, 10, 12, 0)
+        deadline = _local(2026, 6, 5, 17, 0)   # past deadline → no milestones
+        milestones = plan_milestones(deadline, urgency=80, now=now, user_tz=_TZ_STR)
+        assert milestones == []
+        summary = format_reminder_summary([], user_tz=_TZ_STR)
+        assert summary == ""
+
+    def test_quiet_hours_respected_across_all_assignments(self) -> None:
+        """No assigned slot falls in quiet hours (22:00–08:00 local)."""
+        now = _local(2026, 1, 1, 10, 0)
+        deadline = _local(2026, 7, 20, 17, 0)
+
+        milestones = plan_milestones(deadline, urgency=85, now=now, user_tz=_TZ_STR)
+        assigned: list[datetime] = []
+        for m in milestones:
+            slot, _ = assign_slot(
+                m.ideal_at,
+                assigned,
+                deadline,
+                user_tz=_TZ_STR,
+                quiet_hours=(22, 8),
+                slot_minutes=30,
+                slot_capacity=2,
+                max_drift_minutes=720,
+                now=now,
+            )
+            assigned.append(slot)
+
+        for slot in assigned:
+            local_h = slot.astimezone(_TZ).hour
+            # Not in quiet window [22, 24) ∪ [0, 8)
+            assert 8 <= local_h < 22, (
+                f"Slot {slot.astimezone(_TZ).isoformat()} falls in quiet hours (hour={local_h})"
+            )

--- a/tests/unit/test_deadline_planner.py
+++ b/tests/unit/test_deadline_planner.py
@@ -1,0 +1,400 @@
+"""Unit tests for app.scheduler.deadline_planner.
+
+Table-driven. Covers tier selection, milestone clipping, load-balancing
+outward walk, quiet-hours skip, never-past-deadline guard, fallback flag,
+and format_reminder_summary round-trips.
+
+No I/O, no DB, no async — all functions are pure.
+
+Private data: all test values use placeholder strings / synthetic datetimes.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.scheduler.deadline_planner import (
+    MilestoneSlot,
+    assign_slot,
+    format_reminder_summary,
+    plan_milestones,
+    tier_for,
+)
+
+# Use a fixed timezone throughout tests.
+_TZ_STR = "America/Chicago"
+_TZ = ZoneInfo(_TZ_STR)
+
+
+def _local(year: int, month: int, day: int, hour: int = 0, minute: int = 0) -> datetime:
+    """Build a tz-aware datetime in America/Chicago."""
+    return datetime(year, month, day, hour, minute, tzinfo=_TZ)
+
+
+def _utc(year: int, month: int, day: int, hour: int = 0, minute: int = 0) -> datetime:
+    """Build a tz-aware datetime in UTC."""
+    return datetime(year, month, day, hour, minute, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# tier_for — 6 table-driven cases
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("urgency,expected", [
+    (0,   "sparse"),
+    (39,  "sparse"),
+    (40,  "standard"),
+    (79,  "standard"),
+    (80,  "dense"),
+    (100, "dense"),
+])
+def test_tier_for(urgency: int, expected: str) -> None:
+    assert tier_for(urgency) == expected
+
+
+# ---------------------------------------------------------------------------
+# plan_milestones
+# ---------------------------------------------------------------------------
+
+class TestPlanMilestones:
+
+    def test_6_month_out_dense_returns_7_milestones(self) -> None:
+        """6-month deadline + dense urgency → all 7 milestones (90d..4h)."""
+        now = _local(2026, 1, 1, 10, 0)
+        # Deadline 200 days away (>90d) at end-of-day
+        deadline = _local(2026, 7, 20, 17, 0)
+        slots = plan_milestones(deadline, urgency=85, now=now, user_tz=_TZ_STR)
+        assert len(slots) == 7
+        labels = [s.label for s in slots]
+        assert labels == ["90d", "30d", "14d", "7d", "3d", "1d", "4h"]
+
+    def test_5_day_out_standard_clips_past_milestones(self) -> None:
+        """5-day deadline + standard urgency → only 3d, 1d, 4h milestones."""
+        now = _local(2026, 6, 1, 10, 0)
+        deadline = _local(2026, 6, 6, 17, 0)   # 5 days away
+        slots = plan_milestones(deadline, urgency=50, now=now, user_tz=_TZ_STR)
+        labels = [s.label for s in slots]
+        # 60d, 14d, 7d are in the past → clipped; 3d, 1d, 4h fit
+        assert "60d" not in labels
+        assert "14d" not in labels
+        assert "7d" not in labels
+        assert set(labels) == {"3d", "1d", "4h"}
+        assert len(slots) == 3
+
+    def test_1_day_out_sparse_returns_1_milestone(self) -> None:
+        """1-day deadline + sparse urgency → only 4h milestone."""
+        now = _local(2026, 6, 1, 10, 0)
+        deadline = _local(2026, 6, 2, 17, 0)   # ~31h away
+        slots = plan_milestones(deadline, urgency=20, now=now, user_tz=_TZ_STR)
+        labels = [s.label for s in slots]
+        assert labels == ["4h"]
+
+    def test_22h_clock_time_deadline_dense_yields_4h_at_6am(self) -> None:
+        """22h-out clock-time deadline (10am tomorrow) + dense → 1 milestone (4h ≈ 6am).
+
+        The 1d milestone is clipped because deadline - 1d is at or before now.
+        The 4h milestone ideal is deadline - 4h = 6am (clock-time anchoring).
+        """
+        now = _local(2026, 6, 1, 12, 0)        # noon today
+        deadline = _local(2026, 6, 2, 10, 0)   # 10am tomorrow (22h away, NOT end-of-day)
+        slots = plan_milestones(deadline, urgency=85, now=now, user_tz=_TZ_STR)
+        assert len(slots) == 1, f"Expected 1 slot, got {len(slots)}: {[s.label for s in slots]}"
+        assert slots[0].label == "4h"
+        # ideal_at should be 6am (deadline - 4h)
+        expected_ideal = deadline - timedelta(hours=4)
+        assert slots[0].ideal_at == expected_ideal
+
+    def test_past_deadline_returns_empty(self) -> None:
+        """Deadline in the past → empty list."""
+        now = _local(2026, 6, 10, 12, 0)
+        deadline = _local(2026, 6, 5, 17, 0)   # in the past
+        slots = plan_milestones(deadline, urgency=80, now=now, user_tz=_TZ_STR)
+        assert slots == []
+
+    def test_16_minutes_out_returns_empty(self) -> None:
+        """16-minute-out deadline → empty list (4h milestone would be -3h44m in past)."""
+        now = _local(2026, 6, 1, 12, 0)
+        deadline = now + timedelta(minutes=16)
+        # 4h-before fires at deadline - 4h = now - 3h44m → in the past → skipped
+        slots = plan_milestones(deadline, urgency=80, now=now, user_tz=_TZ_STR)
+        assert slots == []
+
+    def test_slots_sorted_ascending(self) -> None:
+        """plan_milestones returns slots sorted by ideal_at ascending."""
+        now = _local(2026, 1, 1, 10, 0)
+        deadline = _local(2026, 7, 20, 17, 0)
+        slots = plan_milestones(deadline, urgency=85, now=now, user_tz=_TZ_STR)
+        assert len(slots) >= 2
+        for a, b in zip(slots, slots[1:], strict=False):
+            assert a.ideal_at <= b.ideal_at
+
+    def test_milestone_slot_dataclass_fields(self) -> None:
+        """MilestoneSlot has label, tier, ideal_at fields."""
+        now = _local(2026, 1, 1, 10, 0)
+        deadline = _local(2026, 4, 15, 17, 0)
+        slots = plan_milestones(deadline, urgency=80, now=now, user_tz=_TZ_STR)
+        assert len(slots) > 0
+        s = slots[0]
+        assert isinstance(s, MilestoneSlot)
+        assert isinstance(s.label, str)
+        assert s.tier in ("dense", "standard", "sparse")
+        assert s.ideal_at.tzinfo is not None  # tz-aware
+
+
+# ---------------------------------------------------------------------------
+# assign_slot
+# ---------------------------------------------------------------------------
+
+class TestAssignSlot:
+
+    def _make_ideal(self) -> datetime:
+        """A simple ideal slot: Wednesday 10am local."""
+        return _local(2026, 6, 3, 10, 0)   # Wednesday
+
+    def _make_deadline(self) -> datetime:
+        """Deadline safely after the ideal."""
+        return _local(2026, 6, 6, 17, 0)
+
+    def test_empty_existing_returns_ideal(self) -> None:
+        """No existing slots → returns (ideal_snapped, False)."""
+        ideal = self._make_ideal()
+        slot, fallback = assign_slot(
+            ideal, [], self._make_deadline(),
+            user_tz=_TZ_STR,
+            quiet_hours=(22, 8),
+            slot_minutes=30,
+            slot_capacity=2,
+            max_drift_minutes=720,
+            now=_local(2026, 6, 1, 10, 0),
+        )
+        assert not fallback
+        assert slot <= ideal + timedelta(minutes=30)  # within one bucket of ideal
+
+    def test_full_ideal_bucket_walks_earlier(self) -> None:
+        """When ideal bucket is full, assign_slot returns a slot 30 min earlier."""
+        ideal = _local(2026, 6, 3, 10, 0)
+        deadline = _local(2026, 6, 6, 17, 0)
+        now = _local(2026, 6, 1, 8, 0)
+        # Two existing slots at the ideal time (fills capacity=2)
+        existing = [ideal, ideal + timedelta(minutes=5)]
+        slot, fallback = assign_slot(
+            ideal, existing, deadline,
+            user_tz=_TZ_STR,
+            quiet_hours=(22, 8),
+            slot_minutes=30,
+            slot_capacity=2,
+            max_drift_minutes=720,
+            now=now,
+        )
+        assert not fallback
+        # Should be 30 min before ideal (biased earlier)
+        assert slot < ideal
+
+    def test_full_bucket_and_earlier_also_full_walks_back_further(self) -> None:
+        """If ideal and ideal-30min are both full, walks to an adjacent open slot."""
+        ideal = _local(2026, 6, 3, 10, 0)
+        deadline = _local(2026, 6, 6, 17, 0)
+        now = _local(2026, 6, 1, 8, 0)
+        # Fill ideal and ideal-30min buckets; also fill ideal+30 to force wider walk
+        minus30 = ideal - timedelta(minutes=30)
+        plus30  = ideal + timedelta(minutes=30)
+        existing = [ideal, ideal, minus30, minus30, plus30, plus30]   # 2 each → all full
+        slot, fallback = assign_slot(
+            ideal, existing, deadline,
+            user_tz=_TZ_STR,
+            quiet_hours=(22, 8),
+            slot_minutes=30,
+            slot_capacity=2,
+            max_drift_minutes=720,
+            now=now,
+        )
+        assert not fallback
+        # Must be outside the three packed buckets
+        assert slot not in (ideal, minus30, plus30)
+        # Should be earlier or later by >=60 min from ideal
+        assert abs((slot - ideal).total_seconds()) >= 3600
+
+    def test_past_guard_causes_later_walk(self) -> None:
+        """When walking earlier would cross now+15min, falls through to later."""
+        # ideal is only 20 min after now → can't walk earlier at all
+        now = _local(2026, 6, 3, 9, 0)
+        ideal = _local(2026, 6, 3, 9, 30)   # only 30 min after now
+        deadline = _local(2026, 6, 6, 17, 0)
+        # Fill the ideal bucket
+        existing = [ideal, ideal]
+        slot, fallback = assign_slot(
+            ideal, existing, deadline,
+            user_tz=_TZ_STR,
+            quiet_hours=(22, 8),
+            slot_minutes=30,
+            slot_capacity=2,
+            max_drift_minutes=720,
+            now=now,
+        )
+        assert not fallback
+        # Must be later than ideal since earlier is blocked by the past guard
+        assert slot > ideal
+
+    def test_never_returns_slot_at_or_after_deadline(self) -> None:
+        """assign_slot never returns a slot >= deadline."""
+        ideal = _local(2026, 6, 3, 10, 0)
+        deadline = _local(2026, 6, 3, 11, 0)   # deadline only 1h after ideal
+        now = _local(2026, 6, 1, 8, 0)
+        # Fill every earlier bucket but leave ideal empty
+        slot, fallback = assign_slot(
+            ideal, [], deadline,
+            user_tz=_TZ_STR,
+            quiet_hours=(22, 8),
+            slot_minutes=30,
+            slot_capacity=2,
+            max_drift_minutes=720,
+            now=now,
+        )
+        assert slot < deadline
+
+    def test_all_slots_full_returns_fallback_true(self) -> None:
+        """When all slots within max_drift are full, returns (ideal, True)."""
+        ideal = _local(2026, 6, 3, 10, 0)
+        deadline = _local(2026, 6, 6, 17, 0)
+        now = _local(2026, 6, 1, 8, 0)
+        max_drift_minutes = 60  # only ±60 min search window
+        steps = max_drift_minutes // 30 + 1
+
+        # Pack every bucket within ±60 min (plus ideal itself)
+        existing: list[datetime] = []
+        for i in range(-steps, steps + 1):
+            t = ideal + timedelta(minutes=30 * i)
+            existing.extend([t, t])   # 2 per bucket → full
+
+        slot, fallback = assign_slot(
+            ideal, existing, deadline,
+            user_tz=_TZ_STR,
+            quiet_hours=(22, 8),
+            slot_minutes=30,
+            slot_capacity=2,
+            max_drift_minutes=max_drift_minutes,
+            now=now,
+        )
+        assert fallback is True
+        assert slot == ideal   # returns original ideal (not snapped) on fallback
+
+    def test_quiet_hours_6am_target_pushed_to_8am(self) -> None:
+        """Ideal at 6am is in quiet hours (22-8); assign_slot pushes to 8am."""
+        # ideal = 6am local (quiet hours 22-8 → 6am is quiet)
+        ideal = _local(2026, 6, 3, 6, 0)
+        deadline = _local(2026, 6, 6, 17, 0)
+        now = _local(2026, 6, 1, 8, 0)
+        slot, fallback = assign_slot(
+            ideal, [], deadline,
+            user_tz=_TZ_STR,
+            quiet_hours=(22, 8),
+            slot_minutes=30,
+            slot_capacity=2,
+            max_drift_minutes=720,
+            now=now,
+        )
+        assert not fallback
+        local_slot = slot.astimezone(_TZ)
+        assert local_slot.hour >= 8, f"Expected slot at or after 8am, got {local_slot.hour}:{local_slot.minute:02d}"
+
+    def test_high_urgency_small_drift_returns_fallback_sooner(self) -> None:
+        """max_drift=120 with packed schedule → fallback True sooner than default."""
+        ideal = _local(2026, 6, 3, 10, 0)
+        deadline = _local(2026, 6, 6, 17, 0)
+        now = _local(2026, 6, 1, 8, 0)
+        # Fill ±120 min with capacity=2 each
+        existing: list[datetime] = []
+        for i in range(-5, 6):
+            t = ideal + timedelta(minutes=30 * i)
+            existing.extend([t, t])
+
+        slot_small, fallback_small = assign_slot(
+            ideal, existing, deadline,
+            user_tz=_TZ_STR,
+            quiet_hours=(22, 8),
+            slot_minutes=30,
+            slot_capacity=2,
+            max_drift_minutes=120,
+            now=now,
+        )
+        assert fallback_small is True
+
+        # With default max_drift=720, the same schedule would have open slots
+        # (we only packed ±150 min worth of buckets, so outside that window is open)
+        slot_default, fallback_default = assign_slot(
+            ideal, existing, deadline,
+            user_tz=_TZ_STR,
+            quiet_hours=(22, 8),
+            slot_minutes=30,
+            slot_capacity=2,
+            max_drift_minutes=720,
+            now=now,
+        )
+        assert fallback_default is False
+
+
+# ---------------------------------------------------------------------------
+# format_reminder_summary
+# ---------------------------------------------------------------------------
+
+class TestFormatReminderSummary:
+
+    def test_three_slots_same_week(self) -> None:
+        """3 slots in the same week → comma-separated day+time list."""
+        slots = [
+            ("3d", _local(2026, 6, 3, 12, 0)),   # Wed noon
+            ("1d", _local(2026, 6, 4, 9, 0)),     # Thu 9am
+            ("4h", _local(2026, 6, 4, 8, 0)),     # Thu 8am  (listed by label order)
+        ]
+        result = format_reminder_summary(slots, user_tz=_TZ_STR)
+        assert result == "I'll ping you Wed noon, Thu 9am, Thu 8am."
+
+    def test_one_slot(self) -> None:
+        """Single slot → singular form."""
+        slots = [("4h", _local(2026, 6, 5, 8, 0))]  # Thu 8am (June 5 2026 is a Friday)
+        result = format_reminder_summary(slots, user_tz=_TZ_STR)
+        # Just check structure and that it starts with "I'll ping you "
+        assert result.startswith("I'll ping you ")
+        assert result.endswith(".")
+
+    def test_empty_returns_empty_string(self) -> None:
+        """Empty slot list → empty string."""
+        result = format_reminder_summary([], user_tz=_TZ_STR)
+        assert result == ""
+
+    def test_midnight_label(self) -> None:
+        """Slot at midnight → 'midnight', not '12am'."""
+        slots = [("4h", _local(2026, 6, 3, 0, 0))]  # Wednesday midnight
+        result = format_reminder_summary(slots, user_tz=_TZ_STR)
+        assert "midnight" in result
+        assert "12am" not in result
+
+    def test_noon_label(self) -> None:
+        """Slot at noon → 'noon', not '12pm'."""
+        slots = [("3d", _local(2026, 6, 3, 12, 0))]  # Wednesday noon
+        result = format_reminder_summary(slots, user_tz=_TZ_STR)
+        assert "noon" in result
+        assert "12pm" not in result
+
+    def test_am_pm_formatting(self) -> None:
+        """Regular hours format correctly as Xam / Xpm."""
+        slots_am = [("1d", _local(2026, 6, 4, 9, 0))]
+        slots_pm = [("1d", _local(2026, 6, 4, 21, 0))]
+        assert "9am" in format_reminder_summary(slots_am, user_tz=_TZ_STR)
+        assert "9pm" in format_reminder_summary(slots_pm, user_tz=_TZ_STR)
+
+    def test_minute_suffix_included_when_nonzero(self) -> None:
+        """Times with non-zero minutes include the minute portion."""
+        slots = [("4h", _local(2026, 6, 4, 9, 30))]
+        result = format_reminder_summary(slots, user_tz=_TZ_STR)
+        assert "9:30am" in result
+
+    def test_tz_conversion_applied(self) -> None:
+        """Datetimes are converted to user_tz before formatting."""
+        # 15:00 UTC = 10:00 CDT (America/Chicago, UTC-5 in June)
+        dt_utc = _utc(2026, 6, 3, 15, 0)
+        slots = [("3d", dt_utc)]
+        result = format_reminder_summary(slots, user_tz=_TZ_STR)
+        assert "10am" in result

--- a/tests/unit/test_reachability.py
+++ b/tests/unit/test_reachability.py
@@ -79,6 +79,12 @@ _KNOWN_DEAD: frozenset[str] = frozenset(
         # app/tools/rewards.py — apply_feedback_weight defined but not called.
         # Cleanup: wire into record_reward_feedback or remove.
         "apply_feedback_weight",  # never called; feedback weight logic unused
+        # app/scheduler/deadline_planner.py — plan_milestones is the deadline
+        # reminder series planner. Pure function; PR 4 (intake inline scheduling
+        # in app/graph/nodes/intake.py) and PR 5 (daemon backstop in
+        # app/scheduler/reminder_scheduler.py) will add real callers. Remove
+        # this entry when those PRs land.
+        "plan_milestones",
     ]
 )
 


### PR DESCRIPTION
## Summary

PR 3 of 7 in the deadline-reminders epic. Adds `app/scheduler/deadline_planner.py` — a pure-function module with no I/O, no DB, no async. It is the algorithm core consumed by:

- **PR 4** (intake node — inline scheduling immediately after task creation)
- **PR 5** (reminder_scheduler daemon — backstop for intake failures + deadline edits)

## What this PR adds

### `tier_for(urgency: int) -> Tier`

Maps urgency score to one of three milestone densities:

| Urgency | Tier | Milestones (before deadline) |
|---|---|---|
| ≥ 80 | dense | 90d, 30d, 14d, 7d, 3d, 1d, 4h |
| 40–79 | standard | 60d, 14d, 7d, 3d, 1d, 4h |
| < 40 | sparse | 60d, 14d, 3d, 4h |

### `plan_milestones(deadline_at, urgency, now, *, user_tz)`

Returns `list[MilestoneSlot]` (label, tier, ideal_at), filtered to milestones where `deadline - offset > now + 15min`. Sorted ascending by `ideal_at`.

Two deadline flavors handled:
- **Clock-time deadline** (e.g. "10am tomorrow"): `ideal = deadline - offset` exactly — 4h-before of 10am fires at 6am.
- **End-of-day deadline** (17:00 local, the default when no time is given): multi-day milestones anchor to a preferred morning hour (1d → 9am, 3d → 10am, etc.) so the reminder fires at a useful time of day, not 5pm-minus-offset.

### `assign_slot(ideal_slot, existing_slots, deadline_at, *, ...)`

Load-balancer. Walks outward from the ideal time in `slot_minutes` increments, trying **earlier first** (never in the past; never ≥ deadline; skip quiet hours 22:00–08:00 local; skip buckets at capacity). Falls back to `(ideal, True)` when nothing found within `max_drift_minutes` — caller emits an ops_alert.

Tunable via kwargs (callers read from env via `_env_defaults()`):
- `REMINDER_SLOT_MINUTES` (default 30)
- `REMINDER_SLOT_CAPACITY` (default 2)
- `REMINDER_QUIET_START_HOUR` / `REMINDER_QUIET_END_HOUR` (default 22 / 8)

### `format_reminder_summary(slots, user_tz)`

Natural-language formatter. `"I'll ping you Wed noon, Thu 9am, Thu 8am."` Special-cases noon and midnight; handles am/pm; includes minutes when non-zero.

## Tests

**30 unit tests** (`tests/unit/test_deadline_planner.py`):
- `tier_for`: 6 parametrized boundary cases
- `plan_milestones`: 6-month dense (7 milestones), 5-day standard (3 milestones clipped), 1-day sparse (1 milestone), 22h clock-time dense (4h only, ideal = 6am), past deadline (empty), 16-min-out (empty), sort order, dataclass field types
- `assign_slot`: empty list → ideal, full ideal bucket → walk earlier, both packed → walk further, past-guard forces later walk, never-past-deadline, all-full fallback flag, quiet hours 6am → pushed to 8am, high-urgency small-drift returns fallback sooner
- `format_reminder_summary`: 3 slots, 1 slot, empty, midnight label, noon label, am/pm, minute suffix, tz conversion

**6 integration smoke tests** (`tests/integration/test_deadline_planner_smoke.py`):
- Dense plan 7 milestones, assign all, verify no fallbacks and slot < deadline
- Standard plan + assign + summary roundtrip
- Sparse 2-day deadline → 1 slot valid
- 10 tasks sharing one deadline window → no bucket overflow
- Empty/past deadline → empty summary
- Quiet hours respected across all assignments

## Test-rig clause 1 note

These are pure functions — no DB/HTTP/async. Reachability tests (the DB-calling integration tests that exercise these functions from production call sites) land in:
- PR 4: `tests/integration/test_intake.py` (inline scheduling path)
- PR 5: `tests/integration/test_reminder_scheduler.py` (daemon path)

The integration smoke file here exercises the full public API surface end-to-end (plan → assign → summarise → collision check) without a DB, satisfying the "new public functions need integration coverage" clause with a no-infra shape. Full call-site reachability completes in PR 4/5.

## Test plan

- [x] `pytest tests/unit/test_deadline_planner.py -x -q` — 30 passed
- [x] `pytest tests/integration/test_deadline_planner_smoke.py -x -q` — 6 passed
- [x] `ruff check app/scheduler/deadline_planner.py tests/unit/test_deadline_planner.py tests/integration/test_deadline_planner_smoke.py` — clean
- [x] `mypy app/scheduler/deadline_planner.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)