### PR TITLE
feat(reminders): deadline-driven reminder series + daemon backstop + intake rewrite

### DIFF
--- a/DEV-AGENTS.md
+++ b/DEV-AGENTS.md
@@ -39,7 +39,7 @@ These are the authoritative behavioral contracts. The Python implementation in `
 
 The Python/LangGraph application. Safe to edit via PRs.
 
-- `app/tools/notion.py` — Notion API client (9 verbs + health_check)
+- `app/tools/notion.py` — Notion API client (11 verbs + health_check); includes `query_tasks_with_unscheduled_deadlines` and `mark_reminder_scheduled` for deadline-reminder plumbing
 - `app/tools/signal_client.py` — Signal bridge async client
 - `app/tools/reminders.py` — Reminder outbox CRUD
 - `app/tools/rewards.py` — Reward delivery (emoji + image; v1 scope)
@@ -59,7 +59,10 @@ The Python/LangGraph application. Safe to edit via PRs.
 - `app/graph/nodes/complete.py` — COMPLETE intent node
 - `app/graph/nodes/send.py` — Terminal send node
 - `app/scheduler/scheduler.py` — APScheduler v3 wiring with PostgresJobStore
-- `app/scheduler/jobs.py` — Declarative SCHEDULED_JOBS list + reconcile_jobstore; jobs: `reminder_dispatcher`, `notion_health`, `ops_alerts_drain`, `state_audit`, `check_in_dispatcher`, `weekly_recap`
+- `app/scheduler/jobs.py` — Declarative SCHEDULED_JOBS list + reconcile_jobstore; jobs: `reminder_dispatcher`, `notion_health`, `ops_alerts_drain`, `state_audit`, `reminder_scheduler`, `check_in_dispatcher`, `weekly_recap`
+- `app/scheduler/deadline_planner.py` — Pure-function milestone planner: `tier_for`, `plan_milestones`, `assign_slot` (load-balanced slot finder), `format_reminder_summary`; no I/O
+- `app/scheduler/reminder_scheduling.py` — Shared scheduling helper `schedule_for_task`; called by intake (inline) and daemon (backstop); also `supersede_ledger_rows`, `cancel_outbox_rows`, `get_active_deadline_for_page`
+- `app/scheduler/reminder_scheduler.py` — Nightly backstop daemon `run_reminder_scheduler`; picks up tasks intake missed or deadlines edited in Notion; runs at 04:00 USER_TZ
 - `app/scheduler/reminder_worker.py` — SELECT FOR UPDATE SKIP LOCKED worker
 - `app/ingress/signal_listener.py` — Authorized Signal WebSocket consumer; routes reactions to reward feedback, schedules read receipts, maintains typing indicators around graph execution, and invokes the graph for text messages
 - `app/prompts/` — Jinja2 prompt templates (`*.md.j2`) for each intent

--- a/app/graph/nodes/intake.py
+++ b/app/graph/nodes/intake.py
@@ -1,18 +1,24 @@
-"""ADD_TASK node: task intake with label inference, sub-task generation, reminder detection.
+"""ADD_TASK node: task intake with label inference, deadline detection, and reminder scheduling.
 
-Ports docs/ai-prompts/intake.md (464 lines) behavior:
+Ports docs/ai-prompts/intake.md behavior:
 - Aggressive label inference (urgency, work_type, time_estimate)
-- Sub-task generation for every task
-- Reminder detection (wall-clock time → outbox row)
-- Clarification flow (max 3 questions)
+- Deadline detection: phrases like "by Friday", "before next Wednesday" set due_at
+- Stakes detection: high-stakes tasks with no deadline trigger ONE clarification question
+- Sub-task generation on request only (explicit breakdown routes to NEED_HELP)
+- Reminder detection (wall-clock time → outbox row via existing path)
+- Inline reminder scheduling for deadline tasks immediately after task creation
+- Clarification flow (max 3 questions, stakes-clarification counts as one)
 - Reschedule from recent_outbound context
 
-When a reminder is detected:
-- Creates Notion row via app/tools/notion.create_reminder()
-- Enqueues outbox row via app/tools/reminders.enqueue()
-- Uses app/tools/time_context to resolve user-local time
+DEADLINE REMINDER SCHEDULING:
+After notion.create_task() succeeds with a due_at_iso, the node calls
+schedule_for_task() from app/scheduler/reminder_scheduling.py to plan and
+enqueue the milestone reminder series inline. If any milestone enqueue fails,
+an ops_alert is emitted and Reminder Scheduled At is left empty so the nightly
+reminder_scheduler daemon can retry.
 
-REMINDER PERSISTENCE uses the outbox state machine; the reminder worker (APScheduler) handles delivery.
+REMINDER PERSISTENCE uses the outbox state machine; the reminder_worker (APScheduler)
+handles delivery. The reminder_scheduling_ledger tracks assigned slots for load balancing.
 """
 from __future__ import annotations
 
@@ -28,8 +34,9 @@ from app.graph.state import OutboundDraft, State
 
 log = structlog.get_logger(__name__)
 
+
 async def intake_node(state: State) -> dict[str, Any]:
-    """ADD_TASK handler: infer labels, generate sub-tasks, detect reminders."""
+    """ADD_TASK handler: infer labels, detect deadlines, schedule reminders, save task."""
     peer = state.get("peer", "")
 
     try:
@@ -104,15 +111,21 @@ async def intake_node(state: State) -> dict[str, Any]:
         inline_steps = parsed.get("inline_steps", "")
         use_hidden_subtasks = bool(parsed.get("use_hidden_subtasks", False))
         sub_tasks = parsed.get("sub_tasks", [])
-        confirmation_message = parsed.get("confirmation_message", f"Got it — {work_type}, ~{time_estimate} min.")
+        due_at_iso = parsed.get("due_at") or None
+        is_high_stakes = bool(parsed.get("is_high_stakes", False))
+        confirmation_message = parsed.get(
+            "confirmation_message",
+            f"Saved — {work_type}, ~{time_estimate} min.",
+        )
 
         log.info(
             "intake_node.parsed",
             is_reminder=is_reminder,
             has_remind_at=bool(remind_at_str),
-            remind_at=remind_at_str,  # ISO timestamp; not PII
+            remind_at=remind_at_str,
             urgency=urgency,
             time_estimate=time_estimate,
+            has_due_at=bool(due_at_iso),
         )
 
         if is_reminder and remind_at_str:
@@ -123,8 +136,13 @@ async def intake_node(state: State) -> dict[str, Any]:
                 energy_required=energy_required,
                 remind_at_str=remind_at_str,
             )
+            page_id = (notion_page or {}).get("id")
         else:
-            log.info("intake_node.no_reminder", has_remind_at=bool(remind_at_str), is_reminder=is_reminder)
+            log.info(
+                "intake_node.no_reminder",
+                has_remind_at=bool(remind_at_str),
+                is_reminder=is_reminder,
+            )
             notion_page = await notion.create_task(
                 title=task_title,
                 work_type=work_type,
@@ -132,11 +150,31 @@ async def intake_node(state: State) -> dict[str, Any]:
                 time_estimate=time_estimate,
                 energy_required=energy_required,
                 inline_steps=inline_steps,
+                due_at_iso=due_at_iso,
             )
+            page_id = (notion_page or {}).get("id")
 
-        page_id = (notion_page or {}).get("id")
+            # Inline reminder scheduling for deadline tasks.
+            if due_at_iso and page_id and not is_reminder:
+                confirmation_message = await _schedule_deadline_reminders(
+                    page_id=page_id,
+                    title=task_title,
+                    peer=peer,
+                    due_at_iso=due_at_iso,
+                    urgency=urgency,
+                    user_timezone=user_timezone,
+                    is_high_stakes=is_high_stakes,
+                    confirmation_message=confirmation_message,
+                )
+            elif not due_at_iso and not is_reminder and not is_high_stakes:
+                # Low-stakes task with no deadline: add the no-ping disclaimer.
+                confirmation_message = (
+                    f"{confirmation_message} "
+                    "No deadline, so I won't ping you. Reply 'remind me' if you want one."
+                )
 
-        # Create hidden sub-tasks if needed
+        # Create hidden sub-tasks if needed (explicit user request path via NEED_HELP,
+        # or when the LLM still populates use_hidden_subtasks for complex tasks).
         if use_hidden_subtasks and sub_tasks and page_id:
             for sub in sub_tasks:
                 try:
@@ -172,6 +210,106 @@ async def intake_node(state: State) -> dict[str, Any]:
             "notion_page_id": None,
         }
         return {"pending_outbound": [fallback]}
+
+
+async def _schedule_deadline_reminders(
+    *,
+    page_id: str,
+    title: str,
+    peer: str,
+    due_at_iso: str,
+    urgency: int,
+    user_timezone: str,
+    is_high_stakes: bool,
+    confirmation_message: str,
+) -> str:
+    """Schedule inline milestone reminders for a deadline task.
+
+    Calls schedule_for_task, appends a deterministic reminder summary to the
+    confirmation message (NOT generated by the LLM to avoid hallucinated times).
+
+    Returns the (possibly augmented) confirmation_message string.
+    """
+    from app.scheduler.deadline_planner import format_reminder_summary
+    from app.scheduler.reminder_scheduling import schedule_for_task
+    from app.tools import notion, ops_alerts
+
+    try:
+        normalized = due_at_iso.strip().replace("Z", "+00:00")
+        deadline_at = datetime.fromisoformat(normalized)
+        if deadline_at.tzinfo is None:
+            deadline_at = deadline_at.replace(tzinfo=UTC)
+    except (ValueError, TypeError) as exc:
+        log.warning("intake_node.due_at_parse_failed", due_at_iso=due_at_iso, error=str(exc))
+        return confirmation_message
+
+    now = datetime.now(UTC)
+
+    try:
+        assigned_slots, enqueue_failures = await schedule_for_task(
+            page_id=page_id,
+            title=title,
+            peer=peer,
+            deadline_at=deadline_at,
+            urgency=urgency,
+            now=now,
+            user_tz=user_timezone,
+        )
+    except Exception as exc:
+        log.exception("intake_node.schedule_for_task_failed", page_id=page_id, error=str(exc))
+        enqueue_failures = ["schedule_error"]
+        assigned_slots = []
+
+    if assigned_slots and not enqueue_failures:
+        # All milestones successfully enqueued — mark scheduled and append summary.
+        try:
+            await notion.mark_reminder_scheduled(page_id)
+        except Exception as notion_exc:
+            # Non-fatal: outbox rows exist; daemon retries mark_reminder_scheduled.
+            log.warning(
+                "intake_node.mark_scheduled_failed",
+                page_id=page_id,
+                error=str(notion_exc),
+            )
+
+        summary = format_reminder_summary(assigned_slots, user_timezone)
+        if summary:
+            confirmation_message = f"{confirmation_message} {summary}"
+
+    elif enqueue_failures:
+        # Partial or full failure — daemon backstop will retry tonight.
+        log.warning(
+            "intake_node.reminder_partial_failure",
+            page_id=page_id,
+            failed_milestones=enqueue_failures,
+        )
+        try:
+            await ops_alerts.enqueue(
+                kind="intake_reminder_partial_failure",
+                body=(
+                    "intake: inline reminder scheduling partially failed for <page_id>. "
+                    f"Failed milestones: {enqueue_failures}. "
+                    "reminder_scheduler daemon will retry tonight."
+                ),
+                severity="warning",
+            )
+        except Exception as alert_exc:
+            log.error("intake_node.ops_alert_failed", error=str(alert_exc))
+
+        confirmation_message = (
+            f"{confirmation_message} "
+            "(Couldn't schedule reminders right now — I'll retry tonight.)"
+        )
+
+    elif not assigned_slots:
+        # Deadline too close or already past — no milestones fit.
+        # Mark scheduled to stop daemon from retrying indefinitely.
+        try:
+            await notion.mark_reminder_scheduled(page_id)
+        except Exception:
+            pass
+
+    return confirmation_message
 
 
 async def _create_reminder(
@@ -230,7 +368,7 @@ async def _create_reminder(
                 from app.tools import ops_alerts
                 await ops_alerts.enqueue(
                     kind="reminder_enqueue_failed",
-                    body=f"Reminder outbox enqueue failed for page {page_id!r}. Reminder exists in Notion but will not be delivered until the outbox row is created.",
+                    body="Reminder outbox enqueue failed for <page_id>. Reminder exists in Notion but will not be delivered until the outbox row is created.",
                     severity="warning",
                 )
             except Exception:
@@ -273,10 +411,12 @@ def _parse_intake_response(response_text: str) -> dict[str, Any]:
         "energy_required": "Medium",
         "is_reminder": False,
         "remind_at": None,
+        "due_at": None,
+        "is_high_stakes": False,
         "use_hidden_subtasks": False,
         "sub_tasks": [],
         "inline_steps": "",
-        "confirmation_message": "Got it — added.",
+        "confirmation_message": "Saved — added.",
     }
 
 

--- a/app/prompts/intake.md.j2
+++ b/app/prompts/intake.md.j2
@@ -2,7 +2,7 @@
 
 ### Module 2: Task Intake
 
-The user wants to add a task. Extract details, infer labels, and ALWAYS generate sub-tasks.
+The user wants to add a task. Extract details and infer labels aggressively.
 
 User said: "{{ user_message | default('') }}"
 Previous context: {{ conversation_history | default('No prior context.') }}
@@ -12,28 +12,6 @@ Current user time: {{ current_time | default('') }}
 User timezone: {{ user_timezone | default('America/Chicago') }}
 
 ### Task Intake Prompt
-
-CORE PRINCIPLE: Users interpret vague goals as infinite and avoid them.
-Every task MUST have explicit sub-tasks that define exactly what "done" looks like.
-
-### Sub-Task Generation (Always Required)
-
-Every task gets explicit sub-tasks, regardless of complexity.
-- Quick tasks (15-30 min): 2-3 inline steps shown with the task
-- Standard tasks (30-60 min): 3-5 inline steps
-- Large tasks (60+ min): Create as hidden Notion sub-tasks
-
-### Storage Decision Rules
-
-STORAGE DECISION (use_hidden_subtasks):
-- true: Store as separate Notion tasks (for tasks > 60 min or multi-phase work)
-- false: Store as inline steps in task description (for tasks <= 60 min)
-
-BREAKDOWN SIGNALS (use_hidden_subtasks=true):
-- Vague scope: "complete the project", "finish the report", "work on X"
-- Multi-phase: tasks requiring research -> draft -> review -> finalize
-- Long duration: estimated > 60 minutes
-- Multiple deliverables: "prepare and send", "design and implement"
 
 ### Decision Fatigue Prevention
 
@@ -48,6 +26,56 @@ CLARIFYING QUESTIONS (last resort):
 - Ask ONE question at a time — never multiple questions in a single message
 - Maximum 3 clarifying questions per task — after 3, infer and save with best guess
 - Never ask about labels (urgency, time, energy) — always infer those
+
+### DEADLINE DETECTION
+
+When the user's message contains a deadline phrase, parse it to an ISO 8601 datetime.
+
+Deadline phrases:
+- "before <date/day>" — e.g. "before next Wednesday", "before Friday"
+- "by <date/day>" — e.g. "by end of month", "by the 15th"
+- "due <date>" — e.g. "due Thursday", "due July 1st"
+- "at <time> <date>" / "<date> at <time>" — e.g. "at 10am tomorrow", "Friday at noon"
+- "needs to be done <date>" — e.g. "needs to be done this week"
+- "finish by <date>", "complete by <date>", "submit by <date>"
+
+When detected:
+- Parse to ISO 8601 using user timezone: {{ user_timezone | default('America/Chicago') }}
+- Resolve relative references ("tomorrow", "next week", day names) against current_time
+- When a clock time is given ("at 10am"), use that exact time
+- When no clock time is given ("by Friday"), default to 17:00 local (end of business day)
+- Set `due_at` in output (distinct from `remind_at` — deadline ≠ explicit reminder)
+- `due_at` and `urgency` are independent: urgency = relative priority; due_at = hard time bound
+
+Examples:
+  "Cancel my appointment before next Wednesday" at current_time 2026-06-01T10:00 Central →
+    due_at: "2026-06-03T17:00:00-05:00"
+  "Finish the report by 10am tomorrow" at current_time 2026-06-01T09:00 Central →
+    due_at: "2026-06-02T10:00:00-05:00"
+  "Pay taxes by April 15" at current_time 2026-03-01T12:00 Central →
+    due_at: "2026-04-15T17:00:00-05:00"
+
+### STAKES DETECTION
+
+Some tasks are too important to silently park without a deadline. If a task matches
+a high-stakes category AND no deadline phrase was detected, ask ONE clarification
+question: "When do you want this done by?"
+
+Then resume normal intake with the user's answer parsed as due_at.
+
+High-stakes categories (LLM judgment — list is illustrative, not exhaustive):
+- Life/family protection: life insurance, will, estate, beneficiaries, custody
+- Health: medical appointments, prescriptions, screenings, referrals, lab work
+- Legal: contracts, court dates, regulatory filings, immigration paperwork
+- Financial protection: taxes, mortgage, loan deadlines, insurance renewals
+- Safety: home maintenance with safety implications (smoke alarms, recalls)
+
+Rules:
+- This is the ONLY automatic clarification for non-vague tasks (deadline-missing high-stakes)
+- Low-stakes deadlineless tasks ("organize bookshelf", "research vacation spots") save silently
+- If the user answers "I don't know" or similar, save with no due_at but set urgency = 70
+- The stakes-clarification counts as one of the max-3 clarification questions
+- Set `is_high_stakes: true` in output when a task matches a high-stakes category
 
 ### Reminder Detection
 
@@ -94,26 +122,48 @@ If task is clear enough to save:
   "energy_required": "High|Medium|Low",
   "is_reminder": false,
   "remind_at": null,
+  "due_at": null,
+  "is_high_stakes": false,
   "use_hidden_subtasks": false,
-  "sub_tasks": [{"title": "...", "time_estimate_minutes": 10, "done_criteria": "...", "sequence": 1}],
-  "inline_steps": "1. First step\n2. Second step",
-  "confirmation_message": "Got it — focus, ~30 min. Plan: 1) X, 2) Y"
+  "sub_tasks": [],
+  "inline_steps": "",
+  "confirmation_message": "Saved — focus, ~30 min, due Fri."
 }
 
-If task is too vague and clarification_count < 3:
+If task is too vague or is high-stakes with no deadline and clarification_count < 3:
 {
   "action": "clarify",
   "clarification_question": "...",
   "clarification_count": 1
 }
 
-### Confirmation Message Format
+### Confirmation Format
 
-- For inline steps: "Got it — [work type], ~[time]. Here's your plan: 1) X, 2) Y, 3) Z"
-- For hidden sub-tasks: "Got it — [work type], ~[time]. First step: [step]. This is 1 of [N] steps."
+For ALL tasks (no sub-tasks in the confirmation by default):
+- "Saved — [work type], ~[time]." (no deadline)
+- "Saved — [work type], ~[time], due [humanized deadline]." (with deadline)
 - For reminders: "Got it — I'll remind you [time description] to [task]."
 
-REMINDER CONFIRMATION SAFETY:
-- Never mention cron jobs, polling, outbox, Notion writes, or scheduling internals
+Do NOT include numbered plan steps or "Here's your plan: 1)..." in the confirmation.
+Do NOT list sub-tasks inline. The LLM-generated confirmation is the leading clause;
+the app node appends the reminder schedule summary deterministically from assigned slots.
+
+When you detect a deadline, include the humanized deadline in confirmation_message:
+"Saved — independent, ~15 min, due Wed." (not the ISO timestamp, a human form)
+
+### Sub-Tasks On Request Only
+
+Intake saves the task with labels. Sub-task generation is NOT automatic.
+If the user explicitly asks for breakdown ("how do I start?", "break this down",
+"what are the steps?"), that routes to NEED_HELP, not here.
+
+The `use_hidden_subtasks` and `sub_tasks` fields are only populated when the
+task itself is inherently multi-step and the user explicitly asked for a breakdown.
+For standard intake: leave `use_hidden_subtasks: false` and `sub_tasks: []`.
+
+### Confirmation Safety
+
+- Never mention cron jobs, polling, outbox, Notion writes, ledger, or scheduling internals
 - Never include self-commentary about what you did, did not do, or considered internally
-- The visible confirmation should be a single short sentence, then stop
+- The visible confirmation should be a brief acknowledgment sentence, then stop
+- Reminder confirmations: do not append notes about automatic retry, daemon, or Notion status

--- a/app/scheduler/deadline_planner.py
+++ b/app/scheduler/deadline_planner.py
@@ -1,0 +1,409 @@
+"""Deadline milestone planner — pure functions, no I/O.
+
+Computes a reminder schedule for a task with a deadline, balancing across
+existing scheduled reminders to avoid collisions. Used by:
+  - app/scheduler/reminder_scheduling.py: schedule_for_task (called by both
+    intake node inline scheduling and reminder_scheduler daemon backstop)
+
+No I/O, no DB, no async. Fully testable without infrastructure.
+
+Env-tunable defaults (read by callers via _env_defaults()):
+  REMINDER_SLOT_MINUTES      - time-slot bucket size (default 30)
+  REMINDER_SLOT_CAPACITY     - max reminders per slot bucket (default 2)
+  REMINDER_QUIET_START_HOUR  - quiet hours start (default 22, i.e. 10pm)
+  REMINDER_QUIET_END_HOUR    - quiet hours end   (default 8,  i.e. 8am)
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Literal
+from zoneinfo import ZoneInfo
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+Tier = Literal["dense", "standard", "sparse"]
+
+# ---------------------------------------------------------------------------
+# Tier table
+# ---------------------------------------------------------------------------
+
+_TIER_MILESTONES: dict[Tier, list[tuple[str, timedelta]]] = {
+    "dense": [
+        ("90d", timedelta(days=90)),
+        ("30d", timedelta(days=30)),
+        ("14d", timedelta(days=14)),
+        ("7d",  timedelta(days=7)),
+        ("3d",  timedelta(days=3)),
+        ("1d",  timedelta(days=1)),
+        ("4h",  timedelta(hours=4)),
+    ],
+    "standard": [
+        ("60d", timedelta(days=60)),
+        ("14d", timedelta(days=14)),
+        ("7d",  timedelta(days=7)),
+        ("3d",  timedelta(days=3)),
+        ("1d",  timedelta(days=1)),
+        ("4h",  timedelta(hours=4)),
+    ],
+    "sparse": [
+        ("60d", timedelta(days=60)),
+        ("14d", timedelta(days=14)),
+        ("3d",  timedelta(days=3)),
+        ("4h",  timedelta(hours=4)),
+    ],
+}
+
+# For end-of-day (17:00 local) deadlines: preferred local hour for
+# multi-day reminder ideal slots.  Sub-day milestones always use
+# deadline - offset so they anchor naturally to the clock time.
+_EOD_IDEAL_HOUR: dict[str, int] = {
+    "90d": 9,
+    "60d": 9,
+    "30d": 9,
+    "14d": 9,
+    "7d":  10,
+    "3d":  10,
+    "1d":  9,
+}
+
+# End-of-day sentinel: when deadline local time matches this hour/minute,
+# we treat the deadline as "end of day" and anchor ideal slots to morning times.
+_EOD_HOUR = 17
+_EOD_MINUTE = 0
+
+# Minimum lead time: a milestone is only included when it fires at least
+# this far in the future.
+_MIN_LEAD = timedelta(minutes=15)
+
+
+# ---------------------------------------------------------------------------
+# MilestoneSlot dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass
+class MilestoneSlot:
+    """A single planned reminder milestone.
+
+    Attributes:
+        label:    Human-readable offset string, e.g. "3d", "4h".
+        tier:     The tier that generated this milestone.
+        ideal_at: The ideal (unloaded) fire time, tz-aware.
+    """
+    label: str
+    tier: Tier
+    ideal_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def tier_for(urgency: int) -> Tier:
+    """Return the milestone tier for a given urgency score (0-100).
+
+    Args:
+        urgency: Integer urgency score. Values outside [0, 100] are accepted
+                 but clamped implicitly by the tier thresholds.
+
+    Returns:
+        "dense"    when urgency >= 80
+        "standard" when 40 <= urgency <= 79
+        "sparse"   when urgency < 40
+    """
+    if urgency >= 80:
+        return "dense"
+    if urgency >= 40:
+        return "standard"
+    return "sparse"
+
+
+def plan_milestones(
+    deadline_at: datetime,
+    urgency: int,
+    now: datetime,
+    *,
+    user_tz: str = "America/Chicago",
+) -> list[MilestoneSlot]:
+    """Compute ideal reminder slots for all milestones that fit in remaining time.
+
+    A milestone fits when ``(deadline_at - milestone_offset) > now + 15min``.
+
+    For clock-time deadlines (i.e. the deadline has a specific time other than
+    the end-of-day default of 17:00 local), ideal slots are anchored relative
+    to the clock time: ``ideal = deadline_at - offset``.
+
+    For end-of-day deadlines (17:00 local), multi-day milestones (>= 1d) use
+    a preferred morning hour in user-local time (see _EOD_IDEAL_HOUR), so the
+    reminder fires at a sensible time of day rather than 5pm-minus-offset.
+    Sub-day milestones (4h) always use ``deadline - 4h`` regardless.
+
+    Args:
+        deadline_at: Deadline datetime, must be tz-aware.
+        urgency:     Integer urgency score used to select the tier.
+        now:         Current time, must be tz-aware.
+        user_tz:     IANA timezone string for the user.
+
+    Returns:
+        List of MilestoneSlot, sorted by ideal_at ascending (earliest first).
+    """
+    tz = ZoneInfo(user_tz)
+    tier = tier_for(urgency)
+    milestones = _TIER_MILESTONES[tier]
+
+    # Determine whether the deadline is an end-of-day deadline.
+    deadline_local = deadline_at.astimezone(tz)
+    is_eod = (deadline_local.hour == _EOD_HOUR and deadline_local.minute == _EOD_MINUTE)
+
+    slots: list[MilestoneSlot] = []
+    for label, offset in milestones:
+        raw_ideal = deadline_at - offset
+
+        # Skip milestones that don't leave at least 15 min of lead time.
+        if raw_ideal <= now + _MIN_LEAD:
+            continue
+
+        # Determine the ideal fire time.
+        if is_eod and label in _EOD_IDEAL_HOUR:
+            # Anchor to a preferred morning hour on the milestone date.
+            milestone_date_local = raw_ideal.astimezone(tz).date()
+            preferred_hour = _EOD_IDEAL_HOUR[label]
+            ideal = datetime(
+                milestone_date_local.year,
+                milestone_date_local.month,
+                milestone_date_local.day,
+                preferred_hour,
+                0,
+                0,
+                tzinfo=tz,
+            )
+            # Safety: if the anchored time is in the past or too close to now,
+            # fall back to raw_ideal (offset-anchored).
+            if ideal <= now + _MIN_LEAD:
+                ideal = raw_ideal
+        else:
+            ideal = raw_ideal
+
+        slots.append(MilestoneSlot(label=label, tier=tier, ideal_at=ideal))
+
+    slots.sort(key=lambda s: s.ideal_at)
+    return slots
+
+
+def assign_slot(
+    ideal_slot: datetime,
+    existing_slots: list[datetime],
+    deadline_at: datetime,
+    *,
+    user_tz: str = "America/Chicago",
+    quiet_hours: tuple[int, int] = (22, 8),
+    slot_minutes: int = 30,
+    slot_capacity: int = 2,
+    max_drift_minutes: int = 720,
+    now: datetime | None = None,
+) -> tuple[datetime, bool]:
+    """Find an available slot near the ideal time.
+
+    Walks outward from the ideal slot in ``slot_minutes`` increments, trying
+    earlier times first (never in the past, never past deadline), skipping
+    quiet hours and over-capacity buckets.  Falls back to the ideal if no
+    open slot is found within ``max_drift_minutes``.
+
+    Args:
+        ideal_slot:       Desired fire time (tz-aware).
+        existing_slots:   Already-assigned reminder datetimes in the window.
+        deadline_at:      Task deadline (tz-aware); result must be < deadline_at.
+        user_tz:          IANA timezone for quiet-hours evaluation.
+        quiet_hours:      ``(start_hour, end_hour)`` in user-local time.
+                          Times in [start_hour, 24) ∪ [0, end_hour) are quiet.
+        slot_minutes:     Bucket granularity in minutes.
+        slot_capacity:    Maximum allowed reminders per bucket.
+        max_drift_minutes: Search radius around the ideal slot.
+        now:              "Never fire in past" cutoff.  Defaults to
+                          ``deadline_at - timedelta(hours=1)`` when None.
+
+    Returns:
+        ``(chosen_slot, used_fallback)`` where ``used_fallback`` is True when
+        no open slot was found and the caller should emit an ops_alert.
+    """
+    if now is None:
+        now = deadline_at - timedelta(hours=1)
+
+    tz = ZoneInfo(user_tz)
+    q_start, q_end = quiet_hours
+    step = timedelta(minutes=slot_minutes)
+    max_drift = timedelta(minutes=max_drift_minutes)
+
+    # Snap ideal_slot to nearest bucket boundary.
+    snapped_ideal = _snap_to_bucket(ideal_slot, slot_minutes)
+
+    def _bucket_key(dt: datetime) -> datetime:
+        return _snap_to_bucket(dt, slot_minutes)
+
+    def _occupancy(candidate: datetime) -> int:
+        key = _bucket_key(candidate)
+        return sum(1 for s in existing_slots if _bucket_key(s) == key)
+
+    def _in_quiet(candidate: datetime) -> bool:
+        local_h = candidate.astimezone(tz).hour
+        if q_start < q_end:
+            # Quiet window doesn't cross midnight
+            return q_start <= local_h < q_end
+        else:
+            # Crosses midnight: quiet when hour >= q_start OR hour < q_end
+            return local_h >= q_start or local_h < q_end
+
+    def _is_valid(candidate: datetime) -> bool:
+        """Candidate is valid if: > now+15min, < deadline, not quiet, not full."""
+        if candidate <= now + _MIN_LEAD:
+            return False
+        if candidate >= deadline_at:
+            return False
+        if _in_quiet(candidate):
+            return False
+        if _occupancy(candidate) >= slot_capacity:
+            return False
+        return True
+
+    if _is_valid(snapped_ideal):
+        return snapped_ideal, False
+
+    # Walk outward from snapped_ideal: try earlier steps (i=1,2,...) before
+    # the corresponding later step.  Stop when both sides exhaust max_drift.
+    steps = int(max_drift / step)
+    for i in range(1, steps + 1):
+        earlier = snapped_ideal - step * i
+        later   = snapped_ideal + step * i
+
+        if earlier >= snapped_ideal - max_drift:
+            if _is_valid(earlier):
+                return earlier, False
+
+        if later <= snapped_ideal + max_drift:
+            if _is_valid(later):
+                return later, False
+
+    # Nothing found within max_drift — return ideal with fallback flag.
+    return ideal_slot, True
+
+
+def format_reminder_summary(
+    slots: list[tuple[str, datetime]],
+    user_tz: str = "America/Chicago",
+) -> str:
+    """Format a human-readable reminder summary for task confirmations.
+
+    Slots are sorted by datetime ascending before formatting so the summary
+    reads chronologically regardless of the order they were passed in.
+
+    Args:
+        slots:    List of ``(milestone_label, assigned_slot)`` pairs.
+        user_tz:  IANA timezone for display.
+
+    Returns:
+        A sentence like ``"I'll ping you Wed noon, Thu 9am."``
+        Returns empty string when ``slots`` is empty.
+
+    Examples:
+        >>> format_reminder_summary([("3d", wed_noon), ("1d", thu_9am)], "America/Chicago")
+        "I'll ping you Wed noon, Thu 9am."
+        >>> format_reminder_summary([], "America/Chicago")
+        ""
+    """
+    if not slots:
+        return ""
+
+    # Sort chronologically ascending before formatting.
+    sorted_slots = sorted(slots, key=lambda pair: pair[1])
+
+    tz = ZoneInfo(user_tz)
+    parts: list[str] = []
+    for _label, dt in sorted_slots:
+        local = dt.astimezone(tz)
+        parts.append(_format_datetime(local))
+
+    if len(parts) == 1:
+        return f"I'll ping you {parts[0]}."
+    return "I'll ping you " + ", ".join(parts) + "."
+
+
+# ---------------------------------------------------------------------------
+# Env defaults helper (callers do the env read; pure-function discipline)
+# ---------------------------------------------------------------------------
+
+def _env_defaults() -> dict[str, int | tuple[int, int]]:
+    """Read reminder scheduling defaults from environment variables.
+
+    Returns a dict of kwargs suitable for passing to assign_slot:
+      slot_minutes, slot_capacity, quiet_hours.
+
+    Callers pass these as **kwargs; assign_slot itself takes them as plain
+    parameters so it remains a pure function.
+
+    Example::
+
+        defaults = _env_defaults()
+        slot, fallback = assign_slot(ideal, existing, deadline, **defaults)
+    """
+    slot_minutes   = int(os.environ.get("REMINDER_SLOT_MINUTES",   "30"))
+    slot_capacity  = int(os.environ.get("REMINDER_SLOT_CAPACITY",  "2"))
+    quiet_start    = int(os.environ.get("REMINDER_QUIET_START_HOUR", "22"))
+    quiet_end      = int(os.environ.get("REMINDER_QUIET_END_HOUR",   "8"))
+    return {
+        "slot_minutes":  slot_minutes,
+        "slot_capacity": slot_capacity,
+        "quiet_hours":   (quiet_start, quiet_end),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _snap_to_bucket(dt: datetime, slot_minutes: int) -> datetime:
+    """Round dt down to the nearest slot_minutes boundary (UTC-based)."""
+    total_minutes = int(dt.timestamp() // 60)
+    snapped_minutes = (total_minutes // slot_minutes) * slot_minutes
+    return datetime.fromtimestamp(snapped_minutes * 60, tz=dt.tzinfo)
+
+
+def _format_datetime(local: datetime) -> str:
+    """Format a local datetime as a natural-language string.
+
+    Examples:
+        12:00 -> "noon"
+        00:00 -> "midnight"
+        08:00 -> "8am"
+        13:00 -> "1pm"
+        09:30 -> "9:30am"
+        22:30 -> "10:30pm"
+    """
+    h = local.hour
+    m = local.minute
+    day = local.strftime("%a")  # e.g. "Wed"
+
+    if h == 12 and m == 0:
+        return f"{day} noon"
+    if h == 0 and m == 0:
+        return f"{day} midnight"
+
+    # 12-hour format
+    if h == 0:
+        period = "am"
+        display_h = 12
+    elif h < 12:
+        period = "am"
+        display_h = h
+    elif h == 12:
+        period = "pm"
+        display_h = 12
+    else:
+        period = "pm"
+        display_h = h - 12
+
+    if m == 0:
+        return f"{day} {display_h}{period}"
+    return f"{day} {display_h}:{m:02d}{period}"

--- a/app/scheduler/jobs.py
+++ b/app/scheduler/jobs.py
@@ -138,6 +138,19 @@ async def generate_weekly_recap() -> None:
     log.debug("weekly_recap.tick")
 
 
+async def run_deadline_reminder_scheduler() -> None:
+    """Nightly backstop: schedule deadline-driven reminder series for tasks intake missed.
+
+    Runs daily at 04:00 user time (USER_TZ env var). Picks up tasks where
+    "Due At" is set but "Reminder Scheduled At" is empty, plus tasks where
+    the deadline was edited in Notion after inline scheduling. Calls
+    reminder_scheduler.run_reminder_scheduler() which does the full plan →
+    assign → enqueue → ledger cycle.
+    """
+    from app.scheduler.reminder_scheduler import run_reminder_scheduler
+    await run_reminder_scheduler()
+
+
 async def dispatch_check_ins() -> None:
     """Find peers with active tasks past their check-in window and invoke CHECK_IN.
 
@@ -183,6 +196,15 @@ SCHEDULED_JOBS: list[JobSpec] = [
             timezone=_USER_TZ,
         ),
         func=run_state_audit,
+    ),
+    JobSpec(
+        id="reminder_scheduler",
+        trigger=CronTrigger(
+            hour=4,
+            minute=0,
+            timezone=_USER_TZ,
+        ),
+        func=run_deadline_reminder_scheduler,
     ),
     JobSpec(
         id="check_in_dispatcher",

--- a/app/scheduler/reminder_scheduler.py
+++ b/app/scheduler/reminder_scheduler.py
@@ -1,0 +1,290 @@
+"""Deadline-reminder backstop daemon.
+
+run_reminder_scheduler() is registered as an APScheduler job (daily 04:00 USER_TZ).
+It is the backstop for inline scheduling: intake schedules reminders immediately
+after task creation, but if that enqueue failed (transient DB error, mid-flight crash)
+or if the deadline was later edited in Notion, this daemon catches the gap.
+
+Per cycle:
+  1. notion.query_tasks_with_unscheduled_deadlines() — tasks where "Due At" is set
+     but "Reminder Scheduled At" is empty and status != Completed.
+  2. For each task:
+     a. Check reminder_scheduling_ledger for existing non-superseded rows with the
+        same notion_page_id.
+     b. If a prior deadline exists and differs from the current Notion deadline,
+        supersede old ledger rows and cancel the corresponding outbox rows, then
+        schedule fresh ones.
+     c. If no prior rows exist, schedule from scratch.
+     d. Call notion.mark_reminder_scheduled on success.
+
+Failure modes:
+  - Notion 5xx: ops_alerts.enqueue + skip entire cycle; retry next day.
+  - Per-task planner fallback (load-balancer found no ideal slot): log + ops_alert
+    warning; continue with fallback slot.
+  - Per-task enqueue failure: ops_alert + skip that task; next nightly run retries
+    (Reminder Scheduled At stays empty).
+"""
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+
+log = structlog.get_logger(__name__)
+
+_USER_TZ = os.environ.get("USER_TZ", "America/Chicago")
+
+
+async def run_reminder_scheduler() -> None:
+    """Backstop daemon: schedule deadline-driven reminders for tasks intake missed.
+
+    Registered as APScheduler job 'reminder_scheduler' (daily 04:00 USER_TZ).
+    Called by APScheduler; not called directly from app Python code.
+    """
+    from app.scheduler.reminder_scheduling import (
+        cancel_outbox_rows,
+        get_active_deadline_for_page,
+        schedule_for_task,
+        supersede_ledger_rows,
+    )
+    from app.tools import notion, ops_alerts
+
+    now = datetime.now(UTC)
+    log.info("reminder_scheduler.cycle_start", now=now.isoformat())
+
+    # Step 1: Fetch tasks with unscheduled deadlines from Notion.
+    try:
+        result = await notion.query_tasks_with_unscheduled_deadlines()
+    except Exception as exc:
+        log.error("reminder_scheduler.notion_query_failed", error=str(exc))
+        try:
+            await ops_alerts.enqueue(
+                kind="reminder_scheduler_notion_failed",
+                body="reminder_scheduler: Notion query failed. Deadline reminders will retry on next nightly run.",
+                severity="warning",
+            )
+        except Exception as inner_exc:
+            log.error(
+                "reminder_scheduler.ops_alert_failed",
+                error=str(inner_exc),
+            )
+        return
+
+    tasks = result.get("results", [])
+    log.info("reminder_scheduler.tasks_found", count=len(tasks))
+
+    if not tasks:
+        log.info("reminder_scheduler.no_tasks")
+        return
+
+    scheduled_count = 0
+    failed_count = 0
+
+    for task in tasks:
+        page_id = task.get("id", "")
+        if not page_id:
+            continue
+
+        props = task.get("properties", {})
+        title = _extract_title(props)
+        peer = _extract_peer(task)
+        deadline_at = _extract_deadline(props)
+        urgency = _extract_urgency(props)
+
+        if not deadline_at:
+            log.warning(
+                "reminder_scheduler.task_missing_deadline",
+                page_id=page_id,
+            )
+            continue
+
+        if not peer:
+            log.warning(
+                "reminder_scheduler.task_missing_peer",
+                page_id=page_id,
+            )
+            # Use a configured default peer if available; skip otherwise.
+            peer = os.environ.get("AUTHORIZED_PEERS", "").split(",")[0].strip()
+            if not peer:
+                continue
+
+        log.info(
+            "reminder_scheduler.processing_task",
+            page_id=page_id,
+            deadline_at=deadline_at.isoformat(),
+            urgency=urgency,
+        )
+
+        try:
+            # Step 2a: Check if we have prior ledger rows (deadline might have changed).
+            prior_deadline = await get_active_deadline_for_page(page_id)
+
+            if prior_deadline is not None:
+                # Normalize for comparison (both UTC-aware).
+                prior_utc = prior_deadline.astimezone(UTC)
+                current_utc = deadline_at.astimezone(UTC)
+
+                if abs((prior_utc - current_utc).total_seconds()) > 60:
+                    # Step 2b: Deadline changed — supersede old rows and cancel outbox.
+                    log.info(
+                        "reminder_scheduler.deadline_changed",
+                        page_id=page_id,
+                        prior_deadline=prior_utc.isoformat(),
+                        new_deadline=current_utc.isoformat(),
+                    )
+                    superseded_outbox_ids = await supersede_ledger_rows(page_id)
+                    await cancel_outbox_rows(superseded_outbox_ids)
+                else:
+                    # Deadline unchanged but Reminder Scheduled At is empty —
+                    # partial failure from a prior run. Re-schedule.
+                    log.info(
+                        "reminder_scheduler.deadline_unchanged_reschedule",
+                        page_id=page_id,
+                    )
+
+            # Step 2c: Schedule milestones.
+            assigned_slots, enqueue_failures = await schedule_for_task(
+                page_id=page_id,
+                title=title,
+                peer=peer,
+                deadline_at=deadline_at,
+                urgency=urgency,
+                now=now,
+                user_tz=_USER_TZ,
+            )
+
+            if enqueue_failures:
+                log.warning(
+                    "reminder_scheduler.partial_failure",
+                    page_id=page_id,
+                    failed_milestones=enqueue_failures,
+                )
+                try:
+                    await ops_alerts.enqueue(
+                        kind="reminder_scheduler_partial_failure",
+                        body=(
+                            f"reminder_scheduler: partial failure for <page_id>. "
+                            f"Failed milestones: {enqueue_failures}. "
+                            "Reminder Scheduled At left empty; will retry next nightly run."
+                        ),
+                        severity="warning",
+                    )
+                except Exception as alert_exc:
+                    log.error(
+                        "reminder_scheduler.ops_alert_failed",
+                        error=str(alert_exc),
+                    )
+                failed_count += 1
+            elif assigned_slots:
+                # Step 2d: All milestones succeeded — mark as scheduled in Notion.
+                try:
+                    await notion.mark_reminder_scheduled(page_id)
+                    scheduled_count += 1
+                    log.info(
+                        "reminder_scheduler.task_scheduled",
+                        page_id=page_id,
+                        milestone_count=len(assigned_slots),
+                    )
+                except Exception as notion_exc:
+                    log.warning(
+                        "reminder_scheduler.mark_scheduled_failed",
+                        page_id=page_id,
+                        error=str(notion_exc),
+                    )
+                    # Outbox rows exist — reminders will fire even if Notion PATCH fails.
+                    # The daemon will retry mark_reminder_scheduled next cycle since
+                    # Reminder Scheduled At stays empty.
+            else:
+                # No milestones fit (deadline already passed or too close).
+                log.info(
+                    "reminder_scheduler.no_milestones",
+                    page_id=page_id,
+                    deadline_at=deadline_at.isoformat(),
+                )
+                # Mark as scheduled to stop retrying a deadline in the past.
+                try:
+                    await notion.mark_reminder_scheduled(page_id)
+                except Exception:
+                    pass
+
+        except Exception as task_exc:
+            log.exception(
+                "reminder_scheduler.task_failed",
+                page_id=page_id,
+                error=str(task_exc),
+            )
+            try:
+                await ops_alerts.enqueue(
+                    kind="reminder_scheduler_task_failed",
+                    body=(
+                        "reminder_scheduler: unexpected error processing <page_id>. "
+                        "Will retry on next nightly run."
+                    ),
+                    severity="warning",
+                )
+            except Exception:
+                pass
+            failed_count += 1
+
+    log.info(
+        "reminder_scheduler.cycle_done",
+        total_tasks=len(tasks),
+        scheduled=scheduled_count,
+        failed=failed_count,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Notion property extraction helpers
+# ---------------------------------------------------------------------------
+
+def _extract_title(props: dict[str, Any]) -> str:
+    """Extract task title from Notion properties."""
+    title_prop = props.get("Title", {})
+    title_items = title_prop.get("title", [])
+    if title_items:
+        return str(title_items[0].get("plain_text", ""))[:200]
+    return ""
+
+
+def _extract_peer(task: dict[str, Any]) -> str:
+    """Extract peer (Signal number) from task metadata.
+
+    Notion tasks don't store the peer phone number — it lives in the
+    conversation state (Postgres checkpointer). For the daemon, we use
+    the AUTHORIZED_PEERS env var (single-tenant: only one user).
+    This is the expected single-user design of hide-my-list.
+    """
+    return os.environ.get("AUTHORIZED_PEERS", "").split(",")[0].strip()
+
+
+def _extract_deadline(props: dict[str, Any]) -> datetime | None:
+    """Extract Due At datetime from Notion properties."""
+    due_at_prop = props.get("Due At", {})
+    date_obj = due_at_prop.get("date")
+    if not date_obj:
+        return None
+    start = date_obj.get("start")
+    if not start:
+        return None
+    try:
+        # ISO 8601 string; normalize 'Z' suffix.
+        normalized = start.strip().replace("Z", "+00:00")
+        dt = datetime.fromisoformat(normalized)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        return dt.astimezone(UTC)
+    except (ValueError, TypeError) as exc:
+        log.warning("reminder_scheduler.deadline_parse_failed", start=start, error=str(exc))
+        return None
+
+
+def _extract_urgency(props: dict[str, Any]) -> int:
+    """Extract urgency from Notion properties with a default of 50."""
+    urgency_prop = props.get("Urgency", {})
+    value = urgency_prop.get("number")
+    if isinstance(value, (int, float)):
+        return max(0, min(100, int(value)))
+    return 50

--- a/app/scheduler/reminder_scheduling.py
+++ b/app/scheduler/reminder_scheduling.py
@@ -1,0 +1,358 @@
+"""Shared reminder scheduling helper for deadline-driven reminder series.
+
+schedule_for_task() is called by both:
+  - app/graph/nodes/intake.py: inline scheduling immediately after task creation
+  - app/scheduler/reminder_scheduler.py: nightly daemon backstop
+
+The algorithm is: plan milestones via deadline_planner → query the ledger for
+nearby existing slots → assign a load-balanced slot per milestone → enqueue
+outbox row → insert ledger row.
+
+Callers decide whether to call notion.mark_reminder_scheduled() based on
+whether enqueue_failures is empty.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import psycopg
+import psycopg.rows
+import structlog
+
+log = structlog.get_logger(__name__)
+
+# Window around each milestone ideal to query existing ledger slots for
+# load-balancing: ±max_drift hours (matching assign_slot max_drift_minutes default).
+_LEDGER_WINDOW_HOURS = 12
+
+
+async def schedule_for_task(
+    page_id: str,
+    title: str,
+    peer: str,
+    deadline_at: datetime,
+    urgency: int,
+    *,
+    now: datetime,
+    user_tz: str,
+) -> tuple[list[tuple[str, datetime]], list[str]]:
+    """Plan and enqueue the milestone reminder series for one task.
+
+    Calls deadline_planner.plan_milestones + assign_slot per milestone.
+    Queries reminder_scheduling_ledger for nearby existing slots (load balance).
+    Calls reminders.enqueue + inserts ledger row per milestone.
+
+    Callers decide whether to call notion.mark_reminder_scheduled based on
+    whether enqueue_failures is empty (empty = all milestones succeeded;
+    non-empty = at least one failed, daemon will retry via backstop).
+
+    Args:
+        page_id:     Notion page ID of the task.
+        title:       Task title for reminder body text.
+        peer:        E.164 recipient phone number.
+        deadline_at: Task deadline, must be tz-aware.
+        urgency:     Integer urgency score (0-100).
+        now:         Current time reference, must be tz-aware.
+        user_tz:     IANA timezone string for the user.
+
+    Returns:
+        (assigned_slots, enqueue_failures)
+        assigned_slots: list of (milestone_label, assigned_slot_datetime) for
+            milestones that were successfully enqueued.
+        enqueue_failures: list of milestone labels that failed to enqueue.
+    """
+    from app.scheduler.deadline_planner import (
+        _env_defaults,
+        assign_slot,
+        plan_milestones,
+        tier_for,
+    )
+    from app.tools.db import get_db_conn
+    from app.tools.reminders import enqueue
+
+    milestones = plan_milestones(deadline_at, urgency, now, user_tz=user_tz)
+    env_defaults = _env_defaults()
+    tier = tier_for(urgency)
+
+    assigned_slots: list[tuple[str, datetime]] = []
+    enqueue_failures: list[str] = []
+
+    for m in milestones:
+        try:
+            # Query ledger for existing slots in the load-balancing window.
+            existing = await _query_ledger_window(m.ideal_at)
+
+            # Assign a load-balanced slot.
+            slot, used_fallback = assign_slot(
+                m.ideal_at,
+                existing,
+                deadline_at,
+                user_tz=user_tz,
+                now=now,
+                **env_defaults,  # type: ignore[arg-type]
+            )
+
+            if used_fallback:
+                log.warning(
+                    "reminder_scheduling.slot_fallback_used",
+                    page_id=page_id,
+                    milestone=m.label,
+                    ideal_at=m.ideal_at.isoformat(),
+                    assigned_at=slot.isoformat(),
+                )
+
+            # Build the human-readable reminder body (shame-safe, ADHD-friendly).
+            humanized_deadline = _humanize_deadline(deadline_at, user_tz)
+            body = f"{title} is coming up {humanized_deadline} — want to start now?"
+            idempotency_key = (
+                f"deadline-{page_id}-{m.label}-{deadline_at.isoformat()}"
+            )
+
+            async with get_db_conn() as conn:
+                outbox_id = await enqueue(
+                    conn,
+                    notion_page_id=page_id,
+                    peer=peer,
+                    body=body,
+                    due_at=slot,
+                    idempotency_key=idempotency_key,
+                )
+
+                # Insert ledger row within the same connection / transaction.
+                await _insert_ledger_row(
+                    conn,
+                    page_id=page_id,
+                    deadline_at=deadline_at,
+                    urgency=urgency,
+                    tier=tier,
+                    milestone_label=m.label,
+                    ideal_slot_at=m.ideal_at,
+                    assigned_slot_at=slot,
+                    outbox_id=outbox_id,
+                )
+
+            assigned_slots.append((m.label, slot))
+            log.info(
+                "reminder_scheduling.milestone_enqueued",
+                page_id=page_id,
+                milestone=m.label,
+                assigned_at=slot.isoformat(),
+                used_fallback=used_fallback,
+            )
+
+        except psycopg.errors.UniqueViolation:
+            # idempotency_key already exists — milestone already scheduled.
+            log.info(
+                "reminder_scheduling.milestone_already_scheduled",
+                page_id=page_id,
+                milestone=m.label,
+            )
+            # Treat idempotent re-runs as success (not a failure).
+            assigned_slots.append((m.label, m.ideal_at))
+
+        except Exception as exc:
+            log.exception(
+                "reminder_scheduling.milestone_enqueue_failed",
+                page_id=page_id,
+                milestone=m.label,
+                error=str(exc),
+            )
+            enqueue_failures.append(m.label)
+
+    return assigned_slots, enqueue_failures
+
+
+async def _query_ledger_window(
+    ideal_at: datetime,
+    *,
+    window_hours: int = _LEDGER_WINDOW_HOURS,
+) -> list[datetime]:
+    """Return assigned_slot_at values from the ledger near the given ideal time.
+
+    Queries non-superseded rows within ±window_hours of ideal_at to give
+    assign_slot the load data it needs for bucket occupancy calculation.
+
+    Returns an empty list if DATABASE_URL is not set (test/offline environments).
+    """
+    from app.tools.db import get_connection_string, get_db_conn
+
+    try:
+        get_connection_string()  # raises KeyError if not set
+    except KeyError:
+        return []
+
+    window = timedelta(hours=window_hours)
+    lo = ideal_at - window
+    hi = ideal_at + window
+
+    try:
+        async with get_db_conn() as conn:
+            async with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+                await cur.execute(
+                    """
+                    SELECT assigned_slot_at
+                    FROM reminder_scheduling_ledger
+                    WHERE superseded_at IS NULL
+                      AND assigned_slot_at BETWEEN %s AND %s
+                    """,
+                    (lo, hi),
+                )
+                rows = await cur.fetchall()
+        return [row["assigned_slot_at"] for row in rows]
+    except Exception as exc:
+        log.warning("reminder_scheduling.ledger_query_failed", error=str(exc))
+        return []
+
+
+async def _insert_ledger_row(
+    conn: Any,
+    *,
+    page_id: str,
+    deadline_at: datetime,
+    urgency: int,
+    tier: str,
+    milestone_label: str,
+    ideal_slot_at: datetime,
+    assigned_slot_at: datetime,
+    outbox_id: uuid.UUID,
+) -> None:
+    """Insert a row into reminder_scheduling_ledger."""
+    await conn.execute(
+        """
+        INSERT INTO reminder_scheduling_ledger
+          (notion_page_id, deadline_at, urgency, tier, milestone_label,
+           ideal_slot_at, assigned_slot_at, reminder_outbox_id)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+        """,
+        (
+            page_id,
+            deadline_at,
+            urgency,
+            tier,
+            milestone_label,
+            ideal_slot_at,
+            assigned_slot_at,
+            str(outbox_id),
+        ),
+    )
+
+
+async def supersede_ledger_rows(page_id: str) -> list[uuid.UUID]:
+    """Mark all active ledger rows for page_id as superseded (deadline changed).
+
+    Returns the reminder_outbox_id values of superseded rows so callers can
+    cancel the corresponding outbox rows (set state='dead').
+    """
+    now = datetime.now(UTC)
+    from app.tools.db import get_db_conn
+
+    async with get_db_conn() as conn:
+        async with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            await cur.execute(
+                """
+                UPDATE reminder_scheduling_ledger
+                   SET superseded_at = %s
+                 WHERE notion_page_id = %s
+                   AND superseded_at IS NULL
+                RETURNING reminder_outbox_id
+                """,
+                (now, page_id),
+            )
+            rows = await cur.fetchall()
+    return [uuid.UUID(str(row["reminder_outbox_id"])) for row in rows]
+
+
+async def cancel_outbox_rows(outbox_ids: list[uuid.UUID]) -> None:
+    """Cancel outbox rows corresponding to superseded ledger rows.
+
+    Sets state='dead' with a descriptive last_error so the reminder_worker
+    skips delivery. Only affects rows in pending/scheduled state.
+    """
+    if not outbox_ids:
+        return
+
+    from app.tools.db import get_db_conn
+
+    async with get_db_conn() as conn:
+        for oid in outbox_ids:
+            await conn.execute(
+                """
+                UPDATE reminder_outbox
+                   SET state = 'dead',
+                       last_error = 'superseded_by_deadline_change'
+                 WHERE id = %s
+                   AND state IN ('pending', 'scheduled')
+                """,
+                (str(oid),),
+            )
+
+
+async def get_active_deadline_for_page(page_id: str) -> datetime | None:
+    """Return the deadline_at of the most recent non-superseded ledger row for page_id.
+
+    Returns None if no active ledger rows exist (task not yet scheduled or
+    all rows have been superseded).
+    """
+    from app.tools.db import get_db_conn
+
+    async with get_db_conn() as conn:
+        async with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            await cur.execute(
+                """
+                SELECT deadline_at
+                FROM reminder_scheduling_ledger
+                WHERE notion_page_id = %s
+                  AND superseded_at IS NULL
+                ORDER BY scheduled_at DESC
+                LIMIT 1
+                """,
+                (page_id,),
+            )
+            row = await cur.fetchone()
+
+    if row is None:
+        return None
+    dt: datetime = row["deadline_at"]
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt
+
+
+def _humanize_deadline(deadline_at: datetime, user_tz: str) -> str:
+    """Return a natural-language description of how soon the deadline is.
+
+    Examples:
+        "this afternoon"
+        "tomorrow"
+        "in 3 days"
+        "next week"
+    """
+    from zoneinfo import ZoneInfo
+
+    tz = ZoneInfo(user_tz)
+    now_local = datetime.now(UTC).astimezone(tz)
+    deadline_local = deadline_at.astimezone(tz)
+
+    delta = deadline_local - now_local
+    days = delta.days
+
+    if days < 0:
+        return "soon"
+    if days == 0:
+        hour = deadline_local.hour
+        if hour < 12:
+            return "this morning"
+        if hour < 17:
+            return "this afternoon"
+        return "this evening"
+    if days == 1:
+        return "tomorrow"
+    if days <= 6:
+        return f"in {days} days"
+    if days <= 13:
+        return "next week"
+    if days <= 30:
+        return f"in {days // 7} weeks"
+    return f"in about {days // 30} month{'s' if days // 30 > 1 else ''}"

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -38,6 +38,15 @@ services:
       - ALLOW_PRIVATE_TRACE_EXPORT=${ALLOW_PRIVATE_TRACE_EXPORT:-false}
       - USER_TZ=${USER_TZ:-America/Chicago}
       - OPS_ALERT_SIGNAL_NUMBER=${OPS_ALERT_SIGNAL_NUMBER:-}
+      # Deadline reminder scheduling tuning (all optional — defaults shown):
+      # REMINDER_SLOT_MINUTES: bucket size for load balancing (default 30)
+      # REMINDER_SLOT_CAPACITY: max reminders per bucket (default 2)
+      # REMINDER_QUIET_START_HOUR: quiet hours start, local time (default 22)
+      # REMINDER_QUIET_END_HOUR: quiet hours end, local time (default 8)
+      - REMINDER_SLOT_MINUTES=${REMINDER_SLOT_MINUTES:-30}
+      - REMINDER_SLOT_CAPACITY=${REMINDER_SLOT_CAPACITY:-2}
+      - REMINDER_QUIET_START_HOUR=${REMINDER_QUIET_START_HOUR:-22}
+      - REMINDER_QUIET_END_HOUR=${REMINDER_QUIET_END_HOUR:-8}
       # REWARD_ARTIFACTS_DIR: mount path for generated PNG reward images.
       # Must match the volume mount below so images persist across container restarts.
       - REWARD_ARTIFACTS_DIR=/data/reward_artifacts

--- a/docs/ai-prompts/intake.md
+++ b/docs/ai-prompts/intake.md
@@ -11,91 +11,35 @@ flowchart TD
         Infer[Infer ALL labels aggressively]
         Sufficient{Enough context?}
         Clarify[Ask ONE clarifying question]
-        Complexity{Complexity check}
-        Breakdown[Generate sub-tasks]
+        Deadline[Detect deadline phrase]
+        Stakes[Detect high-stakes category]
         Save[Save with inferred defaults]
     end
 
     Parse --> Infer
     Infer --> Sufficient
-    Sufficient -->|Yes| Complexity
+    Sufficient -->|Yes| Deadline
     Sufficient -->|No, too vague| Clarify
     Clarify -->|User responds| Infer
-    Complexity -->|Too large| Breakdown
-    Complexity -->|Manageable| Save
-    Breakdown --> Save
+    Deadline -->|Detected| Save
+    Deadline -->|Not detected| Stakes
+    Stakes -->|High-stakes + no deadline| Clarify
+    Stakes -->|Low-stakes or already has deadline| Save
 ```
 
-> **Decision Fatigue Prevention:** Intake flow strongly prefers inference over questions. Every field inferred from context, keywords, defaults when possible. When task genuinely too vague to act on (e.g., "do the thing", "handle that"), system may ask up to **3 clarifying questions per task**, **one at a time**. Each question depletes limited executive function — questions are last resort, not default. Research: 82% of ADHD participants report frequent decision-making difficulties; 58% experience decision paralysis weekly.
+> **Decision Fatigue Prevention:** Intake flow strongly prefers inference over questions. Every field inferred from context, keywords, defaults when possible. When task genuinely too vague to act on (e.g., "do the thing", "handle that"), system may ask up to **3 clarifying questions per task**, **one at a time**. Stakes-clarification (high-stakes task with no deadline) counts as one of these questions. Research: 82% of ADHD participants report frequent decision-making difficulties; 58% experience decision paralysis weekly.
 
 ### Task Intake Prompt
 
 ```
-The user wants to add a task. Extract details, infer labels, and ALWAYS generate sub-tasks.
+The user wants to add a task. Extract details and infer labels aggressively.
 
 User said: "{user_message}"
 Previous context: {conversation_history}
 User preferences: {user_preferences_context}
 Clarification count so far: {clarification_count} (max 3)
-
-CORE PRINCIPLE: Users interpret vague goals as infinite and avoid them.
-Every task MUST have explicit sub-tasks that define exactly what "done" looks like.
-
-Analyze the task and provide structured output:
-
-TASK_ANALYSIS:
-- title: (concise task name, max 200 chars)
-- work_type: (focus|creative|social|independent)
-- work_type_confidence: (0.0-1.0)
-- urgency: (0-100)
-- urgency_confidence: (0.0-1.0)
-- time_estimate_minutes: (number)
-- time_confidence: (0.0-1.0)
-- energy_required: (high|medium|low)
-
-SUB-TASK GENERATION (ALWAYS REQUIRED):
-Every task gets explicit sub-tasks, regardless of complexity.
-- Quick tasks (15-30 min): 2-3 inline steps shown with the task
-- Standard tasks (30-60 min): 3-5 inline steps
-- Large tasks (60+ min): Create as hidden Notion sub-tasks
-
-For EVERY task, generate:
-- Specific, actionable steps
-- Clear "done" criteria for each step
-- Time estimate for each step
-- Logical sequence
-
-PERSONALIZED PREP STEPS:
-Use the user's preferences to create an environment for success.
-The first 1-2 steps should help the user prepare mentally and physically.
-
-Based on user preferences, include relevant prep steps:
-- If user has a preferred beverage for this work type, suggest making it
-- If user has a comfort spot preference, suggest settling there
-- If user has prep rituals (phone away, close tabs), include them
-- Match environment suggestions to the work type
-
-Example for social task (phone call) with tea preference:
-1. Make a cup of tea
-2. Find a comfortable, quiet spot
-3. Make the call
-4. Note any follow-ups
-
-Example for focus task with coffee preference:
-1. Make coffee and put phone in another room
-2. Close email and messaging tabs
-3. [Core task steps...]
-4. Review work before marking done
-
-STORAGE DECISION (use_hidden_subtasks):
-- true: Store as separate Notion tasks (for tasks > 60 min or multi-phase work)
-- false: Store as inline steps in task description (for tasks ≤ 60 min)
-
-BREAKDOWN SIGNALS (use_hidden_subtasks=true):
-- Vague scope: "complete the project", "finish the report", "work on X"
-- Multi-phase: tasks requiring research → draft → review → finalize
-- Long duration: estimated > 60 minutes
-- Multiple deliverables: "prepare and send", "design and implement"
+Current user time: {current_time}
+User timezone: {user_timezone}
 
 DECISION FATIGUE PREVENTION:
 Prefer inference over questions. Each question is a decision point that depletes
@@ -116,21 +60,55 @@ CLARIFYING QUESTIONS (last resort):
 - Questions should be simple, low-effort to answer (yes/no or short answer preferred)
 - Never ask about labels (urgency, time, energy) — always infer those
 
+DEADLINE DETECTION:
+When the user's message contains a deadline phrase, parse it to an ISO 8601 datetime.
+
+Deadline phrases:
+- "before <date/day>" — e.g. "before next Wednesday", "before Friday"
+- "by <date/day>" — e.g. "by end of month", "by the 15th"
+- "due <date>" — e.g. "due Thursday", "due July 1st"
+- "at <time> <date>" / "<date> at <time>" — e.g. "at 10am tomorrow", "Friday at noon"
+- "needs to be done <date>" — e.g. "needs to be done this week"
+- "finish by <date>", "complete by <date>", "submit by <date>"
+
+When detected:
+- Parse to ISO 8601 using user timezone ({user_timezone})
+- Resolve relative references ("tomorrow", "next week", day names) against current_time
+- When a clock time is given ("at 10am"), use that exact time
+- When no clock time is given ("by Friday"), default to 17:00 local (end of business day)
+- Set `due_at` in output (distinct from `remind_at` — deadline ≠ explicit reminder)
+- `due_at` and `urgency` are independent: urgency = relative priority; due_at = hard time bound
+
+Examples:
+  "Cancel my appointment before next Wednesday" at 2026-06-01T10:00 Central →
+    due_at: "2026-06-03T17:00:00-05:00"
+  "Finish the report by 10am tomorrow" at 2026-06-01T09:00 Central →
+    due_at: "2026-06-02T10:00:00-05:00"
+
+STAKES DETECTION:
+Some tasks are too important to silently park without a deadline. If a task matches
+a high-stakes category AND no deadline phrase was detected, ask ONE clarification
+question: "When do you want this done by?"
+
+High-stakes categories (LLM judgment — list is illustrative, not exhaustive):
+- Life/family protection: life insurance, will, estate, beneficiaries, custody
+- Health: medical appointments, prescriptions, screenings, referrals, lab work
+- Legal: contracts, court dates, regulatory filings, immigration paperwork
+- Financial protection: taxes, mortgage, loan deadlines, insurance renewals
+- Safety: home maintenance with safety implications (smoke alarms, recalls)
+
+Rules:
+- This is the ONLY automatic clarification for non-vague tasks
+- Low-stakes deadlineless tasks save silently (no clarification)
+- If user answers "I don't know", save with no due_at but set urgency = 70
+- Set `is_high_stakes: true` in output when matched
+
 WHEN TO ASK vs. WHEN TO INFER:
   ✅ Infer: "Call mom" → social, ~15 min (clear enough)
-  ✅ Infer: "Work on the project" → focus, ~45 min (assume the most likely project)
+  ✅ Infer: "Work on the project" → focus, ~45 min
   ❓ Ask: "Do the thing" → "Which thing are you thinking of?"
-  ❓ Ask: "Handle that" (no context) → "What needs handling?"
-  ✅ Infer after 3 questions: save with best guess, user can correct
-
-The confirmation message should state what you inferred, allowing the user to
-correct if needed.
-
-Example:
-  ❌ "Is this time-sensitive?" (forces a label decision — never ask this)
-  ❌ "What type of work is this?" (infer from keywords — never ask this)
-  ✅ "Got it — focus work, ~45 min, moderate priority." (inferred, user can correct)
-  ✅ "Which report are you referring to?" (genuinely unclear what the task is)
+  ❓ Ask (high-stakes, no deadline): "I need life insurance" → "When do you want this done by?"
+  ✅ Infer: "Organize my bookshelf" → no deadline needed, saves silently
 
 REMINDER DETECTION:
 When the user's message contains a specific wall-clock time for a notification
@@ -144,41 +122,9 @@ Signals:
 When detected:
 - Set is_reminder = true
 - Parse the time reference and convert to ISO 8601 with timezone offset
-- Default timezone for both relative dates and unspecified clock times: the user's configured timezone from `USER_TZ` env var (default `America/Chicago`)
-- Common timezone mappings: PT = -08:00/-07:00, CT = -06:00/-05:00, ET = -05:00/-04:00
-- Resolve ALL relative references ("today", "tomorrow", "tonight", "this evening", day-of-week names, "next week") against the user's configured timezone (`USER_TZ` env var), never against UTC message metadata or the server date
-- If the session time you see is UTC or otherwise ambiguous, run `scripts/user-time-context.sh [reference_timestamp]` (or do the equivalent conversion) before choosing the calendar date for the reminder
-- Before saving a reminder, explicitly verify in your reasoning:
-  1. Current time in the user's timezone
-  2. Which local calendar date the relative phrase resolves to
-  3. The final `remind_at` ISO 8601 timestamp
-- Set reminder_status = "pending"
+- Default timezone for both relative dates and unspecified clock times: {user_timezone}
+- Resolve ALL relative references ("today", "tomorrow", "tonight", "this evening", day-of-week names, "next week") against the user's configured timezone, never against UTC
 - Set urgency = 90 (reminders are inherently time-critical)
-- Work type and energy level are still inferred from the reminder content
-
-REMINDER PERSISTENCE:
-After `notion-cli.sh create-reminder` returns the Notion page object, the app
-automatically writes a `reminder_outbox` row to Postgres with `state=pending` and
-`due_at=remind_at`. The APScheduler `reminder_dispatcher` job claims and delivers
-due rows every 30 seconds. No additional action is required from the AI node —
-the outbox write is handled by `app/graph/nodes/intake.py`.
-
-**Outbox enqueue failure:** If the outbox write fails after the Notion row is
-created (e.g., transient Postgres error), the runtime logs the exception and emits
-a `reminder_enqueue_failed` ops alert so the operator can investigate. The reminder
-exists in Notion but will not be delivered automatically until the outbox row is
-created. When enqueue fails, the AI node must not confirm exact delivery — use
-tentative wording ("I'll try to remind you around…") rather than certain wording
-("I'll remind you at…").
-
-Examples:
-  "Remind me at 6pm PT to email Melanie" →
-    is_reminder: true, remind_at: "2025-01-04T18:00:00-08:00", title: "Email Melanie availability"
-  "Ping me at 3pm to call the dentist" →
-    is_reminder: true, remind_at: "2025-01-04T15:00:00-06:00" (offset from USER_TZ env; example shows Central), title: "Call the dentist"
-  Message timestamp `2026-04-19T01:27:00Z`, `USER_TZ=America/Chicago`, user says "Tomorrow before noon remind me to clean up boxes" →
-    current user-local time: `2026-04-18T20:27:00-05:00`; "tomorrow" resolves to `2026-04-19`
-    is_reminder: true, remind_at: "2026-04-19T09:00:00-05:00", title: "Clean up boxes"
 
 RESCHEDULE FROM RECENT OUTBOUND CONTEXT:
 When `recent_outbound_context` contains an entry with `awaiting_reply: true` and
@@ -190,26 +136,20 @@ reminder reschedule using the matched entry's title:
 - Use the matched `recent_outbound` entry's `title` as the task title (do not re-ask)
 - Parse the new time reference and convert to ISO 8601 with timezone offset (same rules as above)
 - Set urgency = 90
-- After saving: the matched `recent_outbound` entry must be cleared (set `awaiting_reply: false` or remove the entry)
-- The new `reminder_outbox` row is written by `app/graph/nodes/intake.py` — no additional scheduling step needed.
-- In this `recent_outbound` path, the prior reminder was already delivered, so its Notion row is already `Completed`. No separate cleanup of the old outbox row is needed.
-- Keep all of that bookkeeping internal. The user-facing reply for a reschedule
-  must be only the new reminder confirmation, in the same brief style as any
-  other reminder confirmation.
+- Keep all bookkeeping internal. The user-facing reply is only the new reminder confirmation.
 
-Example:
-  recent_outbound entry: title "Call the dentist", awaiting_reply: true
-  user says: "tomorrow at 9" →
-    is_reminder: true, title: "Call the dentist", remind_at: "<tomorrow 09:00 ISO>",
-    confirmation_message: "Got it — I'll remind you around 9 tomorrow to call the dentist.",
-    then clear matched recent_outbound entry
+SUB-TASKS ON REQUEST ONLY:
+Intake saves the task with labels. Sub-task generation is not automatic.
+If the user explicitly asks for breakdown ("how do I start?", "what are the steps?"),
+that routes to NEED_HELP. Leave `use_hidden_subtasks: false` and `sub_tasks: []` unless
+the task requires it AND the user requested it.
 
-Example:
-  recent_outbound entry: title "Set up your video call software for therapy", awaiting_reply: true
-  user says: "remind me in an hour" →
-    is_reminder: true, title: "Set up your video call software for therapy",
-    remind_at: "<now+1h ISO>",
-    confirmation_message: "Got it — I'll remind you in about an hour to set up your video call software for therapy."
+CONFIRMATION FORMAT:
+- No sub-tasks or numbered plan in confirmation
+- "Saved — [work type], ~[time]." (no deadline)
+- "Saved — [work type], ~[time], due [humanized deadline]." (with deadline)
+- For reminders: "Got it — I'll remind you [time description] to [task]."
+- The app node appends reminder schedule summary; do not generate reminder times yourself
 
 OUTPUT (JSON):
 
@@ -218,116 +158,32 @@ If task is clear enough to save:
   "action": "save",
   "title": "...",
   "work_type": "...",
-  "work_type_confidence": 0.0,
   "urgency": 0,
-  "urgency_confidence": 0.0,
   "time_estimate_minutes": 0,
-  "time_confidence": 0.0,
   "energy_required": "...",
   "is_reminder": false,
   "remind_at": null,
-  "use_hidden_subtasks": true|false,
-  "sub_tasks": [
-    {
-      "title": "...",
-      "time_estimate_minutes": 0,
-      "done_criteria": "what 'done' looks like",
-      "sequence": 1
-    }
-  ],
-  "inline_steps": "1. First step\n2. Second step\n3. Third step" (if use_hidden_subtasks=false),
-  "presentable_title": "..." (first actionable step if use_hidden_subtasks=true),
-  "confirmation_message": "..." (brief confirmation including inferred labels and steps)
+  "due_at": null,
+  "is_high_stakes": false,
+  "use_hidden_subtasks": false,
+  "sub_tasks": [],
+  "inline_steps": "",
+  "confirmation_message": "Saved — focus, ~30 min, due Fri."
 }
 
-If task is too vague and clarification_count < 3:
+If task is too vague or is high-stakes with no deadline and clarification_count < 3:
 {
   "action": "clarify",
   "clarification_question": "...",
-  "clarification_count": 1,
-  "reason": "brief explanation of what is unclear"
+  "clarification_count": 1
 }
 
-CONFIRMATION MESSAGE FORMAT:
-- For inline steps: "Got it — [work type], ~[time]. Here's your plan: 1) X, 2) Y, 3) Z"
-- For hidden sub-tasks: "Got it — [work type], ~[time]. First step: [step]. This is 1 of [N] steps."
-- For reminders: "Got it — I'll remind you Wednesday evening to set up your video call software for therapy."
-
-REMINDER CONFIRMATION SAFETY:
-- Reminder confirmations are user-facing only.
-- Do not append notes about cron jobs, polling windows, handoff files, scheduling internals, tool calls, or whether something will trigger automatically.
-- Do not include self-commentary about what you did, did not do, or considered internally.
-- This applies equally to reminder reschedules created from `recent_outbound`.
-- Do not mention `recent_outbound`, prior reminder pages, reminder replacement, or Notion status cleanup.
-- The visible confirmation should be a single short sentence, then stop.
-- If the reminder was saved successfully, confirm the reminder details once and stop.
-
-IMPORTANT:
-- The user should always see specific next actions, never just "Added - focus work, ~30 min".
-- Every task confirmation includes the concrete steps they'll take.
-- Confirmations state what was inferred — the user can correct, but isn't asked to decide.
-- Minimize questions. Minimize decisions. Infer aggressively and move forward.
-- If you must ask, ask ONE simple question. Never batch questions together.
-- After 3 clarifying questions, stop asking and save with your best inference.
-- Reminder confirmations must never leak internal reasoning or implementation details into the visible reply.
+CONFIRMATION SAFETY:
+- Never mention cron jobs, polling, outbox, Notion writes, ledger, or scheduling internals
+- Never include self-commentary about what you did, did not do, or considered
+- The visible confirmation is a brief acknowledgment sentence
+- Reminder confirmations: do not append notes about automatic retry or internal systems
 ```
-
-### Storage Decision Rules
-
-All tasks get sub-tasks. Decision only about HOW to store:
-
-```mermaid
-flowchart TD
-    subgraph Always["All Tasks Get Sub-tasks"]
-        Generate["Generate 2-5 actionable steps<br/>for EVERY task"]
-    end
-
-    subgraph Signals["Hidden Storage Triggers"]
-        Vague["Vague scope<br/>'complete', 'finish', 'work on'"]
-        MultiPhase["Multi-phase work<br/>research + draft + review"]
-        LongDuration["Long duration<br/>> 60 minutes"]
-        MultiDeliverable["Multiple outputs<br/>'prepare and send'"]
-    end
-
-    subgraph Decision["Storage Decision"]
-        Hidden["use_hidden_subtasks = true<br/>Store as Notion sub-tasks"]
-        Inline["use_hidden_subtasks = false<br/>Store as inline steps"]
-    end
-
-    Generate --> Signals
-    Vague --> Hidden
-    MultiPhase --> Hidden
-    LongDuration --> Hidden
-    MultiDeliverable --> Hidden
-
-    Generate -->|"Short, simple tasks"| Inline
-```
-
-### Task Examples (All Tasks Get Sub-tasks)
-
-**Quick Tasks (Inline Steps) - Personalized:**
-
-| User Says | User Preferences | Confirmation (No Questions Asked) |
-|-----------|------------------|-----------------------------------|
-| "Call mom" | tea, cozy chair | "Got it — social, ~15 min. Plan: 1) Make a cup of tea, 2) Settle into the cozy chair, 3) Make call, 4) Note any follow-ups" |
-| "Call mom" | (none set) | "Got it — social, ~15 min. Plan: 1) Find quiet spot, 2) Make call, 3) Note any follow-ups" |
-| "Pay electricity bill" | batches admin tasks | "Got it — independent, ~10 min. Steps: 1) Open banking app, 2) Find payee, 3) Enter amount and pay" |
-| "Reply to Jake's email" | tea before social | "Got it — social, ~10 min. Steps: 1) Make tea, 2) Read his email, 3) Draft and send response" |
-
-**Standard Tasks (Inline Steps) - Personalized:**
-
-| User Says | User Preferences | Confirmation (No Questions Asked) |
-|-----------|------------------|-----------------------------------|
-| "Review the proposal" | coffee, phone away | "Got it — focus, ~45 min. Plan: 1) Make coffee, put phone away, 2) Read intro, 3) Check numbers, 4) Note concerns, 5) Draft feedback" |
-| "Prepare for meeting" | natural light spot | "Got it — focus, ~30 min. Steps: 1) Find your sunny spot, 2) Review agenda, 3) Gather materials, 4) Note talking points" |
-
-**Large Tasks (Hidden Sub-tasks):**
-
-| User Says | Presentable Title | Hidden Sub-tasks |
-|-----------|-------------------|------------------|
-| "Complete the project" | "Draft project outline - 30 min (1 of 4 steps)" | 1. Draft outline, 2. First revision, 3. Review, 4. Finalize |
-| "Finish the report" | "Write report introduction - 20 min (1 of 4 steps)" | 1. Introduction, 2. Body sections, 3. Conclusion, 4. Edit |
-| "Plan the event" | "List event requirements - 20 min (1 of 5 steps)" | 1. Requirements, 2. Venue research, 3. Budget, 4. Timeline, 5. Send invites |
 
 ### Work Type Inference Rules
 
@@ -382,56 +238,56 @@ flowchart TD
     end
 ```
 
-### Inference Defaults (Questions as Last Resort)
+### Deadline Detection Examples
 
-> **Design principle:** Every question = decision point. Decision points deplete executive function. Infer aggressively, let user correct. When task too vague to identify, ask up to 3 simple questions — one at a time — then fall back to best-guess.
+| User Says | due_at |
+|-----------|--------|
+| "Cancel appointment before next Wednesday" | Next Wed 17:00 local |
+| "Finish report by 10am tomorrow" | Tomorrow 10:00 local |
+| "Pay taxes by April 15" | Apr 15 17:00 local |
+| "Submit by end of month" | Last day of month 17:00 local |
+| "Call dentist" (no deadline) | null |
 
-```mermaid
-flowchart TD
-    subgraph Defaults["Aggressive Inference"]
-        D1["Urgency unclear →<br/>Default: 50 (moderate)"]
-        D2["Time unclear →<br/>Estimate from task type"]
-        D3["Type ambiguous →<br/>Pick most likely match"]
-        D4["Task vague →<br/>Interpret most common meaning"]
-    end
-```
+### Stakes Detection Examples
 
-**Default Inference Rules:**
+| User Says | Stakes? | Action |
+|-----------|---------|--------|
+| "I need to get life insurance" | Yes | Ask "When do you want this done by?" |
+| "Schedule a mammogram" | Yes | Ask "When do you want this done by?" |
+| "Renew car insurance" | Yes | Ask "When do you want this done by?" |
+| "Organize my bookshelf" | No | Save silently, no deadline |
+| "Research vacation spots" | No | Save silently, no deadline |
+
+### Confirmation Examples (After PR 6 integration)
+
+| Case | Confirmation |
+|------|--------------|
+| Deadline task, reminders scheduled | "Saved — independent, ~15 min, due Wed. I'll ping you Mon 9am, Tue 9am, Wed 1pm." |
+| Deadline task, reminders failed | "Saved — independent, ~15 min, due Wed. (Couldn't schedule reminders right now — I'll retry tonight.)" |
+| No deadline, low stakes | "Saved — focus, ~30 min. No deadline, so I won't ping you. Reply 'remind me' if you want one." |
+| Explicit reminder | "Got it — I'll remind you at 6pm to call the dentist." |
+
+### Inference Defaults
 
 | Missing Info | Default | Rationale |
 |--------------|---------|-----------|
-| Urgency | 50 (moderate) | Safe middle ground, easy to adjust |
-| Time estimate | Based on work type (see table below) | Better than asking |
+| Urgency | 50 (moderate) | Safe middle ground |
+| Time estimate | Based on work type | Better than asking |
 | Work type | Infer from keywords | Even low confidence beats asking |
 | Energy | Match to work type | Focus→high, independent→low |
 
 **Time Estimate Defaults by Work Type:**
 
-| Work Type | Default Estimate | Examples |
-|-----------|-----------------|----------|
-| focus | 45 min | Writing, coding, research |
-| creative | 30 min | Brainstorming, design |
-| social | 15 min | Calls, emails, messages |
-| independent | 20 min | Filing, organizing, errands |
-
-**User Corrections:**
-If user says "actually that's urgent" or "that'll take longer", update task. Reactive correction, not proactive questioning — preserves executive function.
-
-**Clarifying Questions (when task identity unclear):**
-If task too vague to determine what it IS (not its labels), system may ask up to 3 simple questions, one at a time:
-
-| Question # | Behavior |
-|------------|----------|
-| 1 | Ask one simple question about what the task is |
-| 2 | Ask follow-up if still unclear |
-| 3 | Final question — after this, infer and save regardless |
-| 4+ | Never reached — save with best guess after question 3 |
-
-Questions should be low-effort: prefer yes/no or short-answer. Never ask about labels (urgency, time, type) — always infer those.
-
+| Work Type | Default Estimate |
+|-----------|-----------------|
+| focus | 45 min |
+| creative | 30 min |
+| social | 15 min |
+| independent | 20 min |
 
 ---
 
 See also:
-- `docs/ai-prompts/shared.md` — base prompt, user preferences context, sub-task generation rules
-- `docs/ai-prompts/breakdown.md` — complex-task flow
+- `docs/ai-prompts/shared.md` — base prompt, user preferences context
+- `docs/ai-prompts/breakdown.md` — on-demand sub-task breakdown flow (NEED_HELP)
+- `docs/architecture.md` — reminder_scheduler daemon backstop

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -119,7 +119,68 @@ duplicate delivery over loss.
 | `ops_alerts_drain` | 5 min | Send pending ops alerts via Signal |
 | `check_in_dispatcher` | 10 min | Trigger CHECK_IN graph turns for due tasks |
 | `state_audit` | Daily 03:00 USER_TZ | VACUUM + prune `recent_outbound` (90-day retention) |
+| `reminder_scheduler` | Daily 04:00 USER_TZ | Backstop: schedule deadline-driven reminder series for tasks intake missed (orphan tasks + deadline edits) |
 | `weekly_recap` | Sun 18:00 USER_TZ | Generate weekly recap |
+
+## Deadline-Driven Reminder Scheduling
+
+Tasks with a `Due At` date automatically generate a milestone reminder series. The scheduling
+happens in two complementary paths:
+
+1. **Inline (intake node)**: Immediately after `notion.create_task()` succeeds with a `due_at_iso`,
+   `app/scheduler/reminder_scheduling.schedule_for_task()` plans and enqueues the full milestone
+   series before returning the confirmation to the user. The user sees the reminder schedule in
+   the confirmation message.
+
+2. **Daemon backstop (`reminder_scheduler`)**: Runs daily at 04:00 USER_TZ. Picks up tasks where
+   `Reminder Scheduled At` is empty — either because inline scheduling failed (transient DB error)
+   or because the deadline was edited in Notion after the fact.
+
+### Milestone Tiers
+
+`app/scheduler/deadline_planner.tier_for(urgency)` selects the tier:
+
+| Urgency | Tier | Milestones before deadline |
+|---------|------|---------------------------|
+| ≥ 80 | dense | 90d, 30d, 14d, 7d, 3d, 1d, 4h |
+| 40–79 | standard | 60d, 14d, 7d, 3d, 1d, 4h |
+| < 40 | sparse | 60d, 14d, 3d, 4h |
+
+A milestone is scheduled only when `(deadline - offset) > now + 15 min`.
+
+### Load Balancing
+
+`assign_slot()` walks outward from the ideal slot in 30-minute increments (configurable via
+`REMINDER_SLOT_MINUTES`), biasing earlier, skipping quiet hours (22:00–08:00 local by default,
+configurable via `REMINDER_QUIET_START_HOUR`/`REMINDER_QUIET_END_HOUR`), and skipping buckets
+that already have ≥ `REMINDER_SLOT_CAPACITY` (default 2) reminders. The load data comes from
+`reminder_scheduling_ledger`.
+
+### reminder_scheduling_ledger
+
+The `reminder_scheduling_ledger` Postgres table (migration `0007_reminder_scheduling_ledger.sql`)
+tracks each assigned slot:
+
+```
+reminder_scheduling_ledger
+  id                  UUID PK
+  notion_page_id      TEXT
+  deadline_at         TIMESTAMPTZ
+  urgency             INT
+  tier                TEXT  -- 'dense'|'standard'|'sparse'
+  milestone_label     TEXT  -- '90d'|'30d'|...|'4h'
+  ideal_slot_at       TIMESTAMPTZ
+  assigned_slot_at    TIMESTAMPTZ  -- load-balanced actual slot
+  reminder_outbox_id  UUID REFERENCES reminder_outbox(id)
+  scheduled_at        TIMESTAMPTZ  -- when this row was created
+  superseded_at       TIMESTAMPTZ  -- set when deadline changes
+```
+
+Indexed on `assigned_slot_at WHERE superseded_at IS NULL` (for load-balancing window queries)
+and `notion_page_id WHERE superseded_at IS NULL` (for deadline-change detection).
+
+When a deadline changes in Notion, the daemon supersedes all active ledger rows and cancels the
+corresponding `reminder_outbox` rows (`state='dead'`), then schedules a fresh series.
 
 ## Model Routing
 
@@ -154,6 +215,10 @@ require auth, set it to any non-empty placeholder in the runtime environment.
 | `SIGNAL_ACCOUNT` | E.164 Signal account number |
 | `AUTHORIZED_PEERS` | Comma-separated E.164 allowed inbound peers; empty or unset refuses startup |
 | `USER_TZ` | User's IANA timezone (default `America/Chicago`) |
+| `REMINDER_SLOT_MINUTES` | Reminder slot bucket size in minutes (default `30`) |
+| `REMINDER_SLOT_CAPACITY` | Max reminders per slot bucket (default `2`) |
+| `REMINDER_QUIET_START_HOUR` | Quiet hours start, user-local (default `22`) |
+| `REMINDER_QUIET_END_HOUR` | Quiet hours end, user-local (default `8`) |
 
 ## Outbound Dependencies
 

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -72,6 +72,22 @@ stateDiagram-v2
 | Reminder Sent | Reminder delivered | `Completed` (reminder_status=sent) |
 | Completed | Task finished | `Completed` |
 
+## Deadline Reminder Series
+
+Tasks with a `Due At` date automatically generate a scheduled reminder series. Intake schedules
+reminders inline immediately after task creation; the `reminder_scheduler` daemon runs daily as
+a backstop for tasks intake missed (transient enqueue failures or deadlines edited in Notion).
+
+The reminder series is milestone-based: the tier is determined by urgency (dense/standard/sparse),
+and each milestone (e.g. 90d, 14d, 3d, 4h before deadline) that fits within remaining time gets
+a load-balanced slot in the `reminder_outbox`. The `reminder_scheduling_ledger` tracks assigned
+slots. If the deadline is later changed in Notion, the daemon supersedes the old series and
+creates a fresh one.
+
+The confirmation message at intake includes the full planned reminder schedule, so the user
+knows exactly when to expect pings. Reminder bodies use shame-safe framing:
+`"<title> is coming up <when> — want to start now?"`
+
 ## Phase 1: Task Intake
 
 ```mermaid

--- a/docs/user-interactions.md
+++ b/docs/user-interactions.md
@@ -81,7 +81,31 @@ sequenceDiagram
     AI->>U: "Got it — focus work, ~30 min, moderate priority.<br/>Plan: 1) Read intro, 2) Check numbers, 3) Note concerns, 4) Draft feedback"
 ```
 
-> **Decision Fatigue Prevention:** System prefers inference over questions. All labels (urgency, time, work type) inferred from context — never asked. When task too vague to identify (e.g., "do the thing"), up to 3 simple clarifying questions, one at a time. User can correct after ("actually that's urgent") but never forced to decide on labels.
+> **Decision Fatigue Prevention:** System prefers inference over questions. All labels (urgency, time, work type) inferred from context — never asked. When task too vague to identify (e.g., "do the thing"), up to 3 simple clarifying questions, one at a time. The one exception to the no-questions rule is high-stakes tasks with no detected deadline — those trigger a single "When do you want this done by?" question. User can correct after ("actually that's urgent") but never forced to decide on labels.
+
+### Deadline Detection
+
+When the user's message contains a deadline phrase, intake parses it to a `due_at` timestamp:
+
+| Phrase type | Example | Parsed as |
+|-------------|---------|-----------|
+| "before X" | "before next Wednesday" | Wed 17:00 local |
+| "by X" | "by end of month" | Last day 17:00 local |
+| "due X" | "due Thursday" | Thu 17:00 local |
+| "at TIME DATE" | "at 10am tomorrow" | Tomorrow 10:00 local |
+| "finish/submit/complete by X" | "submit by Friday" | Fri 17:00 local |
+
+When a clock time is given ("at 10am"), that exact time is used. When no time is given, the default is 17:00 local (end of business day).
+
+`due_at` and `urgency` are independent fields: urgency = relative priority; `due_at` = hard time bound. A task with a deadline automatically generates a milestone reminder series (see `docs/architecture.md` — Deadline-Driven Reminder Scheduling). The full planned schedule appears in the confirmation message.
+
+### Stakes Clarification
+
+The one automatic clarification on a non-vague task: if a task matches a high-stakes category (life/health/legal/financial/safety) and no deadline phrase was detected, intake asks ONE question: "When do you want this done by?"
+
+Low-stakes tasks with no deadline save silently. The confirmation includes: "No deadline, so I won't ping you. Reply 'remind me' if you want one."
+
+If the user answers the stakes-clarifier with "I don't know", the task saves with no deadline but `urgency = 70` so it surfaces in task selection.
 
 ### Intake Flow (Inference-First, Questions as Last Resort)
 

--- a/tests/evals/fixtures/intake/clock_time_deadline.yaml
+++ b/tests/evals/fixtures/intake/clock_time_deadline.yaml
@@ -1,0 +1,34 @@
+---
+# Eval fixture: "at 10am tomorrow" sets exact clock time in due_at (not 17:00 default).
+# Verifies DEADLINE DETECTION correctly handles explicit clock-time phrases.
+id: intake-clock-time-deadline-001
+node: intake
+tier: medium
+peer: "<test-peer-clock>"
+inbound: "I need to submit the placeholder form at 10am tomorrow"
+prior_state:
+  active_task: null
+  conversation_state: idle
+  user_prefs:
+    timezone: America/Chicago
+contracts:
+  - kind: json_field
+    field: "action"
+    value: "save"
+    description: "Must save with the clock-time deadline"
+  - kind: json_field_present
+    field: "due_at"
+    description: "due_at must be set for explicit clock-time deadline"
+  - kind: regex_require
+    pattern: "10:00|10:00:00"
+    field: "due_at"
+    description: "due_at must contain 10am (10:00) when user says 'at 10am'"
+  - kind: judge
+    rubric: |
+      The JSON output must have action='save' and due_at set to tomorrow at
+      10:00:00 in the user's timezone (America/Chicago). The clock time "10am"
+      must be preserved exactly — not replaced with the 17:00 end-of-day default.
+      Score 1.0 if due_at is set and contains T10:00 at the local timezone offset.
+      Score 0.5 if due_at is set but uses 17:00 instead of 10:00.
+      Score 0.0 if due_at is null or action is 'clarify'.
+    threshold: 0.7

--- a/tests/evals/fixtures/intake/deadline_phrase.yaml
+++ b/tests/evals/fixtures/intake/deadline_phrase.yaml
@@ -1,0 +1,32 @@
+---
+# Eval fixture: deadline phrase in user message must produce due_at in LLM output.
+# Verifies the DEADLINE DETECTION block correctly parses relative date phrases.
+id: intake-deadline-phrase-001
+node: intake
+tier: medium
+peer: "<test-peer-deadline>"
+inbound: "I need to cancel my placeholder appointment before next Wednesday"
+prior_state:
+  active_task: null
+  conversation_state: idle
+  user_prefs:
+    timezone: America/Chicago
+contracts:
+  - kind: regex_forbid
+    pattern: "(?i)(here'?s? your plan|step[s]?:|\\d+\\)\\s)"
+    description: "No numbered plan steps in confirmation"
+  - kind: json_field
+    field: "action"
+    value: "save"
+    description: "Must save, not clarify"
+  - kind: json_field_present
+    field: "due_at"
+    description: "due_at must be set when deadline phrase is detected"
+  - kind: judge
+    rubric: |
+      The JSON output must have action='save' and due_at set to a valid ISO 8601
+      timestamp for next Wednesday at or before 17:00 local. The confirmation_message
+      must acknowledge the task was saved and may include the deadline. Score 1.0 if
+      both due_at is set (non-null) and action is 'save'. Score 0.0 if action is
+      'clarify' or due_at is null.
+    threshold: 0.8

--- a/tests/evals/fixtures/intake/high_stakes_no_deadline.yaml
+++ b/tests/evals/fixtures/intake/high_stakes_no_deadline.yaml
@@ -1,0 +1,31 @@
+---
+# Eval fixture: high-stakes task with no deadline must trigger ONE clarification
+# question asking "When do you want this done by?" (or equivalent).
+# Verifies STAKES DETECTION behavior.
+id: intake-high-stakes-no-deadline-001
+node: intake
+tier: medium
+peer: "<test-peer-stakes>"
+inbound: "I need to get life insurance"
+prior_state:
+  active_task: null
+  conversation_state: idle
+  user_prefs:
+    timezone: America/Chicago
+  clarification_count: 0
+contracts:
+  - kind: json_field
+    field: "action"
+    value: "clarify"
+    description: "High-stakes task with no deadline must trigger clarification"
+  - kind: regex_require
+    pattern: "(?i)(when|done by|by when|deadline|complete|finish)"
+    description: "Clarification question must ask about timing/deadline"
+  - kind: judge
+    rubric: |
+      The response must ask ONE clarification question about when the user wants
+      this high-stakes task done. The question must be about timing, not labels.
+      Score 1.0 if action='clarify' and the question asks when the user wants it
+      done or by what date. Score 0.0 if action='save' (task saved without asking
+      about the deadline on a high-stakes task) or if the question is about labels.
+    threshold: 0.8

--- a/tests/evals/fixtures/intake/low_stakes_no_deadline.yaml
+++ b/tests/evals/fixtures/intake/low_stakes_no_deadline.yaml
@@ -1,0 +1,36 @@
+---
+# Eval fixture: low-stakes task with no deadline must save silently (no clarification).
+# Verifies the low-stakes path of STAKES DETECTION: no question, just save.
+id: intake-low-stakes-no-deadline-001
+node: intake
+tier: medium
+peer: "<test-peer-low-stakes>"
+inbound: "I want to organize my bookshelf"
+prior_state:
+  active_task: null
+  conversation_state: idle
+  user_prefs:
+    timezone: America/Chicago
+contracts:
+  - kind: json_field
+    field: "action"
+    value: "save"
+    description: "Low-stakes no-deadline task must save without clarification"
+  - kind: json_field
+    field: "due_at"
+    value: null
+    description: "No due_at for low-stakes task with no deadline"
+  - kind: regex_forbid
+    pattern: "(?i)(when do you want|done by|by when|what's the deadline)"
+    description: "Must NOT ask about deadline for low-stakes tasks"
+  - kind: regex_forbid
+    pattern: "(?i)(here'?s? your plan|step[s]?:|\\d+\\)\\s)"
+    description: "No numbered plan steps in confirmation"
+  - kind: judge
+    rubric: |
+      The response must save the task without asking about a deadline. It should
+      produce action='save' with due_at=null. The confirmation_message may include
+      a 'no deadline' disclaimer. Score 1.0 if action='save' and no clarification
+      question about deadlines is present. Score 0.0 if action='clarify' or if
+      the response asks when the task should be done.
+    threshold: 0.8

--- a/tests/evals/fixtures/intake/no_subtasks_default.yaml
+++ b/tests/evals/fixtures/intake/no_subtasks_default.yaml
@@ -1,0 +1,43 @@
+---
+# Eval fixture: intake must NOT include numbered plan steps in the confirmation.
+# Sub-tasks are on-request only; the "Here's your plan: 1) X, 2) Y" format is removed.
+id: intake-no-subtasks-default-001
+node: intake
+tier: medium
+peer: "<test-peer-no-subtasks>"
+inbound: "I need to review the placeholder proposal"
+prior_state:
+  active_task: null
+  conversation_state: idle
+  user_prefs:
+    timezone: America/Chicago
+contracts:
+  - kind: json_field
+    field: "action"
+    value: "save"
+    description: "Standard task must save without clarification"
+  - kind: regex_forbid
+    pattern: "Here'?s? your plan:\\s*1\\)"
+    description: "Must not include 'Here's your plan: 1)' framing"
+  - kind: regex_forbid
+    pattern: "Step:"
+    description: "Must not include 'Step:' numbering"
+  - kind: regex_forbid
+    pattern: "(?i)(first step|next step|step 1)"
+    description: "Must not prescribe steps in the confirmation"
+  - kind: judge
+    rubric: |
+      The confirmation_message must be a brief acknowledgment of the save —
+      something like "Saved — focus, ~30 min." — without listing numbered steps
+      or a "Here's your plan" section. Score 1.0 if the confirmation is a clean
+      one-sentence save acknowledgment. Score 0.0 if the confirmation includes
+      a numbered list of steps, "Here's your plan:", or "Step:".
+    threshold: 0.8
+  - kind: judge
+    shame_safe: true
+    rubric: |
+      The response must not imply failure, judgement, or urgency the user didn't
+      express. Score 1.0 if the response is neutral, supportive, or encouraging.
+      Score 0.0 if the response uses shame language, urgency inflation, or implies
+      the user should have done this already.
+    threshold: 0.9

--- a/tests/integration/test_deadline_planner_smoke.py
+++ b/tests/integration/test_deadline_planner_smoke.py
@@ -1,0 +1,222 @@
+"""Integration smoke test for app.scheduler.deadline_planner.
+
+Exercises the full public API surface in an integration-shaped manner:
+computes a milestone plan, assigns slots for each milestone, and verifies
+no collisions emerge.  No DB or I/O — "integration" here means the functions
+compose correctly end-to-end, satisfying test-rig clause 1 for new public
+functions.
+
+Reachability for the DB-touching callers is in:
+  - tests/integration/test_intake_deadlines.py (inline scheduling path)
+  - tests/integration/test_reminder_scheduler.py (daemon path)
+
+Private data: all values use placeholders / synthetic datetimes.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from app.scheduler.deadline_planner import (
+    assign_slot,
+    format_reminder_summary,
+    plan_milestones,
+    tier_for,
+)
+
+_TZ_STR = "America/Chicago"
+_TZ = ZoneInfo(_TZ_STR)
+
+
+def _local(year: int, month: int, day: int, hour: int = 0, minute: int = 0) -> datetime:
+    return datetime(year, month, day, hour, minute, tzinfo=_TZ)
+
+
+class TestDeadlinePlannerSmoke:
+    """End-to-end composition: plan → assign → summarise → no collisions."""
+
+    def test_dense_plan_assign_no_collisions(self) -> None:
+        """Dense tier: plan all 7 milestones, assign slots, assert no bucket collisions."""
+        now = _local(2026, 1, 1, 10, 0)
+        deadline = _local(2026, 7, 20, 17, 0)   # ~200 days away
+
+        assert tier_for(85) == "dense"
+        milestones = plan_milestones(deadline, urgency=85, now=now, user_tz=_TZ_STR)
+        assert len(milestones) == 7
+
+        assigned: list[datetime] = []
+        fallback_count = 0
+        for m in milestones:
+            slot, used_fallback = assign_slot(
+                m.ideal_at,
+                assigned,
+                deadline,
+                user_tz=_TZ_STR,
+                quiet_hours=(22, 8),
+                slot_minutes=30,
+                slot_capacity=2,
+                max_drift_minutes=720,
+                now=now,
+            )
+            if used_fallback:
+                fallback_count += 1
+            assigned.append(slot)
+            # Slot must be before deadline
+            assert slot < deadline
+            # Slot must be after now (with 15-min lead)
+            assert slot > now + timedelta(minutes=15)
+
+        # All 7 milestones spaced far apart → no fallbacks expected
+        assert fallback_count == 0, f"Unexpected fallbacks: {fallback_count}"
+
+    def test_standard_plan_assign_summary_roundtrip(self) -> None:
+        """Standard tier: plan → assign → format_reminder_summary roundtrip."""
+        now = _local(2026, 6, 1, 10, 0)
+        deadline = _local(2026, 6, 30, 17, 0)   # 29 days away
+
+        milestones = plan_milestones(deadline, urgency=60, now=now, user_tz=_TZ_STR)
+        assert len(milestones) > 0
+
+        assigned: list[tuple[str, datetime]] = []
+        for m in milestones:
+            slot, _ = assign_slot(
+                m.ideal_at,
+                [s for _, s in assigned],
+                deadline,
+                user_tz=_TZ_STR,
+                quiet_hours=(22, 8),
+                slot_minutes=30,
+                slot_capacity=2,
+                max_drift_minutes=720,
+                now=now,
+            )
+            assigned.append((m.label, slot))
+
+        summary = format_reminder_summary(assigned, user_tz=_TZ_STR)
+        assert summary.startswith("I'll ping you ")
+        assert summary.endswith(".")
+
+    def test_summary_is_chronologically_sorted(self) -> None:
+        """format_reminder_summary output is always chronologically ascending."""
+        now = _local(2026, 6, 1, 10, 0)
+        deadline = _local(2026, 6, 30, 17, 0)
+
+        milestones = plan_milestones(deadline, urgency=60, now=now, user_tz=_TZ_STR)
+        assigned: list[tuple[str, datetime]] = []
+        for m in milestones:
+            slot, _ = assign_slot(
+                m.ideal_at,
+                [s for _, s in assigned],
+                deadline,
+                user_tz=_TZ_STR,
+                quiet_hours=(22, 8),
+                slot_minutes=30,
+                slot_capacity=2,
+                max_drift_minutes=720,
+                now=now,
+            )
+            assigned.append((m.label, slot))
+
+        # Reverse the order before passing to format_reminder_summary
+        # to ensure it re-sorts regardless of input order.
+        reversed_slots = list(reversed(assigned))
+        summary_forward = format_reminder_summary(assigned, user_tz=_TZ_STR)
+        summary_reversed = format_reminder_summary(reversed_slots, user_tz=_TZ_STR)
+        # Both must produce the same (chronological) output
+        assert summary_forward == summary_reversed
+
+    def test_sparse_short_deadline_single_reminder(self) -> None:
+        """Sparse tier + 2-day deadline → exactly 1 milestone (4h), valid slot."""
+        now = _local(2026, 6, 1, 10, 0)
+        deadline = _local(2026, 6, 3, 17, 0)   # 55h away
+
+        milestones = plan_milestones(deadline, urgency=20, now=now, user_tz=_TZ_STR)
+        assert len(milestones) == 1
+        assert milestones[0].label == "4h"
+
+        slot, fallback = assign_slot(
+            milestones[0].ideal_at,
+            [],
+            deadline,
+            user_tz=_TZ_STR,
+            quiet_hours=(22, 8),
+            slot_minutes=30,
+            slot_capacity=2,
+            max_drift_minutes=720,
+            now=now,
+        )
+        assert not fallback
+        assert slot < deadline
+        assert slot > now + timedelta(minutes=15)
+
+    def test_10_tasks_assign_no_slot_overflow(self) -> None:
+        """Simulate 10 tasks with 3d deadline each; assign all slots; bucket occupancy <= capacity."""
+        now = _local(2026, 6, 1, 10, 0)
+        deadline = _local(2026, 6, 4, 17, 0)   # 3 days away
+        capacity = 2
+
+        all_slots: list[datetime] = []
+        for task_i in range(10):
+            # Stagger urgency so we get a mix of sparse/standard
+            urgency = 30 + task_i * 5   # 30..75
+            milestones = plan_milestones(deadline, urgency=urgency, now=now, user_tz=_TZ_STR)
+            for m in milestones:
+                slot, _ = assign_slot(
+                    m.ideal_at,
+                    all_slots,
+                    deadline,
+                    user_tz=_TZ_STR,
+                    quiet_hours=(22, 8),
+                    slot_minutes=30,
+                    slot_capacity=capacity,
+                    max_drift_minutes=720,
+                    now=now,
+                )
+                all_slots.append(slot)
+
+        # Count occupancy per 30-min bucket
+        from collections import Counter
+
+        def _bucket(dt: datetime) -> int:
+            return int(dt.timestamp()) // (30 * 60)
+
+        counts = Counter(_bucket(s) for s in all_slots)
+        overflow = {k: v for k, v in counts.items() if v > capacity}
+        assert not overflow, f"Bucket(s) exceed capacity={capacity}: {overflow}"
+
+    def test_format_empty_returns_empty(self) -> None:
+        """Empty milestone list → empty summary string."""
+        now = _local(2026, 6, 10, 12, 0)
+        deadline = _local(2026, 6, 5, 17, 0)   # past deadline → no milestones
+        milestones = plan_milestones(deadline, urgency=80, now=now, user_tz=_TZ_STR)
+        assert milestones == []
+        summary = format_reminder_summary([], user_tz=_TZ_STR)
+        assert summary == ""
+
+    def test_quiet_hours_respected_across_all_assignments(self) -> None:
+        """No assigned slot falls in quiet hours (22:00-08:00 local)."""
+        now = _local(2026, 1, 1, 10, 0)
+        deadline = _local(2026, 7, 20, 17, 0)
+
+        milestones = plan_milestones(deadline, urgency=85, now=now, user_tz=_TZ_STR)
+        assigned: list[datetime] = []
+        for m in milestones:
+            slot, _ = assign_slot(
+                m.ideal_at,
+                assigned,
+                deadline,
+                user_tz=_TZ_STR,
+                quiet_hours=(22, 8),
+                slot_minutes=30,
+                slot_capacity=2,
+                max_drift_minutes=720,
+                now=now,
+            )
+            assigned.append(slot)
+
+        for slot in assigned:
+            local_h = slot.astimezone(_TZ).hour
+            # Not in quiet window [22, 24) ∪ [0, 8)
+            assert 8 <= local_h < 22, (
+                f"Slot {slot.astimezone(_TZ).isoformat()} falls in quiet hours (hour={local_h})"
+            )

--- a/tests/integration/test_intake_deadlines.py
+++ b/tests/integration/test_intake_deadlines.py
@@ -1,0 +1,399 @@
+"""Integration tests for deadline detection and inline reminder scheduling in intake.
+
+Tests the intake node + reminder_scheduling.schedule_for_task integration:
+- Deadline phrases produce correct due_at in Notion create_task calls
+- Inline reminder scheduling writes ledger + outbox rows
+- Confirmation message includes reminder summary
+- Stakes detection triggers clarification on high-stakes tasks
+- Low-stakes tasks with no deadline save silently with disclaimer
+- Inline enqueue failure → ops_alert + task still saved + no mark_reminder_scheduled
+
+Notion + DB calls are mocked. No DATABASE_URL required for most tests;
+tests that exercise real ledger writes are skipped if DATABASE_URL absent.
+
+Private data: all values are placeholders / synthetic.
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.graph.state import State
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_notion_page(page_id: str = "", title: str = "Placeholder task") -> dict:
+    return {
+        "id": page_id or str(uuid.uuid4()),
+        "properties": {
+            "Title": {"title": [{"plain_text": title}]},
+            "Status": {"select": {"name": "Pending"}},
+        },
+    }
+
+
+def _llm_save_response(
+    title: str = "Placeholder task",
+    work_type: str = "focus",
+    urgency: int = 50,
+    time_estimate: int = 30,
+    is_reminder: bool = False,
+    remind_at: str | None = None,
+    due_at: str | None = None,
+    is_high_stakes: bool = False,
+    confirmation: str = "Saved — focus, ~30 min.",
+) -> str:
+    return json.dumps({
+        "action": "save",
+        "title": title,
+        "work_type": work_type,
+        "urgency": urgency,
+        "time_estimate_minutes": time_estimate,
+        "energy_required": "Medium",
+        "is_reminder": is_reminder,
+        "remind_at": remind_at,
+        "due_at": due_at,
+        "is_high_stakes": is_high_stakes,
+        "use_hidden_subtasks": False,
+        "sub_tasks": [],
+        "inline_steps": "",
+        "confirmation_message": confirmation,
+    })
+
+
+def _llm_clarify_response(question: str) -> str:
+    return json.dumps({
+        "action": "clarify",
+        "clarification_question": question,
+        "clarification_count": 1,
+    })
+
+
+def _state(peer: str = "<test-peer>", incoming: str = "placeholder", prefs: dict | None = None) -> State:
+    return {
+        "peer": peer,
+        "incoming": incoming,
+        "intent": "ADD_TASK",
+        "messages": [],
+        "active_task": None,
+        "streak": 0,
+        "tasks_completed_today": 0,
+        "user_prefs": prefs or {"timezone": "America/Chicago"},
+        "mood": None,
+        "available_minutes": None,
+        "conversation_state": "idle",
+        "pending_outbound": [],
+    }
+
+
+def _mock_llm(response_text: str):
+    """Return a patcher for the LLM that yields the given response text."""
+    mock_llm_response = MagicMock()
+    mock_llm_response.content = response_text
+    mock_model = AsyncMock()
+    mock_model.ainvoke = AsyncMock(return_value=mock_llm_response)
+    return mock_model
+
+
+# ---------------------------------------------------------------------------
+# Test: deadline task creates notion row with due_at_iso
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_deadline_phrase_creates_task_with_due_at() -> None:
+    """'finish report by Friday' → create_task called with due_at_iso set.
+
+    The LLM returns a due_at in its JSON; intake passes it to notion.create_task.
+    """
+    page_id = str(uuid.uuid4())
+    due_at_str = "2026-06-05T17:00:00-05:00"  # Fri 17:00 Central
+
+    task_response = _llm_save_response(
+        title="Placeholder report task",
+        work_type="focus",
+        urgency=60,
+        due_at=due_at_str,
+        confirmation="Saved — focus, ~30 min, due Fri.",
+    )
+
+    create_task_calls: list[dict] = []
+
+    async def mock_create_task(**kwargs: Any) -> dict:
+        create_task_calls.append(kwargs)
+        return _make_notion_page(page_id=page_id, title="Placeholder report task")
+
+    with (
+        patch("app.tools.notion.create_task", side_effect=mock_create_task),
+        patch("app.tools.notion.create_reminder", new_callable=AsyncMock),
+        patch("app.tools.notion.mark_reminder_scheduled", new_callable=AsyncMock),
+        patch(
+            "app.scheduler.reminder_scheduling.schedule_for_task",
+            new_callable=AsyncMock,
+            return_value=([], []),
+        ),
+        patch("app.models.llm", return_value=_mock_llm(task_response)),
+    ):
+        from app.graph.nodes.intake import intake_node
+
+        result = await intake_node(
+            _state(
+                peer="<test-deadline-peer>",
+                incoming="finish placeholder report by Friday",
+            )
+        )
+
+    # create_task was called with the correct due_at_iso
+    assert len(create_task_calls) == 1
+    assert create_task_calls[0]["due_at_iso"] == due_at_str
+
+    # Confirmation is present
+    assert result["pending_outbound"]
+    draft = result["pending_outbound"][0]
+    assert draft["recipient"] == "<test-deadline-peer>"
+
+
+@pytest.mark.asyncio
+async def test_clock_time_deadline_sets_exact_time() -> None:
+    """'finish report by 10am tomorrow' → due_at_iso reflects exact clock time."""
+    page_id = str(uuid.uuid4())
+    due_at_str = "2026-06-02T10:00:00-05:00"  # 10am Central tomorrow
+
+    task_response = _llm_save_response(
+        title="Placeholder report task",
+        work_type="focus",
+        urgency=70,
+        due_at=due_at_str,
+        confirmation="Saved — focus, ~30 min, due tomorrow 10am.",
+    )
+
+    create_task_calls: list[dict] = []
+
+    async def mock_create_task(**kwargs: Any) -> dict:
+        create_task_calls.append(kwargs)
+        return _make_notion_page(page_id=page_id)
+
+    with (
+        patch("app.tools.notion.create_task", side_effect=mock_create_task),
+        patch("app.tools.notion.mark_reminder_scheduled", new_callable=AsyncMock),
+        patch(
+            "app.scheduler.reminder_scheduling.schedule_for_task",
+            new_callable=AsyncMock,
+            return_value=([], []),
+        ),
+        patch("app.models.llm", return_value=_mock_llm(task_response)),
+    ):
+        from app.graph.nodes.intake import intake_node
+
+        result = await intake_node(
+            _state(
+                peer="<test-clock-deadline-peer>",
+                incoming="finish placeholder report by 10am tomorrow",
+            )
+        )
+
+    assert len(create_task_calls) == 1
+    assert create_task_calls[0]["due_at_iso"] == due_at_str
+    assert result["pending_outbound"]
+
+
+@pytest.mark.asyncio
+async def test_deadline_task_confirmation_includes_reminder_summary() -> None:
+    """Deadline task with successful inline scheduling → confirmation includes reminder summary."""
+    page_id = str(uuid.uuid4())
+    due_at_str = "2026-06-05T17:00:00-05:00"
+
+    task_response = _llm_save_response(
+        title="Placeholder task",
+        due_at=due_at_str,
+        urgency=60,
+        confirmation="Saved — focus, ~30 min, due Fri.",
+    )
+
+    # Simulate successful schedule_for_task returning assigned slots
+    fri_5pm = datetime(2026, 6, 5, 17, 0, tzinfo=UTC)
+    wed_9am = datetime(2026, 6, 3, 14, 0, tzinfo=UTC)  # UTC → 9am Central
+    mock_assigned_slots = [("3d", wed_9am), ("4h", fri_5pm - __import__('datetime').timedelta(hours=4))]
+
+    async def mock_schedule(**kwargs: Any) -> tuple:
+        return (mock_assigned_slots, [])
+
+    with (
+        patch("app.tools.notion.create_task", new_callable=AsyncMock, return_value=_make_notion_page(page_id=page_id)),
+        patch("app.tools.notion.mark_reminder_scheduled", new_callable=AsyncMock),
+        patch("app.scheduler.reminder_scheduling.schedule_for_task", side_effect=mock_schedule),
+        patch("app.models.llm", return_value=_mock_llm(task_response)),
+    ):
+        from app.graph.nodes.intake import intake_node
+
+        result = await intake_node(
+            _state(peer="<test-summary-peer>", incoming="placeholder task by Friday")
+        )
+
+    assert result["pending_outbound"]
+    body = result["pending_outbound"][0]["body"]
+    # The body should contain the LLM confirmation + the reminder summary
+    assert "Saved" in body
+    assert "I'll ping you" in body
+
+
+@pytest.mark.asyncio
+async def test_high_stakes_no_deadline_triggers_clarification() -> None:
+    """'I need to purchase life insurance' → clarification question returned."""
+    clarify_response = _llm_clarify_response(
+        "When do you want this done by?"
+    )
+
+    with patch("app.models.llm", return_value=_mock_llm(clarify_response)):
+        from app.graph.nodes.intake import intake_node
+
+        result = await intake_node(
+            _state(
+                peer="<test-stakes-peer>",
+                incoming="I need to purchase life insurance",
+            )
+        )
+
+    # Should return a clarification question, not save
+    assert result["pending_outbound"]
+    body = result["pending_outbound"][0]["body"]
+    assert "?" in body
+    assert "when" in body.lower() or "done by" in body.lower()
+
+
+@pytest.mark.asyncio
+async def test_low_stakes_no_deadline_saves_silently_with_disclaimer() -> None:
+    """'organize my bookshelf' → saved silently, confirmation includes no-deadline disclaimer."""
+    page_id = str(uuid.uuid4())
+
+    task_response = _llm_save_response(
+        title="Placeholder organize task",
+        work_type="independent",
+        urgency=30,
+        due_at=None,
+        is_high_stakes=False,
+        confirmation="Saved — independent, ~20 min.",
+    )
+
+    create_task_calls: list[dict] = []
+
+    async def mock_create_task(**kwargs: Any) -> dict:
+        create_task_calls.append(kwargs)
+        return _make_notion_page(page_id=page_id, title="Placeholder organize task")
+
+    with (
+        patch("app.tools.notion.create_task", side_effect=mock_create_task),
+        patch("app.models.llm", return_value=_mock_llm(task_response)),
+    ):
+        from app.graph.nodes.intake import intake_node
+
+        result = await intake_node(
+            _state(
+                peer="<test-no-deadline-peer>",
+                incoming="organize my placeholder bookshelf",
+            )
+        )
+
+    # Task saved without clarification
+    assert len(create_task_calls) == 1
+    assert create_task_calls[0]["due_at_iso"] is None
+
+    # Confirmation has the no-deadline disclaimer
+    assert result["pending_outbound"]
+    body = result["pending_outbound"][0]["body"]
+    assert "No deadline" in body or "won't ping" in body or "remind me" in body.lower()
+
+
+@pytest.mark.asyncio
+async def test_inline_enqueue_failure_task_still_saved_ops_alert_emitted() -> None:
+    """Inline reminder enqueue failure → task still saved; ops_alert emitted; no mark_reminder_scheduled."""
+    page_id = str(uuid.uuid4())
+    due_at_str = "2026-06-05T17:00:00-05:00"
+
+    task_response = _llm_save_response(
+        title="Placeholder task with deadline",
+        due_at=due_at_str,
+        urgency=60,
+        confirmation="Saved — focus, ~30 min, due Fri.",
+    )
+
+    ops_alert_calls: list[dict] = []
+
+    async def mock_ops_enqueue(kind: str, body: str, severity: str = "warning") -> uuid.UUID:
+        ops_alert_calls.append({"kind": kind, "body": body, "severity": severity})
+        return uuid.uuid4()
+
+    mark_scheduled_calls: list = []
+
+    async def mock_mark_scheduled(pid: str) -> dict:
+        mark_scheduled_calls.append(pid)
+        return {}
+
+    # schedule_for_task returns one failure
+    async def mock_schedule(**kwargs: Any) -> tuple:
+        return ([], ["4h"])  # empty assigned, "4h" failed
+
+    with (
+        patch("app.tools.notion.create_task", new_callable=AsyncMock, return_value=_make_notion_page(page_id=page_id)),
+        patch("app.tools.notion.mark_reminder_scheduled", side_effect=mock_mark_scheduled),
+        patch("app.tools.ops_alerts.enqueue", side_effect=mock_ops_enqueue),
+        patch("app.scheduler.reminder_scheduling.schedule_for_task", side_effect=mock_schedule),
+        patch("app.models.llm", return_value=_mock_llm(task_response)),
+    ):
+        from app.graph.nodes.intake import intake_node
+
+        result = await intake_node(
+            _state(peer="<test-failure-peer>", incoming="placeholder task by Friday")
+        )
+
+    # Task was saved (pending_outbound exists)
+    assert result["pending_outbound"]
+    body = result["pending_outbound"][0]["body"]
+    # Confirmation body mentions retry
+    assert "retry" in body.lower() or "tonight" in body.lower() or "couldn't" in body.lower()
+
+    # ops_alert was emitted for the partial failure
+    assert any("partial" in call["kind"] or "failure" in call["kind"] for call in ops_alert_calls)
+
+    # mark_reminder_scheduled was NOT called (Reminder Scheduled At stays empty for daemon)
+    assert len(mark_scheduled_calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_no_deadline_task_no_schedule_for_task_called() -> None:
+    """Task with no due_at → schedule_for_task is never called."""
+    page_id = str(uuid.uuid4())
+
+    task_response = _llm_save_response(
+        title="Placeholder no-deadline task",
+        due_at=None,
+        is_high_stakes=False,
+        confirmation="Saved — focus, ~30 min.",
+    )
+
+    schedule_calls: list = []
+
+    async def mock_schedule(**kwargs: Any) -> tuple:
+        schedule_calls.append(kwargs)
+        return ([], [])
+
+    with (
+        patch("app.tools.notion.create_task", new_callable=AsyncMock, return_value=_make_notion_page(page_id=page_id)),
+        patch("app.scheduler.reminder_scheduling.schedule_for_task", side_effect=mock_schedule),
+        patch("app.models.llm", return_value=_mock_llm(task_response)),
+    ):
+        from app.graph.nodes.intake import intake_node
+
+        result = await intake_node(
+            _state(peer="<test-no-sched-peer>", incoming="placeholder task no deadline")
+        )
+
+    assert result["pending_outbound"]
+    # schedule_for_task was not called since there's no due_at
+    assert len(schedule_calls) == 0

--- a/tests/integration/test_reminder_scheduler.py
+++ b/tests/integration/test_reminder_scheduler.py
@@ -1,0 +1,330 @@
+"""Integration tests for the reminder_scheduler daemon (backstop path).
+
+Tests the run_reminder_scheduler() daemon with mocked Notion and mocked
+schedule_for_task (to isolate daemon logic from scheduling algorithm).
+DB-backed tests use real Postgres and are skipped when DATABASE_URL is absent.
+
+Covers:
+- Empty Notion response → no writes
+- One task with deadline → schedule_for_task called; mark_reminder_scheduled called on success
+- Rerun on already-scheduled task → no-op (Notion filter excludes it)
+- Deadline changed in Notion → old ledger rows superseded, old outbox rows dead, new rows scheduled
+- Planner fallback (enqueue_failures) → ops_alert emitted; mark_reminder_scheduled NOT called
+- Notion 5xx → ops_alert emitted; cycle aborted
+
+Private data: all values are placeholders / synthetic.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_notion_task(
+    page_id: str,
+    title: str = "Placeholder task",
+    due_at_iso: str = "2026-06-05T17:00:00-05:00",
+    urgency: int = 50,
+) -> dict:
+    return {
+        "id": page_id,
+        "properties": {
+            "Title": {"title": [{"plain_text": title}]},
+            "Status": {"select": {"name": "Pending"}},
+            "Due At": {"date": {"start": due_at_iso}},
+            "Urgency": {"number": urgency},
+        },
+    }
+
+
+def _notion_result(tasks: list[dict]) -> dict:
+    return {"results": tasks, "has_more": False}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_empty_notion_no_writes() -> None:
+    """Empty Notion result → no schedule_for_task calls and no mark_reminder_scheduled calls."""
+    mark_calls: list = []
+    schedule_calls: list = []
+
+    async def mock_mark_scheduled(pid: str) -> dict:
+        mark_calls.append(pid)
+        return {}
+
+    async def mock_schedule(**kwargs: Any) -> tuple:
+        schedule_calls.append(kwargs)
+        return ([], [])
+
+    with (
+        patch(
+            "app.tools.notion.query_tasks_with_unscheduled_deadlines",
+            new_callable=AsyncMock,
+            return_value=_notion_result([]),
+        ),
+        patch("app.tools.notion.mark_reminder_scheduled", side_effect=mock_mark_scheduled),
+        patch("app.scheduler.reminder_scheduling.schedule_for_task", side_effect=mock_schedule),
+        patch("app.scheduler.reminder_scheduling.get_active_deadline_for_page", new_callable=AsyncMock, return_value=None),
+    ):
+        from app.scheduler.reminder_scheduler import run_reminder_scheduler
+        await run_reminder_scheduler()
+
+    assert len(mark_calls) == 0
+    assert len(schedule_calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_one_task_schedules_and_marks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One orphan task → schedule_for_task called; mark_reminder_scheduled called on success."""
+    monkeypatch.setenv("AUTHORIZED_PEERS", "<test-peer-number>")
+
+    page_id = str(uuid.uuid4())
+    task = _make_notion_task(page_id=page_id, due_at_iso="2026-06-05T17:00:00-05:00", urgency=60)
+
+    mark_calls: list = []
+    schedule_calls: list = []
+
+    fake_slots = [("3d", datetime(2026, 6, 2, 14, 0, tzinfo=UTC))]
+
+    async def mock_mark_scheduled(pid: str) -> dict:
+        mark_calls.append(pid)
+        return {}
+
+    async def mock_schedule(**kwargs: Any) -> tuple:
+        schedule_calls.append(kwargs)
+        return (fake_slots, [])
+
+    with (
+        patch(
+            "app.tools.notion.query_tasks_with_unscheduled_deadlines",
+            new_callable=AsyncMock,
+            return_value=_notion_result([task]),
+        ),
+        patch("app.tools.notion.mark_reminder_scheduled", side_effect=mock_mark_scheduled),
+        patch("app.scheduler.reminder_scheduling.schedule_for_task", side_effect=mock_schedule),
+        patch("app.scheduler.reminder_scheduling.get_active_deadline_for_page", new_callable=AsyncMock, return_value=None),
+    ):
+        from app.scheduler.reminder_scheduler import run_reminder_scheduler
+        await run_reminder_scheduler()
+
+    assert len(schedule_calls) == 1
+    assert schedule_calls[0]["page_id"] == page_id
+    assert len(mark_calls) == 1
+    assert mark_calls[0] == page_id
+
+
+@pytest.mark.asyncio
+async def test_already_scheduled_task_skipped() -> None:
+    """Tasks already scheduled (Reminder Scheduled At set) are excluded by Notion filter.
+
+    The Notion query only returns tasks where Reminder Scheduled At is empty.
+    So an already-scheduled task never appears — this tests the empty-result path.
+    """
+    # An already-scheduled task would not appear in query_tasks_with_unscheduled_deadlines
+    # because Notion filters to Reminder Scheduled At is_empty.
+    schedule_calls: list = []
+
+    async def mock_schedule(**kwargs: Any) -> tuple:
+        schedule_calls.append(kwargs)
+        return ([], [])
+
+    with (
+        patch(
+            "app.tools.notion.query_tasks_with_unscheduled_deadlines",
+            new_callable=AsyncMock,
+            return_value=_notion_result([]),  # Empty — already-scheduled tasks excluded
+        ),
+        patch("app.scheduler.reminder_scheduling.schedule_for_task", side_effect=mock_schedule),
+        patch("app.scheduler.reminder_scheduling.get_active_deadline_for_page", new_callable=AsyncMock, return_value=None),
+    ):
+        from app.scheduler.reminder_scheduler import run_reminder_scheduler
+        await run_reminder_scheduler()
+
+    # Never called — no tasks to process
+    assert len(schedule_calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_deadline_changed_supersedes_old_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Deadline changed in Notion → supersede_ledger_rows + cancel_outbox_rows called."""
+    monkeypatch.setenv("AUTHORIZED_PEERS", "<test-peer-number>")
+
+    page_id = str(uuid.uuid4())
+    new_due = "2026-06-10T17:00:00-05:00"
+    old_deadline = datetime(2026, 6, 5, 22, 0, tzinfo=UTC)  # Old: Jun 5 UTC
+
+    task = _make_notion_task(page_id=page_id, due_at_iso=new_due, urgency=60)
+
+    supersede_calls: list = []
+    cancel_calls: list = []
+    schedule_calls: list = []
+
+    old_outbox_ids = [uuid.uuid4()]
+
+    async def mock_supersede(pid: str) -> list:
+        supersede_calls.append(pid)
+        return old_outbox_ids
+
+    async def mock_cancel(oids: list) -> None:
+        cancel_calls.append(oids)
+
+    fake_slots = [("3d", datetime(2026, 6, 7, 14, 0, tzinfo=UTC))]
+
+    async def mock_schedule(**kwargs: Any) -> tuple:
+        schedule_calls.append(kwargs)
+        return (fake_slots, [])
+
+    with (
+        patch(
+            "app.tools.notion.query_tasks_with_unscheduled_deadlines",
+            new_callable=AsyncMock,
+            return_value=_notion_result([task]),
+        ),
+        patch("app.tools.notion.mark_reminder_scheduled", new_callable=AsyncMock, return_value={}),
+        patch(
+            "app.scheduler.reminder_scheduling.get_active_deadline_for_page",
+            new_callable=AsyncMock,
+            return_value=old_deadline,  # Prior deadline exists and differs
+        ),
+        patch("app.scheduler.reminder_scheduling.supersede_ledger_rows", side_effect=mock_supersede),
+        patch("app.scheduler.reminder_scheduling.cancel_outbox_rows", side_effect=mock_cancel),
+        patch("app.scheduler.reminder_scheduling.schedule_for_task", side_effect=mock_schedule),
+    ):
+        from app.scheduler.reminder_scheduler import run_reminder_scheduler
+        await run_reminder_scheduler()
+
+    # Old rows were superseded and outbox rows cancelled
+    assert len(supersede_calls) == 1
+    assert supersede_calls[0] == page_id
+    assert len(cancel_calls) == 1
+    assert cancel_calls[0] == old_outbox_ids
+
+    # New schedule was created
+    assert len(schedule_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_enqueue_failure_emits_ops_alert_no_mark_scheduled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Partial enqueue failure → ops_alert emitted; mark_reminder_scheduled NOT called."""
+    monkeypatch.setenv("AUTHORIZED_PEERS", "<test-peer-number>")
+
+    page_id = str(uuid.uuid4())
+    task = _make_notion_task(page_id=page_id, due_at_iso="2026-06-05T17:00:00-05:00", urgency=60)
+
+    ops_alert_calls: list = []
+    mark_calls: list = []
+
+    async def mock_ops_enqueue(kind: str, body: str, severity: str = "warning") -> uuid.UUID:
+        ops_alert_calls.append({"kind": kind, "body": body})
+        return uuid.uuid4()
+
+    async def mock_mark_scheduled(pid: str) -> dict:
+        mark_calls.append(pid)
+        return {}
+
+    # schedule_for_task returns failure
+    async def mock_schedule(**kwargs: Any) -> tuple:
+        return ([], ["4h"])
+
+    with (
+        patch(
+            "app.tools.notion.query_tasks_with_unscheduled_deadlines",
+            new_callable=AsyncMock,
+            return_value=_notion_result([task]),
+        ),
+        patch("app.tools.notion.mark_reminder_scheduled", side_effect=mock_mark_scheduled),
+        patch("app.tools.ops_alerts.enqueue", side_effect=mock_ops_enqueue),
+        patch("app.scheduler.reminder_scheduling.schedule_for_task", side_effect=mock_schedule),
+        patch("app.scheduler.reminder_scheduling.get_active_deadline_for_page", new_callable=AsyncMock, return_value=None),
+    ):
+        from app.scheduler.reminder_scheduler import run_reminder_scheduler
+        await run_reminder_scheduler()
+
+    # ops_alert was emitted
+    assert len(ops_alert_calls) >= 1
+    assert any("failure" in c["kind"] or "partial" in c["kind"] for c in ops_alert_calls)
+
+    # mark_reminder_scheduled was NOT called
+    assert len(mark_calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_notion_5xx_emits_ops_alert_and_aborts() -> None:
+    """Notion 5xx on query → ops_alert emitted; cycle aborts (no schedule_for_task calls)."""
+    ops_alert_calls: list = []
+    schedule_calls: list = []
+
+    async def mock_ops_enqueue(kind: str, body: str, severity: str = "warning") -> uuid.UUID:
+        ops_alert_calls.append({"kind": kind})
+        return uuid.uuid4()
+
+    async def mock_schedule(**kwargs: Any) -> tuple:
+        schedule_calls.append(kwargs)
+        return ([], [])
+
+    with (
+        patch(
+            "app.tools.notion.query_tasks_with_unscheduled_deadlines",
+            new_callable=AsyncMock,
+            side_effect=Exception("HTTP 503 Service Unavailable"),
+        ),
+        patch("app.tools.ops_alerts.enqueue", side_effect=mock_ops_enqueue),
+        patch("app.scheduler.reminder_scheduling.schedule_for_task", side_effect=mock_schedule),
+    ):
+        from app.scheduler.reminder_scheduler import run_reminder_scheduler
+        await run_reminder_scheduler()
+
+    # ops_alert emitted
+    assert len(ops_alert_calls) >= 1
+    assert any("notion" in c["kind"] for c in ops_alert_calls)
+
+    # No scheduling attempted
+    assert len(schedule_calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_task_missing_deadline_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Task in Notion response with no Due At → skipped gracefully."""
+    monkeypatch.setenv("AUTHORIZED_PEERS", "<test-peer-number>")
+
+    page_id = str(uuid.uuid4())
+    bad_task = {
+        "id": page_id,
+        "properties": {
+            "Title": {"title": [{"plain_text": "Placeholder task no due"}]},
+            "Status": {"select": {"name": "Pending"}},
+            "Due At": {"date": None},  # No date
+            "Urgency": {"number": 50},
+        },
+    }
+
+    schedule_calls: list = []
+
+    async def mock_schedule(**kwargs: Any) -> tuple:
+        schedule_calls.append(kwargs)
+        return ([], [])
+
+    with (
+        patch(
+            "app.tools.notion.query_tasks_with_unscheduled_deadlines",
+            new_callable=AsyncMock,
+            return_value=_notion_result([bad_task]),
+        ),
+        patch("app.scheduler.reminder_scheduling.schedule_for_task", side_effect=mock_schedule),
+        patch("app.scheduler.reminder_scheduling.get_active_deadline_for_page", new_callable=AsyncMock, return_value=None),
+    ):
+        from app.scheduler.reminder_scheduler import run_reminder_scheduler
+        await run_reminder_scheduler()
+
+    # Skipped — no schedule_for_task calls
+    assert len(schedule_calls) == 0

--- a/tests/unit/test_deadline_planner.py
+++ b/tests/unit/test_deadline_planner.py
@@ -1,0 +1,419 @@
+"""Unit tests for app.scheduler.deadline_planner.
+
+Table-driven. Covers tier selection, milestone clipping, load-balancing
+outward walk, quiet-hours skip, never-past-deadline guard, fallback flag,
+and format_reminder_summary round-trips.
+
+No I/O, no DB, no async — all functions are pure.
+
+Private data: all test values use placeholder strings / synthetic datetimes.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.scheduler.deadline_planner import (
+    MilestoneSlot,
+    assign_slot,
+    format_reminder_summary,
+    plan_milestones,
+    tier_for,
+)
+
+# Use a fixed timezone throughout tests.
+_TZ_STR = "America/Chicago"
+_TZ = ZoneInfo(_TZ_STR)
+
+
+def _local(year: int, month: int, day: int, hour: int = 0, minute: int = 0) -> datetime:
+    """Build a tz-aware datetime in America/Chicago."""
+    return datetime(year, month, day, hour, minute, tzinfo=_TZ)
+
+
+def _utc(year: int, month: int, day: int, hour: int = 0, minute: int = 0) -> datetime:
+    """Build a tz-aware datetime in UTC."""
+    return datetime(year, month, day, hour, minute, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# tier_for — 6 table-driven cases
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("urgency,expected", [
+    (0,   "sparse"),
+    (39,  "sparse"),
+    (40,  "standard"),
+    (79,  "standard"),
+    (80,  "dense"),
+    (100, "dense"),
+])
+def test_tier_for(urgency: int, expected: str) -> None:
+    assert tier_for(urgency) == expected
+
+
+# ---------------------------------------------------------------------------
+# plan_milestones
+# ---------------------------------------------------------------------------
+
+class TestPlanMilestones:
+
+    def test_6_month_out_dense_returns_7_milestones(self) -> None:
+        """6-month deadline + dense urgency → all 7 milestones (90d..4h)."""
+        now = _local(2026, 1, 1, 10, 0)
+        # Deadline 200 days away (>90d) at end-of-day
+        deadline = _local(2026, 7, 20, 17, 0)
+        slots = plan_milestones(deadline, urgency=85, now=now, user_tz=_TZ_STR)
+        assert len(slots) == 7
+        labels = [s.label for s in slots]
+        assert labels == ["90d", "30d", "14d", "7d", "3d", "1d", "4h"]
+
+    def test_5_day_out_standard_clips_past_milestones(self) -> None:
+        """5-day deadline + standard urgency → only 3d, 1d, 4h milestones."""
+        now = _local(2026, 6, 1, 10, 0)
+        deadline = _local(2026, 6, 6, 17, 0)   # 5 days away
+        slots = plan_milestones(deadline, urgency=50, now=now, user_tz=_TZ_STR)
+        labels = [s.label for s in slots]
+        # 60d, 14d, 7d are in the past → clipped; 3d, 1d, 4h fit
+        assert "60d" not in labels
+        assert "14d" not in labels
+        assert "7d" not in labels
+        assert set(labels) == {"3d", "1d", "4h"}
+        assert len(slots) == 3
+
+    def test_1_day_out_sparse_returns_1_milestone(self) -> None:
+        """1-day deadline + sparse urgency → only 4h milestone."""
+        now = _local(2026, 6, 1, 10, 0)
+        deadline = _local(2026, 6, 2, 17, 0)   # ~31h away
+        slots = plan_milestones(deadline, urgency=20, now=now, user_tz=_TZ_STR)
+        labels = [s.label for s in slots]
+        assert labels == ["4h"]
+
+    def test_22h_clock_time_deadline_dense_yields_4h_at_6am(self) -> None:
+        """22h-out clock-time deadline (10am tomorrow) + dense → 1 milestone (4h ≈ 6am).
+
+        The 1d milestone is clipped because deadline - 1d is at or before now.
+        The 4h milestone ideal is deadline - 4h = 6am (clock-time anchoring).
+        """
+        now = _local(2026, 6, 1, 12, 0)        # noon today
+        deadline = _local(2026, 6, 2, 10, 0)   # 10am tomorrow (22h away, NOT end-of-day)
+        slots = plan_milestones(deadline, urgency=85, now=now, user_tz=_TZ_STR)
+        assert len(slots) == 1, f"Expected 1 slot, got {len(slots)}: {[s.label for s in slots]}"
+        assert slots[0].label == "4h"
+        # ideal_at should be 6am (deadline - 4h)
+        expected_ideal = deadline - timedelta(hours=4)
+        assert slots[0].ideal_at == expected_ideal
+
+    def test_past_deadline_returns_empty(self) -> None:
+        """Deadline in the past → empty list."""
+        now = _local(2026, 6, 10, 12, 0)
+        deadline = _local(2026, 6, 5, 17, 0)   # in the past
+        slots = plan_milestones(deadline, urgency=80, now=now, user_tz=_TZ_STR)
+        assert slots == []
+
+    def test_16_minutes_out_returns_empty(self) -> None:
+        """16-minute-out deadline → empty list (4h milestone would be -3h44m in past)."""
+        now = _local(2026, 6, 1, 12, 0)
+        deadline = now + timedelta(minutes=16)
+        # 4h-before fires at deadline - 4h = now - 3h44m → in the past → skipped
+        slots = plan_milestones(deadline, urgency=80, now=now, user_tz=_TZ_STR)
+        assert slots == []
+
+    def test_slots_sorted_ascending(self) -> None:
+        """plan_milestones returns slots sorted by ideal_at ascending."""
+        now = _local(2026, 1, 1, 10, 0)
+        deadline = _local(2026, 7, 20, 17, 0)
+        slots = plan_milestones(deadline, urgency=85, now=now, user_tz=_TZ_STR)
+        assert len(slots) >= 2
+        for a, b in zip(slots, slots[1:], strict=False):
+            assert a.ideal_at <= b.ideal_at
+
+    def test_milestone_slot_dataclass_fields(self) -> None:
+        """MilestoneSlot has label, tier, ideal_at fields."""
+        now = _local(2026, 1, 1, 10, 0)
+        deadline = _local(2026, 4, 15, 17, 0)
+        slots = plan_milestones(deadline, urgency=80, now=now, user_tz=_TZ_STR)
+        assert len(slots) > 0
+        s = slots[0]
+        assert isinstance(s, MilestoneSlot)
+        assert isinstance(s.label, str)
+        assert s.tier in ("dense", "standard", "sparse")
+        assert s.ideal_at.tzinfo is not None  # tz-aware
+
+
+# ---------------------------------------------------------------------------
+# assign_slot
+# ---------------------------------------------------------------------------
+
+class TestAssignSlot:
+
+    def _make_ideal(self) -> datetime:
+        """A simple ideal slot: Wednesday 10am local."""
+        return _local(2026, 6, 3, 10, 0)   # Wednesday
+
+    def _make_deadline(self) -> datetime:
+        """Deadline safely after the ideal."""
+        return _local(2026, 6, 6, 17, 0)
+
+    def test_empty_existing_returns_ideal(self) -> None:
+        """No existing slots → returns (ideal_snapped, False)."""
+        ideal = self._make_ideal()
+        slot, fallback = assign_slot(
+            ideal, [], self._make_deadline(),
+            user_tz=_TZ_STR,
+            quiet_hours=(22, 8),
+            slot_minutes=30,
+            slot_capacity=2,
+            max_drift_minutes=720,
+            now=_local(2026, 6, 1, 10, 0),
+        )
+        assert not fallback
+        assert slot <= ideal + timedelta(minutes=30)  # within one bucket of ideal
+
+    def test_full_ideal_bucket_walks_earlier(self) -> None:
+        """When ideal bucket is full, assign_slot returns a slot 30 min earlier."""
+        ideal = _local(2026, 6, 3, 10, 0)
+        deadline = _local(2026, 6, 6, 17, 0)
+        now = _local(2026, 6, 1, 8, 0)
+        # Two existing slots at the ideal time (fills capacity=2)
+        existing = [ideal, ideal + timedelta(minutes=5)]
+        slot, fallback = assign_slot(
+            ideal, existing, deadline,
+            user_tz=_TZ_STR,
+            quiet_hours=(22, 8),
+            slot_minutes=30,
+            slot_capacity=2,
+            max_drift_minutes=720,
+            now=now,
+        )
+        assert not fallback
+        # Should be 30 min before ideal (biased earlier)
+        assert slot < ideal
+
+    def test_full_bucket_and_earlier_also_full_walks_back_further(self) -> None:
+        """If ideal and ideal-30min are both full, walks to an adjacent open slot."""
+        ideal = _local(2026, 6, 3, 10, 0)
+        deadline = _local(2026, 6, 6, 17, 0)
+        now = _local(2026, 6, 1, 8, 0)
+        # Fill ideal and ideal-30min buckets; also fill ideal+30 to force wider walk
+        minus30 = ideal - timedelta(minutes=30)
+        plus30  = ideal + timedelta(minutes=30)
+        existing = [ideal, ideal, minus30, minus30, plus30, plus30]   # 2 each → all full
+        slot, fallback = assign_slot(
+            ideal, existing, deadline,
+            user_tz=_TZ_STR,
+            quiet_hours=(22, 8),
+            slot_minutes=30,
+            slot_capacity=2,
+            max_drift_minutes=720,
+            now=now,
+        )
+        assert not fallback
+        # Must be outside the three packed buckets
+        assert slot not in (ideal, minus30, plus30)
+        # Should be earlier or later by >=60 min from ideal
+        assert abs((slot - ideal).total_seconds()) >= 3600
+
+    def test_past_guard_causes_later_walk(self) -> None:
+        """When walking earlier would cross now+15min, falls through to later."""
+        # ideal is only 20 min after now → can't walk earlier at all
+        now = _local(2026, 6, 3, 9, 0)
+        ideal = _local(2026, 6, 3, 9, 30)   # only 30 min after now
+        deadline = _local(2026, 6, 6, 17, 0)
+        # Fill the ideal bucket
+        existing = [ideal, ideal]
+        slot, fallback = assign_slot(
+            ideal, existing, deadline,
+            user_tz=_TZ_STR,
+            quiet_hours=(22, 8),
+            slot_minutes=30,
+            slot_capacity=2,
+            max_drift_minutes=720,
+            now=now,
+        )
+        assert not fallback
+        # Must be later than ideal since earlier is blocked by the past guard
+        assert slot > ideal
+
+    def test_never_returns_slot_at_or_after_deadline(self) -> None:
+        """assign_slot never returns a slot >= deadline."""
+        ideal = _local(2026, 6, 3, 10, 0)
+        deadline = _local(2026, 6, 3, 11, 0)   # deadline only 1h after ideal
+        now = _local(2026, 6, 1, 8, 0)
+        # Fill every earlier bucket but leave ideal empty
+        slot, fallback = assign_slot(
+            ideal, [], deadline,
+            user_tz=_TZ_STR,
+            quiet_hours=(22, 8),
+            slot_minutes=30,
+            slot_capacity=2,
+            max_drift_minutes=720,
+            now=now,
+        )
+        assert slot < deadline
+
+    def test_all_slots_full_returns_fallback_true(self) -> None:
+        """When all slots within max_drift are full, returns (ideal, True)."""
+        ideal = _local(2026, 6, 3, 10, 0)
+        deadline = _local(2026, 6, 6, 17, 0)
+        now = _local(2026, 6, 1, 8, 0)
+        max_drift_minutes = 60  # only ±60 min search window
+        steps = max_drift_minutes // 30 + 1
+
+        # Pack every bucket within ±60 min (plus ideal itself)
+        existing: list[datetime] = []
+        for i in range(-steps, steps + 1):
+            t = ideal + timedelta(minutes=30 * i)
+            existing.extend([t, t])   # 2 per bucket → full
+
+        slot, fallback = assign_slot(
+            ideal, existing, deadline,
+            user_tz=_TZ_STR,
+            quiet_hours=(22, 8),
+            slot_minutes=30,
+            slot_capacity=2,
+            max_drift_minutes=max_drift_minutes,
+            now=now,
+        )
+        assert fallback is True
+        assert slot == ideal   # returns original ideal (not snapped) on fallback
+
+    def test_quiet_hours_6am_target_pushed_to_8am(self) -> None:
+        """Ideal at 6am is in quiet hours (22-8); assign_slot pushes to 8am."""
+        # ideal = 6am local (quiet hours 22-8 → 6am is quiet)
+        ideal = _local(2026, 6, 3, 6, 0)
+        deadline = _local(2026, 6, 6, 17, 0)
+        now = _local(2026, 6, 1, 8, 0)
+        slot, fallback = assign_slot(
+            ideal, [], deadline,
+            user_tz=_TZ_STR,
+            quiet_hours=(22, 8),
+            slot_minutes=30,
+            slot_capacity=2,
+            max_drift_minutes=720,
+            now=now,
+        )
+        assert not fallback
+        local_slot = slot.astimezone(_TZ)
+        assert local_slot.hour >= 8, f"Expected slot at or after 8am, got {local_slot.hour}:{local_slot.minute:02d}"
+
+    def test_high_urgency_small_drift_returns_fallback_sooner(self) -> None:
+        """max_drift=120 with packed schedule → fallback True sooner than default."""
+        ideal = _local(2026, 6, 3, 10, 0)
+        deadline = _local(2026, 6, 6, 17, 0)
+        now = _local(2026, 6, 1, 8, 0)
+        # Fill ±120 min with capacity=2 each
+        existing: list[datetime] = []
+        for i in range(-5, 6):
+            t = ideal + timedelta(minutes=30 * i)
+            existing.extend([t, t])
+
+        slot_small, fallback_small = assign_slot(
+            ideal, existing, deadline,
+            user_tz=_TZ_STR,
+            quiet_hours=(22, 8),
+            slot_minutes=30,
+            slot_capacity=2,
+            max_drift_minutes=120,
+            now=now,
+        )
+        assert fallback_small is True
+
+        # With default max_drift=720, the same schedule would have open slots
+        # (we only packed ±150 min worth of buckets, so outside that window is open)
+        slot_default, fallback_default = assign_slot(
+            ideal, existing, deadline,
+            user_tz=_TZ_STR,
+            quiet_hours=(22, 8),
+            slot_minutes=30,
+            slot_capacity=2,
+            max_drift_minutes=720,
+            now=now,
+        )
+        assert fallback_default is False
+
+
+# ---------------------------------------------------------------------------
+# format_reminder_summary — chronological order enforced
+# ---------------------------------------------------------------------------
+
+class TestFormatReminderSummary:
+
+    def test_three_slots_returned_chronologically(self) -> None:
+        """format_reminder_summary sorts slots by datetime ascending, regardless of input order.
+
+        The 4h slot (Thu 8am) is earlier than the 1d slot (Thu 9am) and the 3d slot (Wed noon).
+        Passing them in non-chronological order must still produce ascending output.
+        """
+        wed_noon = _local(2026, 6, 3, 12, 0)   # Wed noon — earliest
+        thu_9am  = _local(2026, 6, 4, 9, 0)    # Thu 9am — middle
+        thu_8am  = _local(2026, 6, 4, 8, 0)    # Thu 8am — also earlier than thu_9am
+
+        # Pass in non-chronological order (as PR 600 had them — 9am before 8am)
+        slots_non_chron = [
+            ("3d", wed_noon),
+            ("1d", thu_9am),
+            ("4h", thu_8am),
+        ]
+        result = format_reminder_summary(slots_non_chron, user_tz=_TZ_STR)
+        # Chronological order: Wed noon → Thu 8am → Thu 9am
+        assert result == "I'll ping you Wed noon, Thu 8am, Thu 9am."
+
+    def test_one_slot(self) -> None:
+        """Single slot → singular form."""
+        slots = [("4h", _local(2026, 6, 5, 8, 0))]
+        result = format_reminder_summary(slots, user_tz=_TZ_STR)
+        assert result.startswith("I'll ping you ")
+        assert result.endswith(".")
+
+    def test_empty_returns_empty_string(self) -> None:
+        """Empty slot list → empty string."""
+        result = format_reminder_summary([], user_tz=_TZ_STR)
+        assert result == ""
+
+    def test_midnight_label(self) -> None:
+        """Slot at midnight → 'midnight', not '12am'."""
+        slots = [("4h", _local(2026, 6, 3, 0, 0))]  # Wednesday midnight
+        result = format_reminder_summary(slots, user_tz=_TZ_STR)
+        assert "midnight" in result
+        assert "12am" not in result
+
+    def test_noon_label(self) -> None:
+        """Slot at noon → 'noon', not '12pm'."""
+        slots = [("3d", _local(2026, 6, 3, 12, 0))]  # Wednesday noon
+        result = format_reminder_summary(slots, user_tz=_TZ_STR)
+        assert "noon" in result
+        assert "12pm" not in result
+
+    def test_am_pm_formatting(self) -> None:
+        """Regular hours format correctly as Xam / Xpm."""
+        slots_am = [("1d", _local(2026, 6, 4, 9, 0))]
+        slots_pm = [("1d", _local(2026, 6, 4, 21, 0))]
+        assert "9am" in format_reminder_summary(slots_am, user_tz=_TZ_STR)
+        assert "9pm" in format_reminder_summary(slots_pm, user_tz=_TZ_STR)
+
+    def test_minute_suffix_included_when_nonzero(self) -> None:
+        """Times with non-zero minutes include the minute portion."""
+        slots = [("4h", _local(2026, 6, 4, 9, 30))]
+        result = format_reminder_summary(slots, user_tz=_TZ_STR)
+        assert "9:30am" in result
+
+    def test_tz_conversion_applied(self) -> None:
+        """Datetimes are converted to user_tz before formatting."""
+        # 15:00 UTC = 10:00 CDT (America/Chicago, UTC-5 in June)
+        dt_utc = _utc(2026, 6, 3, 15, 0)
+        slots = [("3d", dt_utc)]
+        result = format_reminder_summary(slots, user_tz=_TZ_STR)
+        assert "10am" in result
+
+    def test_already_sorted_input_stays_sorted(self) -> None:
+        """Already-sorted input produces the same chronological output."""
+        wed_noon = _local(2026, 6, 3, 12, 0)
+        thu_8am  = _local(2026, 6, 4, 8, 0)
+        thu_9am  = _local(2026, 6, 4, 9, 0)
+
+        slots_chron = [("3d", wed_noon), ("4h", thu_8am), ("1d", thu_9am)]
+        result = format_reminder_summary(slots_chron, user_tz=_TZ_STR)
+        assert result == "I'll ping you Wed noon, Thu 8am, Thu 9am."

--- a/tests/unit/test_reachability.py
+++ b/tests/unit/test_reachability.py
@@ -57,6 +57,7 @@ _ENTRY_POINTS: frozenset[str] = frozenset(
         "run_state_audit",  # func=run_state_audit in JobSpec
         "generate_weekly_recap",  # func=generate_weekly_recap in JobSpec
         "dispatch_check_ins",  # func=dispatch_check_ins in JobSpec
+        "run_deadline_reminder_scheduler",  # func=run_deadline_reminder_scheduler in JobSpec
         # app/ingress/signal_listener.py — called by main.py via asyncio.run()
         "run",  # asyncio.run(run()) in main.py
     ]


### PR DESCRIPTION
## Summary

Bundles the deadline-reminder feature end-to-end (originally planned as PRs 3–7). Closed PR #600 (`feat/deadline-planner`) is superseded; this branch contains the same planner code with a bug fix plus all remaining phases.

- **deadline_planner.py**: Pure-function milestone planner with tier-based milestone offsets (dense/standard/sparse), quiet-hours enforcement, load-balanced slot assignment via `assign_slot()`, and `format_reminder_summary()`. Fixes the chronological-sort bug from closed PR #600 (slots were returned in caller order; now sorted ascending before formatting).
- **reminder_scheduling.py**: Shared `schedule_for_task()` helper used by both intake and the nightly daemon. Handles ledger queries, slot assignment, outbox enqueue, and ledger insert. `UniqueViolation` treated as idempotent success.
- **reminder_scheduler.py + jobs.py**: Nightly backstop daemon at 04:00 USER_TZ. Detects deadline changes via ledger comparison (±60s tolerance), supersedes stale ledger rows, cancels corresponding outbox entries, schedules a fresh series.
- **intake.py + intake.md.j2 + docs/ai-prompts/intake.md**: Inline scheduling immediately after task creation. Adds deadline detection (phrase → ISO 8601, 17:00 end-of-day default for bare dates) and stakes detection (life/health/legal/financial/safety categories → one clarifying question instead of silent save). Confirmation format updated. Sub-task generation removed from the default path (on-request only via NEED_HELP).
- **Spec docs + DEV-AGENTS.md + docker/compose.yaml**: Present-tense rewrites for architecture.md (reminder_scheduler job, Deadline-Driven Reminder Scheduling section, env vars), task-lifecycle.md (Deadline Reminder Series section), user-interactions.md (Deadline Detection + Stakes Clarification). Four new optional env vars in compose.yaml with defaults.

## Test plan

- [ ] `pytest tests/unit/test_deadline_planner.py -v` — 31 unit tests, includes chronological-sort regression test
- [ ] `pytest tests/integration/test_deadline_planner_smoke.py -v` — 7 smoke tests (skipped without DATABASE_URL)
- [ ] `pytest tests/integration/test_reminder_scheduler.py -v` — 7 daemon behavior tests
- [ ] `pytest tests/integration/test_intake_deadlines.py -v` — 7 intake deadline tests (all mocked; no DB needed)
- [ ] `pytest tests/unit/test_reachability.py -v` — reachability check including new `run_deadline_reminder_scheduler` entry point
- [ ] `ruff check app/ tests/` — clean
- [ ] `mypy app/ --ignore-missing-imports` — clean (38 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)