### PR TITLE
feat(reminders): deadline-driven reminder series (redesigned, smaller PR)

### DIFF
--- a/DEV-AGENTS.md
+++ b/DEV-AGENTS.md
@@ -39,7 +39,7 @@ These are the authoritative behavioral contracts. The Python implementation in `
 
 The Python/LangGraph application. Safe to edit via PRs.
 
-- `app/tools/notion.py` — Notion API client (9 verbs + health_check)
+- `app/tools/notion.py` — Notion API client (12 verbs + health_check); deadline-reminder plumbing includes `query_tasks_with_unscheduled_deadlines`, `query_scheduled_tasks_with_deadlines`, and `mark_reminder_scheduled`
 - `app/tools/signal_client.py` — Signal bridge async client
 - `app/tools/reminders.py` — Reminder outbox CRUD
 - `app/tools/rewards.py` — Reward delivery (emoji + image; v1 scope)
@@ -59,8 +59,11 @@ The Python/LangGraph application. Safe to edit via PRs.
 - `app/graph/nodes/complete.py` — COMPLETE intent node
 - `app/graph/nodes/send.py` — Terminal send node
 - `app/scheduler/scheduler.py` — APScheduler v3 wiring with PostgresJobStore
-- `app/scheduler/jobs.py` — Declarative SCHEDULED_JOBS list + reconcile_jobstore; jobs: `reminder_dispatcher`, `notion_health`, `ops_alerts_drain`, `state_audit`, `check_in_dispatcher`, `weekly_recap`
-- `app/scheduler/reminder_worker.py` — SELECT FOR UPDATE SKIP LOCKED worker
+- `app/scheduler/jobs.py` — Declarative SCHEDULED_JOBS list + reconcile_jobstore; jobs: `reminder_dispatcher`, `notion_health`, `ops_alerts_drain`, `state_audit`, `check_in_dispatcher`, `weekly_recap`, `reminder_scheduler`
+- `app/scheduler/reminder_worker.py` — SELECT FOR UPDATE SKIP LOCKED worker; branches on `reminder_outbox.kind` so that `kind='deadline'` rows do NOT trigger `notion.complete_reminder` (deadline-series pings nudge an unfinished task; only wall-clock `kind='reminder'` rows complete the task on delivery)
+- `app/scheduler/deadline_planner.py` — Pure-function milestone planner: tier selection (dense/standard/sparse), `plan_milestones`, `assign_slot` (load-balanced quiet-hours-aware), `format_reminder_summary`. No I/O. Env-tunable defaults via `REMINDER_SLOT_MINUTES`, `REMINDER_SLOT_CAPACITY`, `REMINDER_QUIET_START_HOUR`, `REMINDER_QUIET_END_HOUR`.
+- `app/scheduler/reminder_scheduling.py` — Shared `schedule_for_task` helper used by both intake-inline scheduling and the daemon backstop. Enqueues outbox rows with `kind='deadline'`, inserts ledger rows, exposes `supersede_ledger_rows` + `cancel_outbox_rows` + `get_active_deadline_for_page` for deadline-edit detection.
+- `app/scheduler/reminder_scheduler.py` — Daily backstop daemon (04:00 user TZ). Dual Notion query: orphan catch-up (Reminder Scheduled At is_empty) and edit-detection (Reminder Scheduled At is_not_empty, deadline cross-checked against ledger with ±60s tolerance). On edit detected, supersedes ledger rows + cancels outbox rows + reschedules.
 - `app/ingress/signal_listener.py` — Authorized Signal WebSocket consumer; routes reactions to reward feedback, schedules read receipts, maintains typing indicators around graph execution, and invokes the graph for text messages
 - `app/prompts/` — Jinja2 prompt templates (`*.md.j2`) for each intent
 - `app/observability/__init__.py` — Package marker for the observability module
@@ -74,6 +77,7 @@ The Python/LangGraph application. Safe to edit via PRs.
 - `migrations/0005_readonly_user.sql` — Adds `hml_readonly` Postgres role with GRANT SELECT for read-only DB access
 - `migrations/0006_reward_feedback_columns.sql` — Adds `feedback_emoji` and `feedback_at` columns to `reward_manifests`
 - `migrations/0007_reminder_scheduling_ledger.sql` — Adds `reminder_scheduling_ledger` table for deadline-driven reminder tracking; drops `reminder_outbox.notion_page_id` UNIQUE constraint and adds UNIQUE on `idempotency_key`
+- `migrations/0008_reminder_outbox_kind.sql` — Adds `reminder_outbox.kind` column (`'reminder'|'deadline'`, default `'reminder'`) with CHECK constraint. The discriminator is consumed by `reminder_worker.py` to suppress `notion.complete_reminder` for `kind='deadline'` rows so the task is not silently marked Completed when a deadline ping fires.
 - `tests/unit/` — Unit tests (no DATABASE_URL required)
 - `tests/integration/` — Integration tests; DB-backed tests require DATABASE_URL, HTTP-only tests do not
 - `tests/perf/` — Perf harness: latency + token stats per model, gated by `ENABLE_LLM_PERF=true`. See `docs/python-rewrite/llm-observability.md` for usage.

--- a/app/graph/nodes/intake.py
+++ b/app/graph/nodes/intake.py
@@ -101,19 +101,41 @@ async def intake_node(state: State) -> dict[str, Any]:
         energy_required = parsed.get("energy_required", "Medium")
         is_reminder = bool(parsed.get("is_reminder", False))
         remind_at_str = parsed.get("remind_at")
+        due_at_str = parsed.get("due_at")
         inline_steps = parsed.get("inline_steps", "")
-        use_hidden_subtasks = bool(parsed.get("use_hidden_subtasks", False))
+        use_hidden_subtasks = bool(parsed.get("use_hidden_subtasks", False)) and not is_reminder
         sub_tasks = parsed.get("sub_tasks", [])
         confirmation_message = parsed.get("confirmation_message", f"Got it — {work_type}, ~{time_estimate} min.")
 
+        # Privacy: log only flags / numeric labels, never raw LLM-extracted
+        # strings. has_remind_at / has_due_at are booleans; urgency /
+        # time_estimate are numeric. Per DEV-AGENTS.md (Safety -> Don't
+        # leak private examples), raw `remind_at` / `due_at` may contain
+        # echoes of the user's task text.
         log.info(
             "intake_node.parsed",
             is_reminder=is_reminder,
             has_remind_at=bool(remind_at_str),
-            remind_at=remind_at_str,  # ISO timestamp; not PII
+            has_due_at=bool(due_at_str),
             urgency=urgency,
             time_estimate=time_estimate,
         )
+
+        # Parse due_at (deadline) — privacy-safe failure: no value, no exception.
+        deadline_at: datetime | None = None
+        if due_at_str and not is_reminder:
+            try:
+                deadline_at = _parse_iso_strict(due_at_str)
+            except ValueError:
+                # Privacy: do not log the raw string or exception. The LLM
+                # produced an unparseable due_at; treat as if no deadline
+                # was given.
+                log.info(
+                    "intake_node.due_at_parse_failed",
+                    has_due_at=True,
+                    parse_failed=True,
+                )
+                deadline_at = None
 
         if is_reminder and remind_at_str:
             notion_page = await _create_reminder(
@@ -132,9 +154,26 @@ async def intake_node(state: State) -> dict[str, Any]:
                 time_estimate=time_estimate,
                 energy_required=energy_required,
                 inline_steps=inline_steps,
+                due_at_iso=deadline_at.isoformat() if deadline_at else None,
             )
 
         page_id = (notion_page or {}).get("id")
+
+        # Inline deadline-series scheduling. Runs after task creation when a
+        # deadline was extracted. Failures are silent from the user's
+        # perspective — the daemon backstop (jobs.reminder_scheduler) will
+        # retry on the next nightly cycle. We never surface infra retry
+        # state to the user (psy-001 / docs/ai-prompts/shared.md).
+        assigned_slots: list[tuple[str, datetime]] = []
+        if deadline_at is not None and page_id:
+            assigned_slots = await _schedule_deadline_series(
+                page_id=page_id,
+                title=task_title,
+                peer=peer,
+                deadline_at=deadline_at,
+                urgency=urgency,
+                user_timezone=user_timezone,
+            )
 
         # Create hidden sub-tasks if needed
         if use_hidden_subtasks and sub_tasks and page_id:
@@ -152,13 +191,36 @@ async def intake_node(state: State) -> dict[str, Any]:
                 except Exception:
                     log.exception("intake_node.subtask_create_failed", page_id=page_id)
 
+        # Append deterministic reminder summary to the confirmation when the
+        # deadline series was scheduled. The summary is computed from
+        # assigned_slots (not the LLM) to avoid hallucinated times. On
+        # scheduling failure we do NOT append anything — the daemon backstop
+        # will pick this task up later, and surfacing infra/retry state to
+        # the user violates the shame-safe / no-tool-narration contract in
+        # docs/ai-prompts/shared.md.
+        if assigned_slots:
+            try:
+                from app.scheduler.deadline_planner import format_reminder_summary
+                summary = format_reminder_summary(assigned_slots, user_timezone)
+                if summary:
+                    confirmation_message = f"{confirmation_message} {summary}"
+            except Exception:
+                log.exception("intake_node.summary_format_failed")
+
         draft = {
             "recipient": peer,
             "body": confirmation_message,
             "notion_page_id": page_id,
         }
 
-        log.info("intake_node.saved", peer=peer, page_id=page_id, is_reminder=is_reminder)
+        log.info(
+            "intake_node.saved",
+            peer=peer,
+            page_id=page_id,
+            is_reminder=is_reminder,
+            has_due_at=deadline_at is not None,
+            scheduled_count=len(assigned_slots),
+        )
         return {
             "pending_outbound": [draft],
             "conversation_state": "idle",
@@ -240,7 +302,13 @@ async def _create_reminder(
 
 
 def _parse_remind_at(remind_at_str: str) -> datetime:
-    """Parse an ISO 8601 string to a UTC-aware datetime."""
+    """Parse an ISO 8601 string to a UTC-aware datetime.
+
+    Caller is responsible for privacy-safe error handling: this function may
+    raise ValueError, but its exception message is intentionally generic
+    (no reflected input) so structlog .exception() output does not echo
+    user content.
+    """
     try:
         normalized = remind_at_str.strip().replace("Z", "+00:00")
         dt = datetime.fromisoformat(normalized)
@@ -248,7 +316,84 @@ def _parse_remind_at(remind_at_str: str) -> datetime:
             dt = dt.replace(tzinfo=UTC)
         return dt.astimezone(UTC)
     except (ValueError, TypeError) as exc:
-        raise ValueError(f"Cannot parse remind_at: {remind_at_str!r}") from exc
+        # Privacy: do NOT include the raw value in the message. The caller's
+        # log emission will surface this exception via log.exception(); the
+        # message text must not echo LLM-controlled input.
+        raise ValueError("invalid ISO timestamp") from exc
+
+
+def _parse_iso_strict(iso_str: str) -> datetime:
+    """Parse an ISO 8601 string to a UTC datetime; privacy-safe error.
+
+    Raises ValueError with a generic message (no reflected input) so callers
+    can log a flag-only failure without leaking the offending value.
+    """
+    if not isinstance(iso_str, str) or not iso_str.strip():
+        raise ValueError("empty ISO timestamp")
+    try:
+        normalized = iso_str.strip().replace("Z", "+00:00")
+        dt = datetime.fromisoformat(normalized)
+    except (ValueError, TypeError) as exc:
+        raise ValueError("malformed ISO timestamp") from exc
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+
+
+async def _schedule_deadline_series(
+    *,
+    page_id: str,
+    title: str,
+    peer: str,
+    deadline_at: datetime,
+    urgency: int,
+    user_timezone: str,
+) -> list[tuple[str, datetime]]:
+    """Inline-schedule the milestone series after task creation.
+
+    Returns the list of (label, assigned_slot) pairs that were successfully
+    enqueued, or an empty list on any failure path. Failures are silent
+    from the user's perspective — the nightly reminder_scheduler daemon
+    re-tries via the orphan query (tasks with Due At but no Reminder
+    Scheduled At). This is the design contract: never leak infra retry
+    state into user-facing confirmations (psy-001).
+    """
+    try:
+        from app.scheduler.reminder_scheduling import schedule_for_task
+        from app.tools import notion
+
+        now = datetime.now(UTC)
+        assigned, failures = await schedule_for_task(
+            page_id,
+            title,
+            peer,
+            deadline_at,
+            urgency,
+            now=now,
+            user_tz=user_timezone,
+        )
+
+        if not failures and assigned:
+            # Mark Reminder Scheduled At so the daemon orphan query excludes
+            # this task on its next run.
+            try:
+                await notion.mark_reminder_scheduled(page_id)
+            except Exception:
+                log.exception("intake_node.mark_scheduled_failed", page_id=page_id)
+
+        # Privacy: log only counts, not slot datetimes.
+        log.info(
+            "intake_node.deadline_series_scheduled",
+            page_id=page_id,
+            scheduled_count=len(assigned),
+            failure_count=len(failures),
+        )
+        return assigned
+    except Exception:
+        # Privacy: do not include the exception string. The daemon will
+        # retry via the unscheduled-deadline filter on its next run.
+        log.exception("intake_node.deadline_series_failed", page_id=page_id)
+        return []
 
 
 def _parse_intake_response(response_text: str) -> dict[str, Any]:
@@ -273,6 +418,7 @@ def _parse_intake_response(response_text: str) -> dict[str, Any]:
         "energy_required": "Medium",
         "is_reminder": False,
         "remind_at": None,
+        "due_at": None,
         "use_hidden_subtasks": False,
         "sub_tasks": [],
         "inline_steps": "",

--- a/app/graph/nodes/intake.py
+++ b/app/graph/nodes/intake.py
@@ -122,8 +122,18 @@ async def intake_node(state: State) -> dict[str, Any]:
         )
 
         # Parse due_at (deadline) — privacy-safe failure: no value, no exception.
+        #
+        # due_at and is_reminder are orthogonal per the prompt contract
+        # (docs/ai-prompts/intake.md Deadline Detection). Parse the deadline
+        # whenever the LLM provided it. The runtime currently routes
+        # is_reminder=true tasks to the reminder path (notion.create_reminder
+        # does not yet thread due_at into the Notion row), so for the v1
+        # implementation a deadline accompanying a reminder is captured at
+        # parse time but the milestone series is only scheduled for
+        # non-reminder tasks. Wiring due_at into reminder rows + scheduling a
+        # series for them is a follow-up.
         deadline_at: datetime | None = None
-        if due_at_str and not is_reminder:
+        if due_at_str:
             try:
                 deadline_at = _parse_iso_strict(due_at_str)
             except ValueError:
@@ -160,12 +170,16 @@ async def intake_node(state: State) -> dict[str, Any]:
         page_id = (notion_page or {}).get("id")
 
         # Inline deadline-series scheduling. Runs after task creation when a
-        # deadline was extracted. Failures are silent from the user's
-        # perspective — the daemon backstop (jobs.reminder_scheduler) will
-        # retry on the next nightly cycle. We never surface infra retry
-        # state to the user (psy-001 / docs/ai-prompts/shared.md).
+        # deadline was extracted AND the task is not a wall-clock reminder.
+        # Reminder rows are created on a different Notion page shape and the
+        # deadline-series wiring for those is a follow-up (see prm-002 in
+        # docs/ai-prompts/intake.md Deadline Detection). Failures are silent
+        # from the user's perspective — the daemon backstop
+        # (jobs.reminder_scheduler) will retry on the next nightly cycle. We
+        # never surface infra retry state to the user
+        # (psy-001 / docs/ai-prompts/shared.md).
         assigned_slots: list[tuple[str, datetime]] = []
-        if deadline_at is not None and page_id:
+        if deadline_at is not None and page_id and not is_reminder:
             assigned_slots = await _schedule_deadline_series(
                 page_id=page_id,
                 title=task_title,
@@ -213,9 +227,13 @@ async def intake_node(state: State) -> dict[str, Any]:
             "notion_page_id": page_id,
         }
 
+        # Privacy: never log raw peer phone numbers (DEV-AGENTS.md Safety).
+        # Match the redaction pattern used by signal_listener.message_received
+        # (`peer=peer[:4] + "***"`). Use `has_peer` boolean if peer is empty.
         log.info(
             "intake_node.saved",
-            peer=peer,
+            has_peer=bool(peer),
+            peer_redacted=(peer[:4] + "***") if peer else "",
             page_id=page_id,
             is_reminder=is_reminder,
             has_due_at=deadline_at is not None,
@@ -227,7 +245,11 @@ async def intake_node(state: State) -> dict[str, Any]:
         }
 
     except Exception:
-        log.exception("intake_node.error", peer=peer)
+        # Privacy: never log raw peer phone numbers in structured logs.
+        log.exception(
+            "intake_node.error",
+            peer_redacted=(peer[:4] + "***") if peer else "",
+        )
         fallback: OutboundDraft = {
             "recipient": peer,
             "body": "Got it, I'll add that to your list.",

--- a/app/prompts/intake.md.j2
+++ b/app/prompts/intake.md.j2
@@ -68,25 +68,35 @@ When detected:
 
 ### Deadline Detection
 
-When the user's message contains a hard time bound for a task (distinct from
-notification intent), populate the `due_at` field. This is independent of
-`is_reminder` — deadlines and reminders are orthogonal:
+`due_at` and `is_reminder` are ORTHOGONAL. They model two different things and
+either or both can be set on a single task:
 
-- `is_reminder` = the user wants a wall-clock ping at a specific time.
-- `due_at` = the user has a hard time bound for the task itself.
+- `is_reminder = true` with `remind_at` set: the user wants a wall-clock ping
+  at a specific moment (a notification). The reminder worker delivers exactly
+  once at `remind_at`.
+- `due_at` set: the user has a hard time bound for the task itself (a
+  deadline). The scheduler builds an escalating series of pings as the
+  deadline approaches.
+- BOTH set: the user expressed both intents (e.g., "remind me at 5pm to
+  finish report by Friday"). Save `remind_at = 5pm today` AND
+  `due_at = Friday 17:00`. Do not suppress either field — they are
+  independent contracts.
+- Neither set: a task with no time bound. `due_at = null`,
+  `is_reminder = false`.
 
 Deadline phrases:
 - "before <date/day>", "by <date/day>", "due <date>"
 - "<date> at <time>", "at <time> <date>", "needs to be done <date>"
 
-When detected:
-- Set is_reminder = false (this is a deadline, not a wall-clock ping)
-- Resolve the phrase to ISO 8601 with timezone offset against current_time
+When a deadline phrase is detected:
+- Set `due_at` to the resolved ISO 8601 timestamp with timezone offset
 - Default timezone: {{ user_timezone | default('America/Chicago') }}
 - If a clock time is given ("by 10am tomorrow"), use that time
 - If no time is given ("by Friday"), default to 17:00 local on that day
-- Set urgency based on the usual rules — do NOT auto-set to 90 just because
+- Set urgency by the usual rules — do NOT auto-set to 90 just because
   there is a deadline. Urgency is a separate signal.
+- Do NOT clear `is_reminder` or `remind_at` if those were ALSO detected
+  in the same message. The two are independent.
 
 Set `due_at` to null when no deadline phrase is present.
 

--- a/app/prompts/intake.md.j2
+++ b/app/prompts/intake.md.j2
@@ -66,6 +66,30 @@ When detected:
 - Set urgency = 90 (reminders are inherently time-critical)
 - Set reminder_status = "pending"
 
+### Deadline Detection
+
+When the user's message contains a hard time bound for a task (distinct from
+notification intent), populate the `due_at` field. This is independent of
+`is_reminder` — deadlines and reminders are orthogonal:
+
+- `is_reminder` = the user wants a wall-clock ping at a specific time.
+- `due_at` = the user has a hard time bound for the task itself.
+
+Deadline phrases:
+- "before <date/day>", "by <date/day>", "due <date>"
+- "<date> at <time>", "at <time> <date>", "needs to be done <date>"
+
+When detected:
+- Set is_reminder = false (this is a deadline, not a wall-clock ping)
+- Resolve the phrase to ISO 8601 with timezone offset against current_time
+- Default timezone: {{ user_timezone | default('America/Chicago') }}
+- If a clock time is given ("by 10am tomorrow"), use that time
+- If no time is given ("by Friday"), default to 17:00 local on that day
+- Set urgency based on the usual rules — do NOT auto-set to 90 just because
+  there is a deadline. Urgency is a separate signal.
+
+Set `due_at` to null when no deadline phrase is present.
+
 ### Reschedule From Recent Outbound Context
 
 When recent_outbound_context contains an entry with awaiting_reply=true and
@@ -94,6 +118,7 @@ If task is clear enough to save:
   "energy_required": "High|Medium|Low",
   "is_reminder": false,
   "remind_at": null,
+  "due_at": null,
   "use_hidden_subtasks": false,
   "sub_tasks": [{"title": "...", "time_estimate_minutes": 10, "done_criteria": "...", "sequence": 1}],
   "inline_steps": "1. First step\n2. Second step",

--- a/app/scheduler/deadline_planner.py
+++ b/app/scheduler/deadline_planner.py
@@ -1,0 +1,409 @@
+"""Deadline milestone planner — pure functions, no I/O.
+
+Computes a reminder schedule for a task with a deadline, balancing across
+existing scheduled reminders to avoid collisions. Used by:
+  - app/scheduler/reminder_scheduling.py: schedule_for_task (called by both
+    intake node inline scheduling and reminder_scheduler daemon backstop)
+
+No I/O, no DB, no async. Fully testable without infrastructure.
+
+Env-tunable defaults (read by callers via _env_defaults()):
+  REMINDER_SLOT_MINUTES      - time-slot bucket size (default 30)
+  REMINDER_SLOT_CAPACITY     - max reminders per slot bucket (default 2)
+  REMINDER_QUIET_START_HOUR  - quiet hours start (default 22, i.e. 10pm)
+  REMINDER_QUIET_END_HOUR    - quiet hours end   (default 8,  i.e. 8am)
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Literal
+from zoneinfo import ZoneInfo
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+Tier = Literal["dense", "standard", "sparse"]
+
+# ---------------------------------------------------------------------------
+# Tier table
+# ---------------------------------------------------------------------------
+
+_TIER_MILESTONES: dict[Tier, list[tuple[str, timedelta]]] = {
+    "dense": [
+        ("90d", timedelta(days=90)),
+        ("30d", timedelta(days=30)),
+        ("14d", timedelta(days=14)),
+        ("7d",  timedelta(days=7)),
+        ("3d",  timedelta(days=3)),
+        ("1d",  timedelta(days=1)),
+        ("4h",  timedelta(hours=4)),
+    ],
+    "standard": [
+        ("60d", timedelta(days=60)),
+        ("14d", timedelta(days=14)),
+        ("7d",  timedelta(days=7)),
+        ("3d",  timedelta(days=3)),
+        ("1d",  timedelta(days=1)),
+        ("4h",  timedelta(hours=4)),
+    ],
+    "sparse": [
+        ("60d", timedelta(days=60)),
+        ("14d", timedelta(days=14)),
+        ("3d",  timedelta(days=3)),
+        ("4h",  timedelta(hours=4)),
+    ],
+}
+
+# For end-of-day (17:00 local) deadlines: preferred local hour for
+# multi-day reminder ideal slots.  Sub-day milestones always use
+# deadline - offset so they anchor naturally to the clock time.
+_EOD_IDEAL_HOUR: dict[str, int] = {
+    "90d": 9,
+    "60d": 9,
+    "30d": 9,
+    "14d": 9,
+    "7d":  10,
+    "3d":  10,
+    "1d":  9,
+}
+
+# End-of-day sentinel: when deadline local time matches this hour/minute,
+# we treat the deadline as "end of day" and anchor ideal slots to morning times.
+_EOD_HOUR = 17
+_EOD_MINUTE = 0
+
+# Minimum lead time: a milestone is only included when it fires at least
+# this far in the future.
+_MIN_LEAD = timedelta(minutes=15)
+
+
+# ---------------------------------------------------------------------------
+# MilestoneSlot dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass
+class MilestoneSlot:
+    """A single planned reminder milestone.
+
+    Attributes:
+        label:    Human-readable offset string, e.g. "3d", "4h".
+        tier:     The tier that generated this milestone.
+        ideal_at: The ideal (unloaded) fire time, tz-aware.
+    """
+    label: str
+    tier: Tier
+    ideal_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def tier_for(urgency: int) -> Tier:
+    """Return the milestone tier for a given urgency score (0-100).
+
+    Args:
+        urgency: Integer urgency score. Values outside [0, 100] are accepted
+                 but clamped implicitly by the tier thresholds.
+
+    Returns:
+        "dense"    when urgency >= 80
+        "standard" when 40 <= urgency <= 79
+        "sparse"   when urgency < 40
+    """
+    if urgency >= 80:
+        return "dense"
+    if urgency >= 40:
+        return "standard"
+    return "sparse"
+
+
+def plan_milestones(
+    deadline_at: datetime,
+    urgency: int,
+    now: datetime,
+    *,
+    user_tz: str = "America/Chicago",
+) -> list[MilestoneSlot]:
+    """Compute ideal reminder slots for all milestones that fit in remaining time.
+
+    A milestone fits when ``(deadline_at - milestone_offset) > now + 15min``.
+
+    For clock-time deadlines (i.e. the deadline has a specific time other than
+    the end-of-day default of 17:00 local), ideal slots are anchored relative
+    to the clock time: ``ideal = deadline_at - offset``.
+
+    For end-of-day deadlines (17:00 local), multi-day milestones (>= 1d) use
+    a preferred morning hour in user-local time (see _EOD_IDEAL_HOUR), so the
+    reminder fires at a sensible time of day rather than 5pm-minus-offset.
+    Sub-day milestones (4h) always use ``deadline - 4h`` regardless.
+
+    Args:
+        deadline_at: Deadline datetime, must be tz-aware.
+        urgency:     Integer urgency score used to select the tier.
+        now:         Current time, must be tz-aware.
+        user_tz:     IANA timezone string for the user.
+
+    Returns:
+        List of MilestoneSlot, sorted by ideal_at ascending (earliest first).
+    """
+    tz = ZoneInfo(user_tz)
+    tier = tier_for(urgency)
+    milestones = _TIER_MILESTONES[tier]
+
+    # Determine whether the deadline is an end-of-day deadline.
+    deadline_local = deadline_at.astimezone(tz)
+    is_eod = (deadline_local.hour == _EOD_HOUR and deadline_local.minute == _EOD_MINUTE)
+
+    slots: list[MilestoneSlot] = []
+    for label, offset in milestones:
+        raw_ideal = deadline_at - offset
+
+        # Skip milestones that don't leave at least 15 min of lead time.
+        if raw_ideal <= now + _MIN_LEAD:
+            continue
+
+        # Determine the ideal fire time.
+        if is_eod and label in _EOD_IDEAL_HOUR:
+            # Anchor to a preferred morning hour on the milestone date.
+            milestone_date_local = raw_ideal.astimezone(tz).date()
+            preferred_hour = _EOD_IDEAL_HOUR[label]
+            ideal = datetime(
+                milestone_date_local.year,
+                milestone_date_local.month,
+                milestone_date_local.day,
+                preferred_hour,
+                0,
+                0,
+                tzinfo=tz,
+            )
+            # Safety: if the anchored time is in the past or too close to now,
+            # fall back to raw_ideal (offset-anchored).
+            if ideal <= now + _MIN_LEAD:
+                ideal = raw_ideal
+        else:
+            ideal = raw_ideal
+
+        slots.append(MilestoneSlot(label=label, tier=tier, ideal_at=ideal))
+
+    slots.sort(key=lambda s: s.ideal_at)
+    return slots
+
+
+def assign_slot(
+    ideal_slot: datetime,
+    existing_slots: list[datetime],
+    deadline_at: datetime,
+    *,
+    user_tz: str = "America/Chicago",
+    quiet_hours: tuple[int, int] = (22, 8),
+    slot_minutes: int = 30,
+    slot_capacity: int = 2,
+    max_drift_minutes: int = 720,
+    now: datetime | None = None,
+) -> tuple[datetime, bool]:
+    """Find an available slot near the ideal time.
+
+    Walks outward from the ideal slot in ``slot_minutes`` increments, trying
+    earlier times first (never in the past, never past deadline), skipping
+    quiet hours and over-capacity buckets.  Falls back to the ideal if no
+    open slot is found within ``max_drift_minutes``.
+
+    Args:
+        ideal_slot:       Desired fire time (tz-aware).
+        existing_slots:   Already-assigned reminder datetimes in the window.
+        deadline_at:      Task deadline (tz-aware); result must be < deadline_at.
+        user_tz:          IANA timezone for quiet-hours evaluation.
+        quiet_hours:      ``(start_hour, end_hour)`` in user-local time.
+                          Times in [start_hour, 24) ∪ [0, end_hour) are quiet.
+        slot_minutes:     Bucket granularity in minutes.
+        slot_capacity:    Maximum allowed reminders per bucket.
+        max_drift_minutes: Search radius around the ideal slot.
+        now:              "Never fire in past" cutoff.  Defaults to
+                          ``deadline_at - timedelta(hours=1)`` when None.
+
+    Returns:
+        ``(chosen_slot, used_fallback)`` where ``used_fallback`` is True when
+        no open slot was found and the caller should emit an ops_alert.
+    """
+    if now is None:
+        now = deadline_at - timedelta(hours=1)
+
+    tz = ZoneInfo(user_tz)
+    q_start, q_end = quiet_hours
+    step = timedelta(minutes=slot_minutes)
+    max_drift = timedelta(minutes=max_drift_minutes)
+
+    # Snap ideal_slot to nearest bucket boundary.
+    snapped_ideal = _snap_to_bucket(ideal_slot, slot_minutes)
+
+    def _bucket_key(dt: datetime) -> datetime:
+        return _snap_to_bucket(dt, slot_minutes)
+
+    def _occupancy(candidate: datetime) -> int:
+        key = _bucket_key(candidate)
+        return sum(1 for s in existing_slots if _bucket_key(s) == key)
+
+    def _in_quiet(candidate: datetime) -> bool:
+        local_h = candidate.astimezone(tz).hour
+        if q_start < q_end:
+            # Quiet window doesn't cross midnight
+            return q_start <= local_h < q_end
+        else:
+            # Crosses midnight: quiet when hour >= q_start OR hour < q_end
+            return local_h >= q_start or local_h < q_end
+
+    def _is_valid(candidate: datetime) -> bool:
+        """Candidate is valid if: > now+15min, < deadline, not quiet, not full."""
+        if candidate <= now + _MIN_LEAD:
+            return False
+        if candidate >= deadline_at:
+            return False
+        if _in_quiet(candidate):
+            return False
+        if _occupancy(candidate) >= slot_capacity:
+            return False
+        return True
+
+    if _is_valid(snapped_ideal):
+        return snapped_ideal, False
+
+    # Walk outward from snapped_ideal: try earlier steps (i=1,2,...) before
+    # the corresponding later step.  Stop when both sides exhaust max_drift.
+    steps = int(max_drift / step)
+    for i in range(1, steps + 1):
+        earlier = snapped_ideal - step * i
+        later   = snapped_ideal + step * i
+
+        if earlier >= snapped_ideal - max_drift:
+            if _is_valid(earlier):
+                return earlier, False
+
+        if later <= snapped_ideal + max_drift:
+            if _is_valid(later):
+                return later, False
+
+    # Nothing found within max_drift — return ideal with fallback flag.
+    return ideal_slot, True
+
+
+def format_reminder_summary(
+    slots: list[tuple[str, datetime]],
+    user_tz: str = "America/Chicago",
+) -> str:
+    """Format a human-readable reminder summary for task confirmations.
+
+    Slots are sorted by datetime ascending before formatting so the summary
+    reads chronologically regardless of the order they were passed in.
+
+    Args:
+        slots:    List of ``(milestone_label, assigned_slot)`` pairs.
+        user_tz:  IANA timezone for display.
+
+    Returns:
+        A sentence like ``"I'll ping you Wed noon, Thu 9am."``
+        Returns empty string when ``slots`` is empty.
+
+    Examples:
+        >>> format_reminder_summary([("3d", wed_noon), ("1d", thu_9am)], "America/Chicago")
+        "I'll ping you Wed noon, Thu 9am."
+        >>> format_reminder_summary([], "America/Chicago")
+        ""
+    """
+    if not slots:
+        return ""
+
+    # Sort chronologically ascending before formatting.
+    sorted_slots = sorted(slots, key=lambda pair: pair[1])
+
+    tz = ZoneInfo(user_tz)
+    parts: list[str] = []
+    for _label, dt in sorted_slots:
+        local = dt.astimezone(tz)
+        parts.append(_format_datetime(local))
+
+    if len(parts) == 1:
+        return f"I'll ping you {parts[0]}."
+    return "I'll ping you " + ", ".join(parts) + "."
+
+
+# ---------------------------------------------------------------------------
+# Env defaults helper (callers do the env read; pure-function discipline)
+# ---------------------------------------------------------------------------
+
+def _env_defaults() -> dict[str, int | tuple[int, int]]:
+    """Read reminder scheduling defaults from environment variables.
+
+    Returns a dict of kwargs suitable for passing to assign_slot:
+      slot_minutes, slot_capacity, quiet_hours.
+
+    Callers pass these as **kwargs; assign_slot itself takes them as plain
+    parameters so it remains a pure function.
+
+    Example::
+
+        defaults = _env_defaults()
+        slot, fallback = assign_slot(ideal, existing, deadline, **defaults)
+    """
+    slot_minutes   = int(os.environ.get("REMINDER_SLOT_MINUTES",   "30"))
+    slot_capacity  = int(os.environ.get("REMINDER_SLOT_CAPACITY",  "2"))
+    quiet_start    = int(os.environ.get("REMINDER_QUIET_START_HOUR", "22"))
+    quiet_end      = int(os.environ.get("REMINDER_QUIET_END_HOUR",   "8"))
+    return {
+        "slot_minutes":  slot_minutes,
+        "slot_capacity": slot_capacity,
+        "quiet_hours":   (quiet_start, quiet_end),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _snap_to_bucket(dt: datetime, slot_minutes: int) -> datetime:
+    """Round dt down to the nearest slot_minutes boundary (UTC-based)."""
+    total_minutes = int(dt.timestamp() // 60)
+    snapped_minutes = (total_minutes // slot_minutes) * slot_minutes
+    return datetime.fromtimestamp(snapped_minutes * 60, tz=dt.tzinfo)
+
+
+def _format_datetime(local: datetime) -> str:
+    """Format a local datetime as a natural-language string.
+
+    Examples:
+        12:00 -> "noon"
+        00:00 -> "midnight"
+        08:00 -> "8am"
+        13:00 -> "1pm"
+        09:30 -> "9:30am"
+        22:30 -> "10:30pm"
+    """
+    h = local.hour
+    m = local.minute
+    day = local.strftime("%a")  # e.g. "Wed"
+
+    if h == 12 and m == 0:
+        return f"{day} noon"
+    if h == 0 and m == 0:
+        return f"{day} midnight"
+
+    # 12-hour format
+    if h == 0:
+        period = "am"
+        display_h = 12
+    elif h < 12:
+        period = "am"
+        display_h = h
+    elif h == 12:
+        period = "pm"
+        display_h = 12
+    else:
+        period = "pm"
+        display_h = h - 12
+
+    if m == 0:
+        return f"{day} {display_h}{period}"
+    return f"{day} {display_h}:{m:02d}{period}"

--- a/app/scheduler/jobs.py
+++ b/app/scheduler/jobs.py
@@ -155,6 +155,18 @@ async def dispatch_check_ins() -> None:
     log.debug("dispatch_check_ins.tick")
 
 
+async def run_reminder_scheduler_job() -> None:
+    """Invoke the reminder_scheduler daemon (deadline-driven series backstop).
+
+    Fires once daily at 04:00 user-local. Picks up tasks whose inline
+    scheduling failed (orphans) and tasks whose Due At was edited after the
+    initial schedule (deadline-edit detection).
+    """
+    log.debug("reminder_scheduler.tick")
+    from app.scheduler.reminder_scheduler import run_reminder_scheduler
+    await run_reminder_scheduler()
+
+
 # ---------------------------------------------------------------------------
 # Declarative job list — single source of truth
 # ---------------------------------------------------------------------------
@@ -197,6 +209,15 @@ SCHEDULED_JOBS: list[JobSpec] = [
             timezone=_USER_TZ,
         ),
         func=generate_weekly_recap,
+    ),
+    JobSpec(
+        id="reminder_scheduler",
+        trigger=CronTrigger(
+            hour=4,
+            minute=0,
+            timezone=_USER_TZ,
+        ),
+        func=run_reminder_scheduler_job,
     ),
 ]
 

--- a/app/scheduler/reminder_scheduler.py
+++ b/app/scheduler/reminder_scheduler.py
@@ -1,0 +1,334 @@
+"""Reminder scheduler daemon — nightly backstop for deadline-driven reminders.
+
+Runs once daily at 04:00 user-local. Two responsibilities:
+
+1. Orphan catch-up.
+   Query Notion for tasks with Due At set but no Reminder Scheduled At
+   (intake's inline scheduling failed). Schedule the milestone series via
+   reminder_scheduling.schedule_for_task.
+
+2. Deadline-edit detection.
+   Query Notion for tasks that already have a Reminder Scheduled At AND a
+   Due At. Cross-check current Notion Due At against the ledger's
+   deadline_at (+-60s tolerance). On mismatch: supersede the active ledger
+   rows, mark the corresponding outbox rows dead, and schedule a fresh
+   milestone series against the new deadline.
+
+The dual-query is required because the orphan-catch-up filter
+(Reminder Scheduled At is_empty) excludes already-scheduled tasks. Without a
+second query that explicitly fetches the scheduled set, deadline edits would
+never be observed.
+
+Failure modes:
+  Notion 5xx     -> ops alert, retry next day.
+  Per-task fail  -> ops alert, continue with next task.
+  Slot fallback  -> warning logged by deadline_planner; ops alert raised by
+                    reminder_scheduling.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+
+log = structlog.get_logger(__name__)
+
+# Tolerance for matching ledger.deadline_at against Notion Due At. Notion
+# stores ISO-8601 with second precision; round-tripping through Postgres can
+# introduce sub-second drift even when the underlying value is unchanged.
+# Anything within +-_DEADLINE_TOLERANCE_SECONDS is treated as "unchanged".
+_DEADLINE_TOLERANCE_SECONDS = 60
+
+
+async def run_reminder_scheduler() -> None:
+    """Entry point for the APScheduler reminder_scheduler job.
+
+    Wraps _run_once() so APScheduler can invoke a no-arg callable; tests can
+    drive _run_once() directly with injected dependencies if needed.
+    """
+    await _run_once()
+
+
+async def _run_once() -> None:
+    from app.tools import notion, ops_alerts
+
+    try:
+        orphans = await notion.query_tasks_with_unscheduled_deadlines()
+    except Exception:
+        # Privacy: do not log exception strings (may echo headers / IDs).
+        log.exception("reminder_scheduler.orphans_query_failed")
+        try:
+            await ops_alerts.enqueue(
+                kind="reminder_scheduler_notion_failed",
+                body="reminder_scheduler: orphan-query Notion call failed; will retry next cycle.",
+                severity="warning",
+            )
+        except Exception:
+            log.exception("reminder_scheduler.ops_alert_failed")
+        orphans = {"results": []}
+
+    try:
+        scheduled = await notion.query_scheduled_tasks_with_deadlines()
+    except Exception:
+        log.exception("reminder_scheduler.scheduled_query_failed")
+        try:
+            await ops_alerts.enqueue(
+                kind="reminder_scheduler_notion_failed",
+                body="reminder_scheduler: scheduled-deadline query Notion call failed; will retry next cycle.",
+                severity="warning",
+            )
+        except Exception:
+            log.exception("reminder_scheduler.ops_alert_failed")
+        scheduled = {"results": []}
+
+    orphan_count = 0
+    edit_count = 0
+
+    for page in orphans.get("results", []):
+        try:
+            handled = await _schedule_orphan(page)
+            if handled:
+                orphan_count += 1
+        except Exception:
+            log.exception(
+                "reminder_scheduler.orphan_failed",
+                page_id=page.get("id", ""),
+            )
+
+    for page in scheduled.get("results", []):
+        try:
+            handled = await _detect_and_reschedule_edit(page)
+            if handled:
+                edit_count += 1
+        except Exception:
+            log.exception(
+                "reminder_scheduler.edit_detection_failed",
+                page_id=page.get("id", ""),
+            )
+
+    log.info(
+        "reminder_scheduler.cycle_done",
+        orphans_handled=orphan_count,
+        edits_handled=edit_count,
+    )
+
+
+async def _schedule_orphan(page: dict[str, Any]) -> bool:
+    """Schedule a milestone series for an unscheduled task."""
+    from app.scheduler.reminder_scheduling import schedule_for_task
+    from app.tools import notion, ops_alerts
+
+    page_id = page.get("id", "")
+    if not page_id:
+        return False
+
+    parsed = _parse_page_for_scheduling(page)
+    if parsed is None:
+        return False
+
+    title, peer, deadline_at, urgency, user_tz = parsed
+    now = datetime.now(UTC)
+
+    assigned_slots, failures = await schedule_for_task(
+        page_id,
+        title,
+        peer,
+        deadline_at,
+        urgency,
+        now=now,
+        user_tz=user_tz,
+    )
+
+    if not failures and assigned_slots:
+        try:
+            await notion.mark_reminder_scheduled(page_id)
+        except Exception:
+            log.exception(
+                "reminder_scheduler.mark_scheduled_failed",
+                page_id=page_id,
+            )
+
+    if failures:
+        try:
+            await ops_alerts.enqueue(
+                kind="reminder_scheduler_partial_failure",
+                body=(
+                    f"reminder_scheduler: failed to enqueue {len(failures)} "
+                    "milestone(s) for orphan task; will retry next cycle."
+                ),
+                severity="warning",
+            )
+        except Exception:
+            log.exception("reminder_scheduler.ops_alert_failed")
+
+    log.info(
+        "reminder_scheduler.orphan_handled",
+        page_id=page_id,
+        scheduled_count=len(assigned_slots),
+        failure_count=len(failures),
+    )
+    return True
+
+
+async def _detect_and_reschedule_edit(page: dict[str, Any]) -> bool:
+    """If Notion Due At has drifted from the active ledger deadline, reschedule.
+
+    Returns True if an edit was detected and handled (or a rescheduling
+    attempt was made), False if no edit was detected.
+    """
+    from app.scheduler.reminder_scheduling import (
+        cancel_outbox_rows,
+        get_active_deadline_for_page,
+        schedule_for_task,
+        supersede_ledger_rows,
+    )
+    from app.tools import notion, ops_alerts
+
+    page_id = page.get("id", "")
+    if not page_id:
+        return False
+
+    parsed = _parse_page_for_scheduling(page)
+    if parsed is None:
+        return False
+
+    title, peer, current_deadline, urgency, user_tz = parsed
+
+    ledger_deadline = await get_active_deadline_for_page(page_id)
+    if ledger_deadline is None:
+        # No active ledger row even though Reminder Scheduled At is set.
+        # That's an inconsistency, but not something the daemon should
+        # paper over — log and skip.
+        log.info(
+            "reminder_scheduler.edit_skip_no_ledger",
+            page_id=page_id,
+        )
+        return False
+
+    drift = abs((current_deadline - ledger_deadline).total_seconds())
+    if drift <= _DEADLINE_TOLERANCE_SECONDS:
+        return False
+
+    log.info(
+        "reminder_scheduler.deadline_edit_detected",
+        page_id=page_id,
+        drift_seconds=int(drift),
+    )
+
+    # Supersede the active ledger rows and dead-letter the outbox entries.
+    superseded_outbox_ids = await supersede_ledger_rows(page_id)
+    await cancel_outbox_rows(superseded_outbox_ids)
+
+    # Schedule a fresh milestone series against the new deadline.
+    now = datetime.now(UTC)
+    assigned_slots, failures = await schedule_for_task(
+        page_id,
+        title,
+        peer,
+        current_deadline,
+        urgency,
+        now=now,
+        user_tz=user_tz,
+    )
+
+    if not failures and assigned_slots:
+        try:
+            # Refresh Reminder Scheduled At to reflect the new series.
+            await notion.mark_reminder_scheduled(page_id)
+        except Exception:
+            log.exception(
+                "reminder_scheduler.mark_scheduled_failed",
+                page_id=page_id,
+            )
+
+    if failures:
+        try:
+            await ops_alerts.enqueue(
+                kind="reminder_scheduler_partial_failure",
+                body=(
+                    f"reminder_scheduler: failed to enqueue {len(failures)} "
+                    "milestone(s) after deadline edit; will retry next cycle."
+                ),
+                severity="warning",
+            )
+        except Exception:
+            log.exception("reminder_scheduler.ops_alert_failed")
+
+    log.info(
+        "reminder_scheduler.edit_handled",
+        page_id=page_id,
+        superseded_count=len(superseded_outbox_ids),
+        scheduled_count=len(assigned_slots),
+        failure_count=len(failures),
+    )
+    return True
+
+
+def _parse_page_for_scheduling(
+    page: dict[str, Any],
+) -> tuple[str, str, datetime, int, str] | None:
+    """Extract (title, peer, deadline_at, urgency, user_tz) from a Notion page payload.
+
+    Returns None when required fields are missing or malformed. Logs only
+    flags / page_id — never the raw values (privacy contract).
+    """
+    import os
+
+    page_id = page.get("id", "")
+    props = page.get("properties", {}) or {}
+
+    # Due At (date)
+    due_at_prop = (props.get("Due At") or {}).get("date") or {}
+    due_at_iso = due_at_prop.get("start")
+    if not due_at_iso:
+        log.info("reminder_scheduler.parse_skip_no_due_at", page_id=page_id)
+        return None
+
+    try:
+        deadline_at = _parse_iso(due_at_iso)
+    except ValueError:
+        log.info(
+            "reminder_scheduler.parse_skip_bad_due_at",
+            page_id=page_id,
+            parse_failed=True,
+        )
+        return None
+
+    # Title — Notion title property is a list of rich_text fragments.
+    title_prop = props.get("Title") or props.get("Name") or {}
+    title_fragments = title_prop.get("title") or []
+    title = "".join(frag.get("plain_text", "") for frag in title_fragments) or "task"
+
+    # Urgency — optional number property; default to 50 (standard tier).
+    urgency_prop = props.get("Urgency") or {}
+    urgency_val = urgency_prop.get("number")
+    urgency = int(urgency_val) if isinstance(urgency_val, (int, float)) else 50
+
+    # Peer — daemon resolves from env. Per-user routing belongs to a
+    # follow-up; the single-user deployment uses one peer.
+    peer = os.environ.get("OPS_ALERT_SIGNAL_NUMBER", "") or os.environ.get(
+        "DEFAULT_PEER", ""
+    )
+    if not peer:
+        log.info("reminder_scheduler.parse_skip_no_peer", page_id=page_id)
+        return None
+
+    user_tz = os.environ.get("USER_TZ", "America/Chicago")
+
+    return title, peer, deadline_at, urgency, user_tz
+
+
+def _parse_iso(iso_str: str) -> datetime:
+    """Parse an ISO 8601 string to a tz-aware UTC datetime.
+
+    Raises ValueError on malformed input. Caller is responsible for
+    privacy-safe logging (never echo iso_str into log fields).
+    """
+    normalized = iso_str.strip().replace("Z", "+00:00")
+    dt = datetime.fromisoformat(normalized)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+
+

--- a/app/scheduler/reminder_scheduler.py
+++ b/app/scheduler/reminder_scheduler.py
@@ -305,11 +305,26 @@ def _parse_page_for_scheduling(
     urgency_val = urgency_prop.get("number")
     urgency = int(urgency_val) if isinstance(urgency_val, (int, float)) else 50
 
-    # Peer — daemon resolves from env. Per-user routing belongs to a
-    # follow-up; the single-user deployment uses one peer.
-    peer = os.environ.get("OPS_ALERT_SIGNAL_NUMBER", "") or os.environ.get(
-        "DEFAULT_PEER", ""
-    )
+    # Peer — daemon resolves from AUTHORIZED_PEERS, the documented user
+    # routing source (see app/ingress/signal_listener.py). The Notion
+    # database is single-tenant, so any reminder the daemon sends must
+    # reach the user whose tasks live in that DB; AUTHORIZED_PEERS is the
+    # single source of truth for that identity.
+    #
+    # OPS_ALERT_SIGNAL_NUMBER is intentionally NOT used here: it is for
+    # operational alerts to the operator, which may be a different person
+    # than the user in dev/staging deployments. Routing user-facing
+    # reminders through it would misdeliver them.
+    #
+    # Single-tenant assumption: AUTHORIZED_PEERS may contain multiple
+    # entries (multi-device, future multi-user). The daemon picks the
+    # first one for now. Per-user routing belongs to a follow-up that
+    # also carries a per-task owner column. DEFAULT_PEER is honoured as
+    # a backwards-compat fallback for existing deployments that have not
+    # yet wired AUTHORIZED_PEERS into the scheduler environment.
+    raw_authorized = os.environ.get("AUTHORIZED_PEERS", "")
+    authorized = [p.strip() for p in raw_authorized.split(",") if p.strip()]
+    peer = authorized[0] if authorized else os.environ.get("DEFAULT_PEER", "")
     if not peer:
         log.info("reminder_scheduler.parse_skip_no_peer", page_id=page_id)
         return None

--- a/app/scheduler/reminder_scheduling.py
+++ b/app/scheduler/reminder_scheduling.py
@@ -1,0 +1,365 @@
+"""Shared reminder scheduling helper for deadline-driven reminder series.
+
+schedule_for_task() is called by both:
+  - app/graph/nodes/intake.py: inline scheduling immediately after task creation
+  - app/scheduler/reminder_scheduler.py: nightly daemon backstop
+
+The algorithm is: plan milestones via deadline_planner -> query the ledger for
+nearby existing slots -> assign a load-balanced slot per milestone -> enqueue
+outbox row (kind='deadline') -> insert ledger row.
+
+The outbox kind='deadline' (migration 0008) is what tells the reminder worker
+to skip notion.complete_reminder on delivery. Without it, the worker would
+silently complete the user's task on the first milestone ping.
+
+Callers decide whether to call notion.mark_reminder_scheduled() based on
+whether enqueue_failures is empty.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import psycopg
+import psycopg.rows
+import structlog
+
+log = structlog.get_logger(__name__)
+
+# Window around each milestone ideal to query existing ledger slots for
+# load-balancing: +-_LEDGER_WINDOW_HOURS hours (matches assign_slot
+# max_drift_minutes default of 720 min = 12h).
+_LEDGER_WINDOW_HOURS = 12
+
+
+async def schedule_for_task(
+    page_id: str,
+    title: str,
+    peer: str,
+    deadline_at: datetime,
+    urgency: int,
+    *,
+    now: datetime,
+    user_tz: str,
+) -> tuple[list[tuple[str, datetime]], list[str]]:
+    """Plan and enqueue the milestone reminder series for one task.
+
+    Calls deadline_planner.plan_milestones + assign_slot per milestone.
+    Queries reminder_scheduling_ledger for nearby existing slots (load balance).
+    Calls reminders.enqueue (kind='deadline') + inserts ledger row per milestone.
+
+    Callers decide whether to call notion.mark_reminder_scheduled based on
+    whether enqueue_failures is empty (empty = all milestones succeeded;
+    non-empty = at least one failed, daemon will retry via backstop).
+
+    Args:
+        page_id:     Notion page ID of the task.
+        title:       Task title for reminder body text.
+        peer:        E.164 recipient phone number.
+        deadline_at: Task deadline, must be tz-aware.
+        urgency:     Integer urgency score (0-100).
+        now:         Current time reference, must be tz-aware.
+        user_tz:     IANA timezone string for the user.
+
+    Returns:
+        (assigned_slots, enqueue_failures)
+        assigned_slots: list of (milestone_label, assigned_slot_datetime) for
+            milestones that were successfully enqueued.
+        enqueue_failures: list of milestone labels that failed to enqueue.
+    """
+    from app.scheduler.deadline_planner import (
+        _env_defaults,
+        assign_slot,
+        plan_milestones,
+        tier_for,
+    )
+    from app.tools.db import get_db_conn
+    from app.tools.reminders import enqueue
+
+    milestones = plan_milestones(deadline_at, urgency, now, user_tz=user_tz)
+    env_defaults = _env_defaults()
+    tier = tier_for(urgency)
+
+    assigned_slots: list[tuple[str, datetime]] = []
+    enqueue_failures: list[str] = []
+
+    for m in milestones:
+        try:
+            # Query ledger for existing slots in the load-balancing window.
+            existing = await _query_ledger_window(m.ideal_at)
+
+            # Assign a load-balanced slot.
+            slot, used_fallback = assign_slot(
+                m.ideal_at,
+                existing,
+                deadline_at,
+                user_tz=user_tz,
+                now=now,
+                **env_defaults,  # type: ignore[arg-type]
+            )
+
+            if used_fallback:
+                log.warning(
+                    "reminder_scheduling.slot_fallback_used",
+                    page_id=page_id,
+                    milestone=m.label,
+                )
+
+            # Build the human-readable reminder body (shame-safe, ADHD-friendly).
+            humanized_deadline = _humanize_deadline(deadline_at, user_tz)
+            body = f"{title} is coming up {humanized_deadline} - want to start now?"
+            idempotency_key = (
+                f"deadline-{page_id}-{m.label}-{deadline_at.isoformat()}"
+            )
+
+            async with get_db_conn() as conn:
+                outbox_id = await enqueue(
+                    conn,
+                    notion_page_id=page_id,
+                    peer=peer,
+                    body=body,
+                    due_at=slot,
+                    idempotency_key=idempotency_key,
+                    kind="deadline",
+                )
+
+                # Insert ledger row within the same connection / transaction.
+                await _insert_ledger_row(
+                    conn,
+                    page_id=page_id,
+                    deadline_at=deadline_at,
+                    urgency=urgency,
+                    tier=tier,
+                    milestone_label=m.label,
+                    ideal_slot_at=m.ideal_at,
+                    assigned_slot_at=slot,
+                    outbox_id=outbox_id,
+                )
+
+            assigned_slots.append((m.label, slot))
+            log.info(
+                "reminder_scheduling.milestone_enqueued",
+                page_id=page_id,
+                milestone=m.label,
+                used_fallback=used_fallback,
+            )
+
+        except psycopg.errors.UniqueViolation:
+            # idempotency_key already exists — milestone already scheduled.
+            log.info(
+                "reminder_scheduling.milestone_already_scheduled",
+                page_id=page_id,
+                milestone=m.label,
+            )
+            # Treat idempotent re-runs as success (not a failure).
+            assigned_slots.append((m.label, m.ideal_at))
+
+        except Exception:
+            # Privacy: log only the milestone label (deterministic, not PII).
+            # Do NOT log the exception string — psycopg / asyncio errors can
+            # surface input substrings, and per DEV-AGENTS.md private content
+            # must not be echoed to structlog.
+            log.exception(
+                "reminder_scheduling.milestone_enqueue_failed",
+                page_id=page_id,
+                milestone=m.label,
+            )
+            enqueue_failures.append(m.label)
+
+    return assigned_slots, enqueue_failures
+
+
+async def _query_ledger_window(
+    ideal_at: datetime,
+    *,
+    window_hours: int = _LEDGER_WINDOW_HOURS,
+) -> list[datetime]:
+    """Return assigned_slot_at values from the ledger near the given ideal time.
+
+    Queries non-superseded rows within +-window_hours of ideal_at to give
+    assign_slot the load data it needs for bucket occupancy calculation.
+
+    Returns an empty list if DATABASE_URL is not set (test/offline environments).
+    """
+    from app.tools.db import get_connection_string, get_db_conn
+
+    try:
+        get_connection_string()  # raises KeyError if not set
+    except KeyError:
+        return []
+
+    window = timedelta(hours=window_hours)
+    lo = ideal_at - window
+    hi = ideal_at + window
+
+    try:
+        async with get_db_conn() as conn:
+            async with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+                await cur.execute(
+                    """
+                    SELECT assigned_slot_at
+                    FROM reminder_scheduling_ledger
+                    WHERE superseded_at IS NULL
+                      AND assigned_slot_at BETWEEN %s AND %s
+                    """,
+                    (lo, hi),
+                )
+                rows = await cur.fetchall()
+        return [row["assigned_slot_at"] for row in rows]
+    except Exception:
+        # Privacy: do not log exception strings (may echo timestamps).
+        log.exception("reminder_scheduling.ledger_query_failed")
+        return []
+
+
+async def _insert_ledger_row(
+    conn: Any,
+    *,
+    page_id: str,
+    deadline_at: datetime,
+    urgency: int,
+    tier: str,
+    milestone_label: str,
+    ideal_slot_at: datetime,
+    assigned_slot_at: datetime,
+    outbox_id: uuid.UUID,
+) -> None:
+    """Insert a row into reminder_scheduling_ledger."""
+    await conn.execute(
+        """
+        INSERT INTO reminder_scheduling_ledger
+          (notion_page_id, deadline_at, urgency, tier, milestone_label,
+           ideal_slot_at, assigned_slot_at, reminder_outbox_id)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+        """,
+        (
+            page_id,
+            deadline_at,
+            urgency,
+            tier,
+            milestone_label,
+            ideal_slot_at,
+            assigned_slot_at,
+            str(outbox_id),
+        ),
+    )
+
+
+async def supersede_ledger_rows(page_id: str) -> list[uuid.UUID]:
+    """Mark all active ledger rows for page_id as superseded (deadline changed).
+
+    Returns the reminder_outbox_id values of superseded rows so callers can
+    cancel the corresponding outbox rows (set state='dead').
+    """
+    now = datetime.now(UTC)
+    from app.tools.db import get_db_conn
+
+    async with get_db_conn() as conn:
+        async with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            await cur.execute(
+                """
+                UPDATE reminder_scheduling_ledger
+                   SET superseded_at = %s
+                 WHERE notion_page_id = %s
+                   AND superseded_at IS NULL
+                RETURNING reminder_outbox_id
+                """,
+                (now, page_id),
+            )
+            rows = await cur.fetchall()
+    return [uuid.UUID(str(row["reminder_outbox_id"])) for row in rows]
+
+
+async def cancel_outbox_rows(outbox_ids: list[uuid.UUID]) -> None:
+    """Cancel outbox rows corresponding to superseded ledger rows.
+
+    Sets state='dead' with a descriptive last_error so the reminder_worker
+    skips delivery. Only affects rows still in pending/scheduled state.
+    """
+    if not outbox_ids:
+        return
+
+    from app.tools.db import get_db_conn
+
+    async with get_db_conn() as conn:
+        for oid in outbox_ids:
+            await conn.execute(
+                """
+                UPDATE reminder_outbox
+                   SET state = 'dead',
+                       last_error = 'superseded_by_deadline_change'
+                 WHERE id = %s
+                   AND state IN ('pending', 'scheduled')
+                """,
+                (str(oid),),
+            )
+
+
+async def get_active_deadline_for_page(page_id: str) -> datetime | None:
+    """Return the deadline_at of the most recent non-superseded ledger row for page_id.
+
+    Returns None if no active ledger rows exist (task not yet scheduled or
+    all rows have been superseded).
+    """
+    from app.tools.db import get_db_conn
+
+    async with get_db_conn() as conn:
+        async with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            await cur.execute(
+                """
+                SELECT deadline_at
+                FROM reminder_scheduling_ledger
+                WHERE notion_page_id = %s
+                  AND superseded_at IS NULL
+                ORDER BY scheduled_at DESC
+                LIMIT 1
+                """,
+                (page_id,),
+            )
+            row = await cur.fetchone()
+
+    if row is None:
+        return None
+    dt: datetime = row["deadline_at"]
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt
+
+
+def _humanize_deadline(deadline_at: datetime, user_tz: str) -> str:
+    """Return a natural-language description of how soon the deadline is.
+
+    Examples:
+        "this afternoon"
+        "tomorrow"
+        "in 3 days"
+        "next week"
+    """
+    from zoneinfo import ZoneInfo
+
+    tz = ZoneInfo(user_tz)
+    now_local = datetime.now(UTC).astimezone(tz)
+    deadline_local = deadline_at.astimezone(tz)
+
+    delta = deadline_local - now_local
+    days = delta.days
+
+    if days < 0:
+        return "soon"
+    if days == 0:
+        hour = deadline_local.hour
+        if hour < 12:
+            return "this morning"
+        if hour < 17:
+            return "this afternoon"
+        return "this evening"
+    if days == 1:
+        return "tomorrow"
+    if days <= 6:
+        return f"in {days} days"
+    if days <= 13:
+        return "next week"
+    if days <= 30:
+        return f"in {days // 7} weeks"
+    return f"in about {days // 30} month{'s' if days // 30 > 1 else ''}"

--- a/app/scheduler/reminder_scheduling.py
+++ b/app/scheduler/reminder_scheduling.py
@@ -100,15 +100,46 @@ async def schedule_for_task(
             )
 
             if used_fallback:
+                # Saturation/quiet-hours fallback is a load-bearing
+                # degradation path: the planner could not find a
+                # naturally-ideal slot inside the drift window, so it had
+                # to fall back to a less-preferred time. The reminder
+                # still goes out, but operationally this is a signal that
+                # slot capacity may be undersized for the current load.
+                # Emit an ops alert so the operator can investigate
+                # (matches the docstring contract in
+                # reminder_scheduler.py).
                 log.warning(
                     "reminder_scheduling.slot_fallback_used",
                     page_id=page_id,
                     milestone=m.label,
                 )
+                try:
+                    from app.tools import ops_alerts
+                    await ops_alerts.enqueue(
+                        kind="reminder_slot_fallback_used",
+                        body=(
+                            "reminder_scheduling: slot fallback used for a "
+                            f"{m.label} milestone (page {page_id!r}). "
+                            "Slot capacity may be undersized for current load."
+                        ),
+                        severity="warning",
+                    )
+                except Exception:
+                    # Privacy: do not surface ops-alert exception strings.
+                    log.exception("reminder_scheduling.ops_alert_failed")
 
-            # Build the human-readable reminder body (shame-safe, ADHD-friendly).
+            # Build the human-readable reminder body (shame-safe,
+            # ADHD-friendly). The previous draft ("is coming up <when> —
+            # want to start now?") combined countdown framing with a
+            # supervisory "start now" decision, which violates the
+            # shame-free messaging contract in design/adhd-priorities.md
+            # (avoid pressure / countdown) and the safe-exit-ramp clause
+            # in docs/ai-prompts/shared.md (no guilt or pressure). The
+            # new body is informational only: it surfaces the upcoming
+            # deadline as data, with no implicit demand to act now.
             humanized_deadline = _humanize_deadline(deadline_at, user_tz)
-            body = f"{title} is coming up {humanized_deadline} - want to start now?"
+            body = f"Heads up — {title} has a deadline {humanized_deadline}."
             idempotency_key = (
                 f"deadline-{page_id}-{m.label}-{deadline_at.isoformat()}"
             )

--- a/app/scheduler/reminder_worker.py
+++ b/app/scheduler/reminder_worker.py
@@ -149,12 +149,21 @@ async def dispatch_due_reminders(
         body = row["body"]
         notion_page_id = row["notion_page_id"]
         idempotency_key = row["idempotency_key"]
+        # kind column added in migration 0008. The worker branches on it after
+        # delivery: 'reminder' rows complete the Notion task; 'deadline' rows
+        # do NOT (deadline series rows nudge the user toward an unfinished
+        # task — the task remains in its current state).
+        # Default to 'reminder' for legacy rows that pre-date migration 0008
+        # (the column has DEFAULT 'reminder' at the DB layer; this is a belt
+        # for older psycopg cursors that may surface NULL for missing columns).
+        kind = row.get("kind") or "reminder"
         attempt = row["attempt"] + 1
 
         log.info(
             "reminder_worker.delivering",
             reminder_id=str(rid),
             attempt=attempt,
+            kind=kind,
         )
 
         try:
@@ -200,18 +209,24 @@ async def dispatch_due_reminders(
                 )
             await conn.commit()
 
-            # Mark Notion reminder as sent (idempotent, outside transaction)
-            try:
-                from app.tools.notion import complete_reminder
-                await complete_reminder(notion_page_id, "sent")
-            except Exception as notion_err:
-                log.warning(
-                    "reminder_worker.notion_complete_failed",
-                    reminder_id=str(rid),
-                    error=str(notion_err),
-                )
+            # Mark Notion reminder as sent (idempotent, outside transaction).
+            # SKIPPED for deadline-series rows: those rows live on the user's
+            # task page, and complete_reminder would set Status=Completed —
+            # which would silently complete the task after the first milestone
+            # ping. Deadline series rows just deliver the body; the task stays
+            # in its current state.
+            if kind == "reminder":
+                try:
+                    from app.tools.notion import complete_reminder
+                    await complete_reminder(notion_page_id, "sent")
+                except Exception as notion_err:
+                    log.warning(
+                        "reminder_worker.notion_complete_failed",
+                        reminder_id=str(rid),
+                        error=str(notion_err),
+                    )
 
-            log.info("reminder_worker.delivered", reminder_id=str(rid))
+            log.info("reminder_worker.delivered", reminder_id=str(rid), kind=kind)
             delivered_count += 1
 
         except Exception as exc:

--- a/app/tools/notion.py
+++ b/app/tools/notion.py
@@ -13,7 +13,8 @@ Covers all 9 verbs from scripts/notion-cli.sh:
 
 Plus deadline-reminder plumbing verbs:
   10. query_tasks_with_unscheduled_deadlines
-  11. mark_reminder_scheduled
+  11. query_scheduled_tasks_with_deadlines
+  12. mark_reminder_scheduled
 
 Plus:
   health_check() — lightweight connectivity probe used by notion_health job.
@@ -362,7 +363,46 @@ async def query_tasks_with_unscheduled_deadlines() -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
-# Verb 11 — mark_reminder_scheduled
+# Verb 11 — query_scheduled_tasks_with_deadlines (edit detection)
+# ---------------------------------------------------------------------------
+
+
+async def query_scheduled_tasks_with_deadlines() -> dict[str, Any]:
+    """Return tasks with both Due At and Reminder Scheduled At set.
+
+    Used by the reminder_scheduler daemon to detect deadline edits AFTER a
+    reminder series has been scheduled. The daemon cross-checks the current
+    Notion Due At against the ledger's deadline_at; mismatches trigger
+    supersede + reschedule.
+
+    4-condition AND filter:
+      - Due At is_not_empty
+      - Reminder Scheduled At is_not_empty (counterpart to
+        query_tasks_with_unscheduled_deadlines)
+      - Status != Completed
+      - Is Reminder = false
+
+    Sorted by Due At ascending.
+    """
+    payload = {
+        "filter": {
+            "and": [
+                {"property": "Due At", "date": {"is_not_empty": True}},
+                {"property": "Reminder Scheduled At", "date": {"is_not_empty": True}},
+                {"property": "Status", "select": {"does_not_equal": "Completed"}},
+                {"property": "Is Reminder", "checkbox": {"equals": False}},
+            ]
+        },
+        "sorts": [{"property": "Due At", "direction": "ascending"}],
+    }
+    async with _client_factory() as client:
+        resp = await client.post(f"/databases/{_database_id()}/query", json=payload)
+        resp.raise_for_status()
+        return resp.json()  # type: ignore[no-any-return]
+
+
+# ---------------------------------------------------------------------------
+# Verb 12 — mark_reminder_scheduled
 # ---------------------------------------------------------------------------
 
 

--- a/app/tools/reminders.py
+++ b/app/tools/reminders.py
@@ -34,6 +34,7 @@ async def enqueue(
     body: str,
     due_at: datetime,
     idempotency_key: str,
+    kind: str = "reminder",
     reminder_id: uuid.UUID | None = None,
 ) -> uuid.UUID:
     """Insert a new reminder into the outbox with state='pending'.
@@ -51,21 +52,27 @@ async def enqueue(
         body: Reminder message text.
         due_at: When the reminder should be sent (UTC).
         idempotency_key: Unique key per reminder; UNIQUE constraint prevents duplicate inserts.
+        kind: Discriminator — "reminder" (default; wall-clock reminder that
+            completes the Notion task on delivery) or "deadline" (milestone
+            in a deadline-driven reminder series; does NOT complete the task).
+            Migration 0008 added the kind column with a CHECK constraint
+            enforcing this set.
         reminder_id: Optional UUID; generated if not provided.
     """
     rid = reminder_id or uuid.uuid4()
     await conn.execute(
         """
         INSERT INTO reminder_outbox
-          (id, notion_page_id, peer, body, due_at, state, idempotency_key)
-        VALUES (%s, %s, %s, %s, %s, 'pending', %s)
+          (id, notion_page_id, peer, body, due_at, state, idempotency_key, kind)
+        VALUES (%s, %s, %s, %s, %s, 'pending', %s, %s)
         """,
-        (str(rid), notion_page_id, peer, body, due_at, idempotency_key),
+        (str(rid), notion_page_id, peer, body, due_at, idempotency_key, kind),
     )
     log.info(
         "reminders.enqueued",
         reminder_id=str(rid),
         due_at=due_at.isoformat(),
+        kind=kind,
     )
     return rid
 

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -38,6 +38,14 @@ services:
       - ALLOW_PRIVATE_TRACE_EXPORT=${ALLOW_PRIVATE_TRACE_EXPORT:-false}
       - USER_TZ=${USER_TZ:-America/Chicago}
       - OPS_ALERT_SIGNAL_NUMBER=${OPS_ALERT_SIGNAL_NUMBER:-}
+      # Deadline-driven reminder scheduling knobs (see
+      # app/scheduler/deadline_planner.py:_env_defaults). All have safe
+      # defaults; expose them here so operators can tune without
+      # rebuilding the image.
+      - REMINDER_SLOT_MINUTES=${REMINDER_SLOT_MINUTES:-30}
+      - REMINDER_SLOT_CAPACITY=${REMINDER_SLOT_CAPACITY:-2}
+      - REMINDER_QUIET_START_HOUR=${REMINDER_QUIET_START_HOUR:-22}
+      - REMINDER_QUIET_END_HOUR=${REMINDER_QUIET_END_HOUR:-8}
       # REWARD_ARTIFACTS_DIR: mount path for generated PNG reward images.
       # Must match the volume mount below so images persist across container restarts.
       - REWARD_ARTIFACTS_DIR=/data/reward_artifacts

--- a/docs/ai-prompts/intake.md
+++ b/docs/ai-prompts/intake.md
@@ -211,6 +211,63 @@ Example:
     remind_at: "<now+1h ISO>",
     confirmation_message: "Got it — I'll remind you in about an hour to set up your video call software for therapy."
 
+DEADLINE DETECTION:
+When the user's message contains a hard time bound for the task itself
+(distinct from a notification ping), populate the `due_at` field. `due_at`
+and `is_reminder` are ORTHOGONAL — they model two different things and
+either or both can be set on a single task:
+
+- `is_reminder = true` with `remind_at` set: the user wants a wall-clock
+  ping at a specific moment (a notification). The reminder worker delivers
+  exactly once at `remind_at`.
+- `due_at` set: the user has a hard time bound for the task itself (a
+  deadline). The scheduler builds an escalating series of pings as the
+  deadline approaches.
+- BOTH set: the user expressed both intents (e.g., "remind me at 5pm to
+  finish report by Friday"). Save `remind_at = 5pm today` AND
+  `due_at = Friday 17:00`. Do not suppress either field — they are
+  independent contracts.
+- Neither set: a task with no time bound. `due_at = null`,
+  `is_reminder = false`.
+
+Deadline phrases:
+- "before <date/day>", "by <date/day>", "due <date>"
+- "<date> at <time>", "at <time> <date>", "needs to be done <date>"
+
+When a deadline phrase is detected:
+- Set `due_at` to the resolved ISO 8601 timestamp with timezone offset
+- Default timezone: the user's configured timezone (`USER_TZ` env var,
+  default `America/Chicago`)
+- If a clock time is given ("by 10am tomorrow"), use that time
+- If no time is given ("by Friday"), default to 17:00 local on that day
+- Set urgency by the usual rules — do NOT auto-set to 90 just because
+  there is a deadline. Urgency is a separate signal.
+- Do NOT clear `is_reminder` or `remind_at` if those were ALSO detected
+  in the same message. The two fields are independent.
+
+Set `due_at` to null when no deadline phrase is present.
+
+Examples:
+  "Submit the placeholder form at 10am tomorrow" →
+    is_reminder: false, due_at: "<tomorrow>T10:00:00-06:00", title: "Submit placeholder form"
+  "Cancel the placeholder appointment before next Wednesday" →
+    is_reminder: false, due_at: "<next Wed>T17:00:00-06:00", title: "Cancel placeholder appointment"
+  "Remind me at 5pm to finish the report by Friday" →
+    is_reminder: true, remind_at: "<today>T17:00:00-06:00",
+    due_at: "<Fri>T17:00:00-06:00", title: "Finish the report"
+
+DEADLINE PERSISTENCE:
+When `due_at` is set on a non-reminder task, `app/graph/nodes/intake.py`
+calls `notion.create_task(due_at_iso=...)` which writes the `Due At`
+property on the Notion row. After successful task creation, the inline
+scheduler (`app/scheduler/reminder_scheduling.schedule_for_task`) builds
+the milestone series, enqueues outbox rows with `kind='deadline'`, and
+calls `notion.mark_reminder_scheduled(page_id)` to set the idempotency
+guard. If inline scheduling fails, the nightly `reminder_scheduler`
+daemon picks the task up via the unscheduled-deadline query. The
+user-facing confirmation never mentions retry state — failure is silent
+from the user's perspective.
+
 OUTPUT (JSON):
 
 If task is clear enough to save:
@@ -226,6 +283,7 @@ If task is clear enough to save:
   "energy_required": "...",
   "is_reminder": false,
   "remind_at": null,
+  "due_at": null,
   "use_hidden_subtasks": true|false,
   "sub_tasks": [
     {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -120,6 +120,7 @@ duplicate delivery over loss.
 | `check_in_dispatcher` | 10 min | Trigger CHECK_IN graph turns for due tasks |
 | `state_audit` | Daily 03:00 USER_TZ | VACUUM + prune `recent_outbound` (90-day retention) |
 | `weekly_recap` | Sun 18:00 USER_TZ | Generate weekly recap |
+| `reminder_scheduler` | Daily 04:00 USER_TZ | Backstop for deadline-driven reminder series: catch tasks where intake's inline scheduling failed and detect deadline edits made in Notion after the initial schedule |
 
 ## Model Routing
 

--- a/docs/notion-schema.md
+++ b/docs/notion-schema.md
@@ -489,7 +489,9 @@ Format: ISO 8601 with timezone (e.g., 2026-06-03T17:00:00-05:00)
 
 **Set by:** `create_task(due_at_iso=...)` when a deadline is provided. Independent of `urgency` — urgency reflects relative priority; `Due At` is a hard time bound.
 
-**Read by:** `query_tasks_with_unscheduled_deadlines()` — filters tasks where `Due At is_not_empty` and `Reminder Scheduled At is_empty` to surface deadline-bearing tasks that have not yet had reminders scheduled.
+**Read by:**
+- `query_tasks_with_unscheduled_deadlines()` — filters tasks where `Due At is_not_empty` and `Reminder Scheduled At is_empty` to surface deadline-bearing tasks that have not yet had reminders scheduled (orphan catch-up path).
+- `query_scheduled_tasks_with_deadlines()` — filters tasks where `Due At is_not_empty` and `Reminder Scheduled At is_not_empty` to surface already-scheduled tasks for deadline-edit detection. The daemon cross-checks the current `Due At` against the ledger's `deadline_at` (±60s tolerance) and reschedules on drift.
 
 ---
 
@@ -501,9 +503,11 @@ Timestamp marking that the automated reminder series for this task has been crea
 Format: ISO 8601 UTC (e.g., 2026-06-01T04:00:00+00:00)
 ```
 
-**Set by:** `mark_reminder_scheduled(page_id)` — PATCHes this field to UTC now. Serves as an idempotency guard: tasks with this field set are excluded by `query_tasks_with_unscheduled_deadlines()`.
+**Set by:** `mark_reminder_scheduled(page_id)` — PATCHes this field to UTC now. Called by `app/graph/nodes/intake.py` immediately after a successful inline deadline-series enqueue (the primary path for new tasks created with a deadline) AND by `app/scheduler/reminder_scheduler.py` after the nightly daemon backstop schedules an orphan series or reschedules following a deadline edit. Serves as an idempotency guard: tasks with this field set are excluded by `query_tasks_with_unscheduled_deadlines()` and routed instead to `query_scheduled_tasks_with_deadlines()` for edit detection.
 
-**Read by:** `query_tasks_with_unscheduled_deadlines()` — filters to `Reminder Scheduled At is_empty` so only unprocessed tasks are returned.
+**Read by:**
+- `query_tasks_with_unscheduled_deadlines()` — filters to `Reminder Scheduled At is_empty` so only unprocessed tasks are returned (orphan catch-up).
+- `query_scheduled_tasks_with_deadlines()` — filters to `Reminder Scheduled At is_not_empty` so already-scheduled tasks flow through the edit-detection path.
 
 ---
 
@@ -784,6 +788,8 @@ sequenceDiagram
 | Next sub-task | `parent_task_id = "{parent_id}" AND status = "pending"` (sort by sequence) |
 | Standalone tasks only | `parent_task_id IS NULL AND status != "has_subtasks"` |
 | Parent tasks | `status = "has_subtasks"` |
+| Unscheduled deadlines (orphan catch-up) | `Due At is_not_empty AND Reminder Scheduled At is_empty AND Status != "Completed" AND Is Reminder = false` (sort by Due At ascending) — `query_tasks_with_unscheduled_deadlines()` |
+| Scheduled deadlines (edit detection) | `Due At is_not_empty AND Reminder Scheduled At is_not_empty AND Status != "Completed" AND Is Reminder = false` (sort by Due At ascending) — `query_scheduled_tasks_with_deadlines()` |
 
 ---
 
@@ -811,6 +817,7 @@ sequenceDiagram
 | Resume task | `resume_count += 1, last_resumed_at → now, progressNotes += "[ts] Resumed (gap: Xm)"` |
 | Create sub-task | `parent_task_id, sequence, status = pending` |
 | Complete sub-task | `status → completed` (check if parent complete) |
+| Mark reminder series scheduled | `Reminder Scheduled At → UTC now` — `mark_reminder_scheduled(page_id)`. Called by `app/graph/nodes/intake.py` after successful inline deadline-series enqueue, and by `app/scheduler/reminder_scheduler.py` after the daemon backstop schedules an orphan or reschedules after a deadline edit. Serves as the idempotency guard that excludes the task from `query_tasks_with_unscheduled_deadlines()`. |
 
 ---
 

--- a/migrations/0008_reminder_outbox_kind.sql
+++ b/migrations/0008_reminder_outbox_kind.sql
@@ -1,0 +1,39 @@
+-- Discriminator on reminder_outbox so the worker can distinguish wall-clock
+-- reminders (which complete the user's Notion task on delivery) from
+-- deadline-driven series reminders (which must NOT complete the task — the
+-- user still has work to do; the deadline-series ping is just a nudge).
+--
+-- Without this column, deadline reminders set notion_page_id = task page id,
+-- and the worker calls notion.complete_reminder(notion_page_id, "sent") after
+-- every successful delivery, which would silently mark the task Completed in
+-- Notion on the FIRST deadline ping.
+--
+-- Design:
+--   kind='reminder'  — existing wall-clock reminder behavior. Worker calls
+--                      complete_reminder on the Notion page after delivery.
+--                      Default for legacy rows so existing behavior is preserved.
+--   kind='deadline'  — deadline-series milestone reminder. Worker skips
+--                      complete_reminder (task remains in its current state).
+--
+-- All existing rows default to 'reminder', preserving legacy semantics.
+-- New deadline-series rows MUST set kind='deadline' explicitly (enforced via
+-- CHECK constraint and propagated through the reminders.enqueue() helper).
+
+BEGIN;
+
+ALTER TABLE reminder_outbox
+  ADD COLUMN IF NOT EXISTS kind TEXT NOT NULL DEFAULT 'reminder';
+
+-- Use a DO block so the migration is idempotent across reruns.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'reminder_outbox_kind_check'
+  ) THEN
+    ALTER TABLE reminder_outbox
+      ADD CONSTRAINT reminder_outbox_kind_check
+      CHECK (kind IN ('reminder', 'deadline'));
+  END IF;
+END $$;
+
+COMMIT;

--- a/tests/evals/fixtures/intake/clock_time_deadline.yaml
+++ b/tests/evals/fixtures/intake/clock_time_deadline.yaml
@@ -1,0 +1,33 @@
+---
+# Eval fixture: "at 10am tomorrow" sets exact clock time in due_at (not the
+# 17:00 end-of-day default). Verifies the Deadline Detection block correctly
+# distinguishes "clock time given" vs. "date only" paths.
+#
+# Test-rig clause-2 coverage: pins the explicit-clock-time branch of the
+# deadline-detection contract.
+id: intake-clock-time-deadline-001
+node: intake
+tier: medium
+peer: "<test-peer-clock>"
+inbound: "I need to submit the placeholder form at 10am tomorrow"
+prior_state:
+  active_task: null
+  conversation_state: idle
+  user_prefs:
+    timezone: America/Chicago
+contracts:
+  - kind: regex_require
+    pattern: "\"action\"\\s*:\\s*\"save\""
+  # due_at must be present, ISO 8601, and contain a 10:00 clock time —
+  # not the 17:00 default the prompt uses when no clock time is supplied.
+  - kind: regex_require
+    pattern: "\"due_at\"\\s*:\\s*\"[0-9]{4}-[0-9]{2}-[0-9]{2}T10:00"
+  - kind: judge
+    rubric: |
+      The JSON output must have action='save' and due_at set to tomorrow at
+      10:00:00 in the user's timezone (America/Chicago). The clock time "10am"
+      must be preserved exactly — not replaced with the 17:00 end-of-day default.
+      Score 1.0 if due_at is set and contains T10:00 with a local timezone offset.
+      Score 0.5 if due_at is set but uses 17:00 instead of 10:00.
+      Score 0.0 if due_at is null or action is 'clarify'.
+    threshold: 0.7

--- a/tests/evals/fixtures/intake/deadline_phrase.yaml
+++ b/tests/evals/fixtures/intake/deadline_phrase.yaml
@@ -1,0 +1,39 @@
+---
+# Eval fixture: deadline phrase in user message must produce due_at in LLM output.
+# Verifies the Deadline Detection block in app/prompts/intake.md.j2 correctly
+# parses relative date phrases like "before next Wednesday" and emits a non-null
+# due_at field in the structured JSON output.
+#
+# This is the test-rig clause-2 coverage for the deadline-detection contract:
+# without a live-LLM fixture, mocked intake tests only exercise the post-LLM
+# parser, not whether the rendered prompt actually makes the model emit due_at.
+id: intake-deadline-phrase-001
+node: intake
+tier: medium
+peer: "<test-peer-deadline>"
+inbound: "I need to cancel my placeholder appointment before next Wednesday"
+prior_state:
+  active_task: null
+  conversation_state: idle
+  user_prefs:
+    timezone: America/Chicago
+contracts:
+  # The intake JSON must contain a non-null due_at. "null" is the explicit
+  # signal that no deadline was detected; the regex below fails if the LLM
+  # emitted "due_at": null or omitted the field entirely.
+  - kind: regex_require
+    pattern: "\"due_at\"\\s*:\\s*\"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}"
+  # action must be "save", not "clarify" — the message is unambiguous.
+  - kind: regex_require
+    pattern: "\"action\"\\s*:\\s*\"save\""
+  # Plan-step framing should not appear for a simple single-step task.
+  - kind: regex_forbid
+    pattern: "(?i)(here'?s? your plan|step[s]?:|\\d+\\)\\s)"
+  - kind: judge
+    rubric: |
+      The JSON output must have action='save' and due_at set to a valid ISO 8601
+      timestamp on or before the user's next Wednesday at 17:00 local. Score 1.0
+      if both due_at is set (non-null, parseable ISO 8601 with timezone offset)
+      and action is 'save'. Score 0.5 if due_at is set but its date is wrong.
+      Score 0.0 if action is 'clarify' or due_at is null/missing.
+    threshold: 0.7

--- a/tests/integration/test_intake_deadlines.py
+++ b/tests/integration/test_intake_deadlines.py
@@ -1,0 +1,305 @@
+"""Integration tests for intake deadline-detection + inline scheduling.
+
+Mocks Notion + the scheduling helper at the boundary. These tests are HTTP-only
+and do NOT require DATABASE_URL — schedule_for_task is exercised against a
+real Postgres in tests/integration/test_reminder_scheduling.py.
+
+Covers the PR 601 blockers in intake:
+  - psy-001: confirmation must NOT append infra/retry state on failure.
+  - sec-001: privacy-safe failure logging (no raw value, no exception text).
+  - Successful path: deterministic reminder summary appended to confirmation.
+
+Private data: all identifiers are placeholders.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.graph.state import State
+
+
+def _make_notion_page(page_id: str = "", title: str = "Task placeholder") -> dict:
+    return {
+        "id": page_id or str(uuid.uuid4()),
+        "properties": {
+            "Title": {"title": [{"plain_text": title}]},
+            "Status": {"select": {"name": "Pending"}},
+        },
+    }
+
+
+def _llm_response(
+    *,
+    title: str = "Task placeholder",
+    due_at: str | None = None,
+    confirmation: str = "Got it — focus, ~30 min.",
+) -> str:
+    return json.dumps({
+        "action": "save",
+        "title": title,
+        "work_type": "focus",
+        "urgency": 50,
+        "time_estimate_minutes": 30,
+        "energy_required": "Medium",
+        "is_reminder": False,
+        "remind_at": None,
+        "due_at": due_at,
+        "use_hidden_subtasks": False,
+        "sub_tasks": [],
+        "inline_steps": "",
+        "confirmation_message": confirmation,
+    })
+
+
+def _state(incoming: str) -> State:
+    return {
+        "peer": "<test-peer>",
+        "incoming": incoming,
+        "intent": "ADD_TASK",
+        "messages": [],
+        "active_task": None,
+        "streak": 0,
+        "tasks_completed_today": 0,
+        "user_prefs": {"timezone": "America/Chicago"},
+        "mood": None,
+        "available_minutes": None,
+        "conversation_state": "idle",
+        "pending_outbound": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — successful deadline: confirmation gets the reminder summary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_deadline_appends_reminder_summary_to_confirmation() -> None:
+    """When schedule_for_task succeeds, the confirmation must include the
+    deterministic reminder summary ("I'll ping you ..."). No infra phrases."""
+    page_id = str(uuid.uuid4())
+    due_at_iso = (datetime.now(UTC) + timedelta(days=10)).isoformat()
+
+    captured_summary_slot = (datetime.now(UTC) + timedelta(days=7))
+
+    async def fake_schedule(*args: Any, **kwargs: Any) -> tuple[list[Any], list[str]]:
+        return [("3d", captured_summary_slot)], []
+
+    with (
+        patch(
+            "app.tools.notion.create_task",
+            new_callable=AsyncMock,
+            return_value=_make_notion_page(page_id=page_id),
+        ),
+        patch(
+            "app.tools.notion.create_reminder",
+            new_callable=AsyncMock,
+            return_value=_make_notion_page(page_id=page_id),
+        ),
+        patch(
+            "app.tools.notion.mark_reminder_scheduled",
+            new_callable=AsyncMock,
+            return_value={},
+        ),
+        patch(
+            "app.scheduler.reminder_scheduling.schedule_for_task",
+            side_effect=fake_schedule,
+        ),
+    ):
+        mock_llm_response = MagicMock()
+        mock_llm_response.content = _llm_response(
+            due_at=due_at_iso,
+            confirmation="Got it — focus, ~30 min.",
+        )
+        mock_model = AsyncMock()
+        mock_model.ainvoke = AsyncMock(return_value=mock_llm_response)
+
+        with patch("app.models.llm", return_value=mock_model):
+            from app.graph.nodes.intake import intake_node
+            result = await intake_node(_state("finish report by Friday"))
+
+    assert result["pending_outbound"]
+    body = result["pending_outbound"][0]["body"]
+    assert "Got it" in body
+    assert "ping you" in body, (
+        f"Expected reminder summary in confirmation, got: {body!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — psy-001: scheduling failure leaves no infra leak in confirmation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_failed_scheduling_does_not_leak_retry_state_to_user() -> None:
+    """When schedule_for_task fails, the confirmation MUST NOT mention
+    "retry", "tonight", "couldn't schedule", or any infra state. The daemon
+    backstop silently picks the task up — the user sees a clean acknowledgment.
+
+    Guards psy-001 from closed PR #601.
+    """
+    page_id = str(uuid.uuid4())
+    due_at_iso = (datetime.now(UTC) + timedelta(days=10)).isoformat()
+
+    async def failing_schedule(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("simulated DB failure")
+
+    with (
+        patch(
+            "app.tools.notion.create_task",
+            new_callable=AsyncMock,
+            return_value=_make_notion_page(page_id=page_id),
+        ),
+        patch(
+            "app.tools.notion.create_reminder",
+            new_callable=AsyncMock,
+            return_value=_make_notion_page(page_id=page_id),
+        ),
+        patch(
+            "app.scheduler.reminder_scheduling.schedule_for_task",
+            side_effect=failing_schedule,
+        ),
+    ):
+        mock_llm_response = MagicMock()
+        mock_llm_response.content = _llm_response(
+            due_at=due_at_iso,
+            confirmation="Got it — focus, ~30 min.",
+        )
+        mock_model = AsyncMock()
+        mock_model.ainvoke = AsyncMock(return_value=mock_llm_response)
+
+        with patch("app.models.llm", return_value=mock_model):
+            from app.graph.nodes.intake import intake_node
+            result = await intake_node(_state("finish report by Friday"))
+
+    body = result["pending_outbound"][0]["body"]
+    # Banned phrases (all from PR 601 / shared.md no-tool-narration contract).
+    banned = [
+        "couldn't schedule",
+        "could not schedule",
+        "retry",
+        "tonight",
+        "tool",
+        "outbox",
+        "database",
+        "backstop",
+        "scheduler",
+    ]
+    body_lower = body.lower()
+    for phrase in banned:
+        assert phrase not in body_lower, (
+            f"Confirmation leaked infra/retry phrase {phrase!r}: {body!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — sec-001: malformed due_at does NOT leak raw value or exception text
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_malformed_due_at_does_not_log_raw_value_or_exception(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When the LLM returns an unparseable due_at, the parse failure must
+    log only flags (no raw value, no exception string). The user-controlled
+    text could contain private task content per DEV-AGENTS.md.
+
+    Guards sec-001 from closed PR #601.
+    """
+    page_id = str(uuid.uuid4())
+    # The "raw value" the LLM returned — pretend it contains a private fragment
+    # we must not echo to logs.
+    malformed_due_at = "PRIVATE_FRAGMENT_FRIDAY"
+
+    with (
+        patch(
+            "app.tools.notion.create_task",
+            new_callable=AsyncMock,
+            return_value=_make_notion_page(page_id=page_id),
+        ),
+        patch(
+            "app.tools.notion.create_reminder",
+            new_callable=AsyncMock,
+            return_value=_make_notion_page(page_id=page_id),
+        ),
+    ):
+        mock_llm_response = MagicMock()
+        mock_llm_response.content = _llm_response(
+            due_at=malformed_due_at,
+            confirmation="Got it — focus, ~30 min.",
+        )
+        mock_model = AsyncMock()
+        mock_model.ainvoke = AsyncMock(return_value=mock_llm_response)
+
+        with patch("app.models.llm", return_value=mock_model):
+            from app.graph.nodes.intake import intake_node
+            with caplog.at_level(logging.DEBUG):
+                result = await intake_node(_state("finish report by Friday"))
+
+    # Confirmation succeeded — parse failure does not crash intake.
+    assert result["pending_outbound"]
+
+    # Log output must NOT contain the raw value.
+    log_text = "\n".join(rec.getMessage() for rec in caplog.records)
+    assert malformed_due_at not in log_text, (
+        f"Logs leaked the raw malformed due_at value: {malformed_due_at!r}"
+    )
+    # And must NOT contain a Python ValueError reflection that echoes it.
+    assert "fromisoformat" not in log_text, (
+        "Logs leaked fromisoformat exception text which can echo the input"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — no deadline: existing behavior preserved
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_deadline_no_summary_no_scheduling() -> None:
+    """When the LLM does not return a due_at, intake must not call
+    schedule_for_task and must not append a reminder summary."""
+    page_id = str(uuid.uuid4())
+
+    schedule_called = AsyncMock(return_value=([], []))
+
+    with (
+        patch(
+            "app.tools.notion.create_task",
+            new_callable=AsyncMock,
+            return_value=_make_notion_page(page_id=page_id),
+        ),
+        patch(
+            "app.tools.notion.create_reminder",
+            new_callable=AsyncMock,
+            return_value=_make_notion_page(page_id=page_id),
+        ),
+        patch(
+            "app.scheduler.reminder_scheduling.schedule_for_task",
+            side_effect=schedule_called,
+        ),
+    ):
+        mock_llm_response = MagicMock()
+        mock_llm_response.content = _llm_response(
+            due_at=None,
+            confirmation="Got it — focus, ~30 min.",
+        )
+        mock_model = AsyncMock()
+        mock_model.ainvoke = AsyncMock(return_value=mock_llm_response)
+
+        with patch("app.models.llm", return_value=mock_model):
+            from app.graph.nodes.intake import intake_node
+            result = await intake_node(_state("I need to organize my bookshelf"))
+
+    schedule_called.assert_not_awaited()
+    body = result["pending_outbound"][0]["body"]
+    assert "ping you" not in body.lower()

--- a/tests/integration/test_notion_due_at.py
+++ b/tests/integration/test_notion_due_at.py
@@ -226,3 +226,84 @@ async def test_mark_reminder_scheduled_returns_response(
     result = await notion_module.mark_reminder_scheduled(fake_page_id)
 
     assert result["id"] == fake_page_id
+
+
+# ---------------------------------------------------------------------------
+# query_scheduled_tasks_with_deadlines (edit detection — daemon backstop)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_query_scheduled_deadlines_filter_shape(
+    notion_server: HTTPServer, fake_db_id: str
+) -> None:
+    """query_scheduled_tasks_with_deadlines sends all 4 AND filter conditions.
+
+    Counterpart to test_query_unscheduled_deadlines_filter_shape. The key
+    difference is the Reminder Scheduled At clause — `is_not_empty` here
+    (already scheduled, candidate for edit detection) instead of `is_empty`
+    (never scheduled, orphan catch-up).
+
+    The daemon's monkeypatch-based tests would still pass if this query
+    filtered on `is_empty` by mistake; this test pins the actual HTTP
+    payload that goes to Notion.
+    """
+    notion_server.expect_request(
+        f"/databases/{fake_db_id}/query", method="POST"
+    ).respond_with_json({"results": []})
+
+    await notion_module.query_scheduled_tasks_with_deadlines()
+
+    req = notion_server.log[0][0]
+    body = _captured_body(req.data)
+    filters = body["filter"]["and"]
+
+    assert len(filters) == 4, (
+        f"Expected 4 ANDed conditions, got {len(filters)}: {filters}"
+    )
+
+    due_at_f = next(f for f in filters if f.get("property") == "Due At")
+    sched_at_f = next(f for f in filters if f.get("property") == "Reminder Scheduled At")
+    status_f = next(f for f in filters if f.get("property") == "Status")
+    is_rem_f = next(f for f in filters if f.get("property") == "Is Reminder")
+
+    assert due_at_f["date"]["is_not_empty"] is True
+    # The load-bearing edit-detection condition: scheduled tasks only.
+    assert sched_at_f["date"]["is_not_empty"] is True, (
+        "query_scheduled_tasks_with_deadlines must filter to "
+        "Reminder Scheduled At is_not_empty — otherwise it duplicates the "
+        "orphan-catch-up query and never detects deadline edits"
+    )
+    assert status_f["select"]["does_not_equal"] == "Completed"
+    assert is_rem_f["checkbox"]["equals"] is False
+
+
+@pytest.mark.asyncio
+async def test_query_scheduled_deadlines_sort_ascending(
+    notion_server: HTTPServer, fake_db_id: str
+) -> None:
+    """query_scheduled_tasks_with_deadlines sorts by Due At ascending."""
+    notion_server.expect_request(
+        f"/databases/{fake_db_id}/query", method="POST"
+    ).respond_with_json({"results": []})
+
+    await notion_module.query_scheduled_tasks_with_deadlines()
+
+    req = notion_server.log[0][0]
+    body = _captured_body(req.data)
+    assert body["sorts"] == [{"property": "Due At", "direction": "ascending"}]
+
+
+@pytest.mark.asyncio
+async def test_query_scheduled_deadlines_returns_response(
+    notion_server: HTTPServer, fake_db_id: str
+) -> None:
+    """query_scheduled_tasks_with_deadlines propagates the Notion response."""
+    page = {"object": "page", "id": "fake-page-id"}
+    notion_server.expect_request(
+        f"/databases/{fake_db_id}/query", method="POST"
+    ).respond_with_json({"results": [page]})
+
+    result = await notion_module.query_scheduled_tasks_with_deadlines()
+
+    assert result["results"] == [page]

--- a/tests/integration/test_reminder_scheduler.py
+++ b/tests/integration/test_reminder_scheduler.py
@@ -1,0 +1,305 @@
+"""Integration tests for app.scheduler.reminder_scheduler (daemon backstop).
+
+These tests focus on the dual-query edit-detection path that closed PR #601
+omitted (doc-001 / d-002): without the second query
+(`query_scheduled_tasks_with_deadlines`), tasks whose Due At is edited AFTER
+the initial schedule are never re-detected, because the orphan query filters
+out anything with `Reminder Scheduled At` set.
+
+Notion is mocked at the verb level (notion.query_tasks_with_unscheduled_deadlines,
+notion.query_scheduled_tasks_with_deadlines, notion.mark_reminder_scheduled).
+Postgres is real — the ledger and outbox round-trips are the load-bearing
+behavior, and the test-rig contract (clause 1) requires real-DB coverage for
+UUID + timestamp fields.
+
+Skipped without DATABASE_URL.
+
+Private data: all identifiers are placeholders.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+_HAS_DB = bool(os.environ.get("DATABASE_URL", ""))
+pytestmark = pytest.mark.skipif(
+    not _HAS_DB,
+    reason="DATABASE_URL not set; skipping integration tests",
+)
+
+
+@pytest.fixture()
+async def db_conn() -> Any:
+    """Clean DB with all migrations applied."""
+    import psycopg
+
+    from app.tools.db import _MIGRATIONS_DIR
+
+    conn_str = os.environ["DATABASE_URL"]
+    async with await psycopg.AsyncConnection.connect(conn_str, autocommit=False) as conn:
+        for mig in sorted(_MIGRATIONS_DIR.glob("*.sql")):
+            await conn.execute(mig.read_text())  # type: ignore[arg-type]
+        await conn.commit()
+        await conn.execute(
+            "TRUNCATE reminder_scheduling_ledger, reminder_outbox, "
+            "recent_outbound, ops_alerts_throttle"
+        )
+        await conn.commit()
+        yield conn
+
+
+def _notion_page(page_id: str, due_at: datetime, urgency: int = 50) -> dict[str, Any]:
+    """Synthesize a minimal Notion query result row."""
+    return {
+        "id": page_id,
+        "properties": {
+            "Title": {"title": [{"plain_text": "Task placeholder"}]},
+            "Due At": {"date": {"start": due_at.isoformat()}},
+            "Urgency": {"number": urgency},
+        },
+    }
+
+
+@pytest.fixture(autouse=True)
+def _peer_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provide DEFAULT_PEER env var so the daemon can resolve a recipient."""
+    monkeypatch.setenv("DEFAULT_PEER", "<peer>")
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — orphan catch-up: ledger + outbox created, mark_reminder_scheduled called
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_daemon_schedules_orphans(
+    db_conn: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Notion task with Due At set but no Reminder Scheduled At is the
+    'orphan' case (intake's inline scheduling failed). The daemon must
+    schedule the milestone series and call mark_reminder_scheduled."""
+    import psycopg.rows
+
+    from app.scheduler.reminder_scheduler import run_reminder_scheduler
+    from app.tools import notion
+
+    page_id = f"page-{uuid.uuid4()}"
+    due_at = datetime.now(UTC) + timedelta(days=10)
+
+    monkeypatch.setattr(
+        notion, "query_tasks_with_unscheduled_deadlines",
+        AsyncMock(return_value={"results": [_notion_page(page_id, due_at)]}),
+    )
+    monkeypatch.setattr(
+        notion, "query_scheduled_tasks_with_deadlines",
+        AsyncMock(return_value={"results": []}),
+    )
+    mark_called = AsyncMock(return_value={})
+    monkeypatch.setattr(notion, "mark_reminder_scheduled", mark_called)
+
+    await run_reminder_scheduler()
+
+    async with db_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        await cur.execute(
+            "SELECT COUNT(*) AS n FROM reminder_scheduling_ledger "
+            "WHERE notion_page_id = %s AND superseded_at IS NULL",
+            (page_id,),
+        )
+        ledger_count = (await cur.fetchone())["n"]
+        await cur.execute(
+            "SELECT COUNT(*) AS n FROM reminder_outbox "
+            "WHERE notion_page_id = %s AND kind = 'deadline'",
+            (page_id,),
+        )
+        outbox_count = (await cur.fetchone())["n"]
+
+    assert ledger_count > 0, "Daemon did not insert ledger rows for orphan"
+    assert outbox_count == ledger_count
+    mark_called.assert_awaited_once_with(page_id)
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — dual-query edit detection: changed Due At supersedes + reschedules
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_daemon_detects_deadline_edit_and_reschedules(
+    db_conn: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The key fix for doc-001/d-002: a task whose Due At was edited in Notion
+    AFTER its initial schedule must be detected via the second
+    (query_scheduled_tasks_with_deadlines) query, then superseded and
+    rescheduled against the new deadline.
+
+    The previous design (single orphan query only) would silently miss this
+    because the orphan filter excludes tasks with Reminder Scheduled At set.
+    """
+    import psycopg.rows
+
+    from app.scheduler.reminder_scheduler import run_reminder_scheduler
+    from app.scheduler.reminder_scheduling import schedule_for_task
+    from app.tools import notion
+
+    page_id = f"page-{uuid.uuid4()}"
+    original_deadline = (datetime.now(UTC) + timedelta(days=20)).replace(microsecond=0)
+    new_deadline = (datetime.now(UTC) + timedelta(days=5)).replace(microsecond=0)
+
+    # Seed: schedule against the original deadline (simulates a prior successful run).
+    await schedule_for_task(
+        page_id,
+        "Task placeholder",
+        "<peer>",
+        original_deadline,
+        50,
+        now=datetime.now(UTC),
+        user_tz="America/Chicago",
+    )
+
+    # Mock Notion: orphan list empty, scheduled list shows the page with the
+    # NEW deadline.
+    monkeypatch.setattr(
+        notion, "query_tasks_with_unscheduled_deadlines",
+        AsyncMock(return_value={"results": []}),
+    )
+    monkeypatch.setattr(
+        notion, "query_scheduled_tasks_with_deadlines",
+        AsyncMock(return_value={"results": [_notion_page(page_id, new_deadline)]}),
+    )
+    monkeypatch.setattr(notion, "mark_reminder_scheduled", AsyncMock(return_value={}))
+
+    await run_reminder_scheduler()
+
+    # Old ledger rows must be superseded.
+    async with db_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        await cur.execute(
+            "SELECT COUNT(*) AS n FROM reminder_scheduling_ledger "
+            "WHERE notion_page_id = %s AND superseded_at IS NOT NULL",
+            (page_id,),
+        )
+        superseded = (await cur.fetchone())["n"]
+        await cur.execute(
+            "SELECT COUNT(*) AS n FROM reminder_scheduling_ledger "
+            "WHERE notion_page_id = %s AND superseded_at IS NULL",
+            (page_id,),
+        )
+        active = (await cur.fetchone())["n"]
+        # Old outbox rows must be marked dead.
+        await cur.execute(
+            "SELECT COUNT(*) AS n FROM reminder_outbox "
+            "WHERE notion_page_id = %s AND state = 'dead' "
+            "AND last_error = 'superseded_by_deadline_change'",
+            (page_id,),
+        )
+        dead = (await cur.fetchone())["n"]
+        # New outbox rows must be pending and reference the new deadline via key.
+        await cur.execute(
+            "SELECT idempotency_key FROM reminder_outbox "
+            "WHERE notion_page_id = %s AND state = 'pending'",
+            (page_id,),
+        )
+        new_rows = await cur.fetchall()
+
+    assert superseded > 0, "Old ledger rows were not superseded after deadline edit"
+    assert active > 0, "No fresh ledger rows after deadline edit"
+    assert dead > 0, "Old outbox rows were not marked dead"
+    # New idempotency keys must encode the NEW deadline.
+    for r in new_rows:
+        assert new_deadline.isoformat() in r["idempotency_key"], (
+            "New outbox rows do not encode the new deadline in idempotency_key"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — tolerance: tiny drift in Notion Due At (within ±60s) is NOT an edit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_daemon_treats_subsecond_drift_as_unchanged(
+    db_conn: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Notion + Postgres round-tripping introduces sub-second drift. The
+    daemon's tolerance window (60s) must absorb that — no supersede, no
+    reschedule, no churn."""
+    import psycopg.rows
+
+    from app.scheduler.reminder_scheduler import run_reminder_scheduler
+    from app.scheduler.reminder_scheduling import schedule_for_task
+    from app.tools import notion
+
+    page_id = f"page-{uuid.uuid4()}"
+    original_deadline = (datetime.now(UTC) + timedelta(days=10)).replace(microsecond=0)
+    notion_deadline = original_deadline + timedelta(seconds=5)  # within tolerance
+
+    await schedule_for_task(
+        page_id, "Task placeholder", "<peer>", original_deadline, 50,
+        now=datetime.now(UTC), user_tz="America/Chicago",
+    )
+
+    monkeypatch.setattr(
+        notion, "query_tasks_with_unscheduled_deadlines",
+        AsyncMock(return_value={"results": []}),
+    )
+    monkeypatch.setattr(
+        notion, "query_scheduled_tasks_with_deadlines",
+        AsyncMock(return_value={"results": [_notion_page(page_id, notion_deadline)]}),
+    )
+    mark_called = AsyncMock(return_value={})
+    monkeypatch.setattr(notion, "mark_reminder_scheduled", mark_called)
+
+    await run_reminder_scheduler()
+
+    # Nothing got superseded.
+    async with db_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        await cur.execute(
+            "SELECT COUNT(*) AS n FROM reminder_scheduling_ledger "
+            "WHERE notion_page_id = %s AND superseded_at IS NOT NULL",
+            (page_id,),
+        )
+        superseded = (await cur.fetchone())["n"]
+
+    assert superseded == 0, "Sub-tolerance drift was incorrectly treated as edit"
+    mark_called.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — Notion query failure does not crash daemon
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_daemon_handles_notion_query_failure(
+    db_conn: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Notion 5xx on the orphan query must result in an ops alert and a
+    clean exit — not an unhandled exception that crashes the scheduler job."""
+    from app.scheduler.reminder_scheduler import run_reminder_scheduler
+    from app.tools import notion, ops_alerts
+
+    monkeypatch.setattr(
+        notion, "query_tasks_with_unscheduled_deadlines",
+        AsyncMock(side_effect=RuntimeError("notion 502")),
+    )
+    monkeypatch.setattr(
+        notion, "query_scheduled_tasks_with_deadlines",
+        AsyncMock(return_value={"results": []}),
+    )
+
+    ops_enqueue = AsyncMock(return_value=None)
+    monkeypatch.setattr(ops_alerts, "enqueue", ops_enqueue)
+
+    # Must not raise.
+    await run_reminder_scheduler()
+
+    # ops alert was enqueued.
+    assert ops_enqueue.await_count >= 1

--- a/tests/integration/test_reminder_scheduler.py
+++ b/tests/integration/test_reminder_scheduler.py
@@ -67,8 +67,20 @@ def _notion_page(page_id: str, due_at: datetime, urgency: int = 50) -> dict[str,
 
 @pytest.fixture(autouse=True)
 def _peer_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Provide DEFAULT_PEER env var so the daemon can resolve a recipient."""
-    monkeypatch.setenv("DEFAULT_PEER", "<peer>")
+    """Provide AUTHORIZED_PEERS env var so the daemon can resolve a recipient.
+
+    Fixes d-001 from PR 602: the daemon used to read OPS_ALERT_SIGNAL_NUMBER
+    or an undocumented DEFAULT_PEER. The documented user-routing source is
+    AUTHORIZED_PEERS (same env var the signal listener gates ingress on).
+    Single-tenant assumption: the first entry is the user. DEFAULT_PEER
+    remains as a backwards-compat fallback in the daemon, but new tests
+    should exercise the AUTHORIZED_PEERS code path explicitly.
+    """
+    monkeypatch.setenv("AUTHORIZED_PEERS", "<peer>")
+    # Also clear DEFAULT_PEER / OPS_ALERT_SIGNAL_NUMBER so the test
+    # cannot accidentally pass via a regressed fallback.
+    monkeypatch.delenv("DEFAULT_PEER", raising=False)
+    monkeypatch.delenv("OPS_ALERT_SIGNAL_NUMBER", raising=False)
 
 
 # ---------------------------------------------------------------------------
@@ -303,3 +315,96 @@ async def test_daemon_handles_notion_query_failure(
 
     # ops alert was enqueued.
     assert ops_enqueue.await_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — d-001 recipient routing: daemon uses AUTHORIZED_PEERS, not
+# OPS_ALERT_SIGNAL_NUMBER. The orphan path enqueues an outbox row whose
+# `peer` column must equal the first AUTHORIZED_PEERS entry, never the
+# ops alert recipient.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_daemon_routes_to_authorized_peers_not_ops_alert(
+    db_conn: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The daemon must not silently misdeliver a user reminder to the ops
+    alert recipient. Fixes d-001 from PR 602."""
+    import psycopg.rows
+
+    from app.scheduler.reminder_scheduler import run_reminder_scheduler
+    from app.tools import notion
+
+    # Override the autouse fixture: place a sentinel in AUTHORIZED_PEERS and
+    # a DIFFERENT sentinel in OPS_ALERT_SIGNAL_NUMBER so we can verify the
+    # daemon picked the right one.
+    monkeypatch.setenv("AUTHORIZED_PEERS", "+15555550111")
+    monkeypatch.setenv("OPS_ALERT_SIGNAL_NUMBER", "+15555550999")
+
+    page_id = f"page-{uuid.uuid4()}"
+    due_at = datetime.now(UTC) + timedelta(days=10)
+
+    monkeypatch.setattr(
+        notion, "query_tasks_with_unscheduled_deadlines",
+        AsyncMock(return_value={"results": [_notion_page(page_id, due_at)]}),
+    )
+    monkeypatch.setattr(
+        notion, "query_scheduled_tasks_with_deadlines",
+        AsyncMock(return_value={"results": []}),
+    )
+    monkeypatch.setattr(notion, "mark_reminder_scheduled", AsyncMock(return_value={}))
+
+    await run_reminder_scheduler()
+
+    async with db_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        await cur.execute(
+            "SELECT DISTINCT peer FROM reminder_outbox "
+            "WHERE notion_page_id = %s AND kind = 'deadline'",
+            (page_id,),
+        )
+        peers = [row["peer"] for row in await cur.fetchall()]
+
+    assert peers, "No outbox rows were created for the orphan task"
+    assert peers == ["+15555550111"], (
+        "Daemon routed deadline reminder to the wrong recipient. "
+        f"Expected ['+15555550111'] (AUTHORIZED_PEERS), got {peers}. "
+        "Routing user reminders to OPS_ALERT_SIGNAL_NUMBER is the d-001 bug."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — APScheduler job wrapper dispatches to the daemon entry point.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_reminder_scheduler_job_dispatches_to_daemon(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`run_reminder_scheduler_job` (the APScheduler-registered callable)
+    must actually invoke `reminder_scheduler.run_reminder_scheduler`.
+
+    The declared-jobs registration test in test_scheduler.py proves the
+    JobSpec is registered, but it does NOT prove the wrapper's body
+    dispatches correctly. If a future refactor renamed the daemon entry
+    point and left the wrapper pointing at a stub, that wouldn't be
+    caught without this test.
+    """
+    from app.scheduler import jobs as jobs_module
+    from app.scheduler import reminder_scheduler as scheduler_module
+
+    called = {"hits": 0}
+
+    async def _fake_run() -> None:
+        called["hits"] += 1
+
+    monkeypatch.setattr(scheduler_module, "run_reminder_scheduler", _fake_run)
+
+    await jobs_module.run_reminder_scheduler_job()
+
+    assert called["hits"] == 1, (
+        "run_reminder_scheduler_job did not dispatch to "
+        "reminder_scheduler.run_reminder_scheduler"
+    )

--- a/tests/integration/test_reminder_scheduling.py
+++ b/tests/integration/test_reminder_scheduling.py
@@ -1,0 +1,395 @@
+"""Integration tests for app.scheduler.reminder_scheduling.
+
+Real-Postgres round-trip coverage for the public helpers that move UUID +
+timestamp values through the DB layer (test-rig clause 1):
+  - schedule_for_task: inserts outbox + ledger rows, both with UUIDs and
+    timestamps; round-trips the entire payload.
+  - get_active_deadline_for_page: reads deadline_at from the ledger.
+  - supersede_ledger_rows: marks rows superseded; returns UUIDs.
+  - cancel_outbox_rows: updates outbox rows to state='dead'.
+
+These tests intentionally do NOT mock the DB helpers — they exercise the
+real Postgres connection so any UUID coercion / timestamp tz drift / column
+type mismatch surfaces as a test failure rather than at runtime.
+
+Notion is not exercised here (schedule_for_task does not call Notion). The
+intake-side mark_reminder_scheduled call is covered separately in
+tests/integration/test_intake.py via mocked Notion.
+
+Skipped without DATABASE_URL.
+
+Private data: all identifiers are placeholders (`<peer>`, `<page-XXXX>`).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+_HAS_DB = bool(os.environ.get("DATABASE_URL", ""))
+pytestmark = pytest.mark.skipif(
+    not _HAS_DB,
+    reason="DATABASE_URL not set; skipping integration tests",
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture: clean DB with migrations applied
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+async def db_conn() -> Any:
+    """Provide a psycopg connection with migrations applied and tables clean.
+
+    Mirrors the pattern from test_reminder_ledger_schema.py.
+    """
+    import psycopg
+
+    from app.tools.db import _MIGRATIONS_DIR
+
+    conn_str = os.environ["DATABASE_URL"]
+    async with await psycopg.AsyncConnection.connect(conn_str, autocommit=False) as conn:
+        for mig in sorted(_MIGRATIONS_DIR.glob("*.sql")):
+            await conn.execute(mig.read_text())  # type: ignore[arg-type]
+        await conn.commit()
+
+        await conn.execute(
+            "TRUNCATE reminder_scheduling_ledger, reminder_outbox, "
+            "recent_outbound, ops_alerts_throttle"
+        )
+        await conn.commit()
+
+        yield conn
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — schedule_for_task: outbox + ledger round-trip (UUID + timestamp)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_schedule_for_task_round_trips_outbox_and_ledger(db_conn: Any) -> None:
+    """End-to-end: schedule_for_task inserts outbox rows (kind='deadline')
+    and ledger rows whose foreign-key references resolve, with all UUID and
+    timestamp fields round-tripping through Postgres."""
+    import psycopg.rows
+
+    from app.scheduler.reminder_scheduling import schedule_for_task
+
+    page_id = f"page-{uuid.uuid4()}"
+    title = "Task placeholder"
+    peer = "<peer>"
+    now = datetime.now(UTC)
+    deadline_at = now + timedelta(days=10)
+    urgency = 50  # standard tier
+
+    assigned_slots, failures = await schedule_for_task(
+        page_id,
+        title,
+        peer,
+        deadline_at,
+        urgency,
+        now=now,
+        user_tz="America/Chicago",
+    )
+
+    assert failures == [], f"Unexpected scheduling failures: {failures}"
+    assert assigned_slots, "Expected at least one milestone for a 10-day deadline"
+
+    # Outbox rows must be kind='deadline'.
+    async with db_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        await cur.execute(
+            "SELECT id, notion_page_id, kind, due_at, state, idempotency_key, body "
+            "FROM reminder_outbox WHERE notion_page_id = %s",
+            (page_id,),
+        )
+        outbox_rows = await cur.fetchall()
+
+    assert len(outbox_rows) == len(assigned_slots), (
+        f"Outbox row count {len(outbox_rows)} != "
+        f"assigned milestone count {len(assigned_slots)}"
+    )
+    for row in outbox_rows:
+        assert row["kind"] == "deadline", (
+            f"Outbox row {row['id']!r} has kind={row['kind']!r}, "
+            "expected 'deadline' (worker would otherwise complete the task on delivery)"
+        )
+        assert row["state"] == "pending"
+        assert row["idempotency_key"].startswith(f"deadline-{page_id}-")
+        # due_at must be tz-aware (Postgres TIMESTAMPTZ).
+        assert row["due_at"].tzinfo is not None
+
+    # Ledger rows must reference outbox rows by UUID (FK round-trip).
+    async with db_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        await cur.execute(
+            "SELECT id, notion_page_id, deadline_at, urgency, tier, "
+            "milestone_label, ideal_slot_at, assigned_slot_at, "
+            "reminder_outbox_id, superseded_at "
+            "FROM reminder_scheduling_ledger WHERE notion_page_id = %s",
+            (page_id,),
+        )
+        ledger_rows = await cur.fetchall()
+
+    assert len(ledger_rows) == len(assigned_slots)
+    outbox_ids = {str(r["id"]) for r in outbox_rows}
+    for lr in ledger_rows:
+        assert str(lr["reminder_outbox_id"]) in outbox_ids, (
+            "Ledger row references unknown outbox UUID"
+        )
+        assert lr["tier"] == "standard"
+        assert lr["superseded_at"] is None
+        # Timestamps round-trip with tzinfo.
+        assert lr["deadline_at"].tzinfo is not None
+        assert lr["assigned_slot_at"].tzinfo is not None
+        assert lr["ideal_slot_at"].tzinfo is not None
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — schedule_for_task is idempotent on duplicate runs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_schedule_for_task_idempotent_on_rerun(db_conn: Any) -> None:
+    """Calling schedule_for_task twice with the same (page_id, deadline)
+    must not duplicate outbox/ledger rows — UniqueViolation on idempotency_key
+    is caught and treated as success.
+
+    Note: the second invocation reports the same milestones as "assigned" via
+    the UniqueViolation branch but does NOT create new ledger rows. We assert
+    on the table state rather than the return value.
+    """
+    import psycopg.rows
+
+    from app.scheduler.reminder_scheduling import schedule_for_task
+
+    page_id = f"page-{uuid.uuid4()}"
+    peer = "<peer>"
+    now = datetime.now(UTC)
+    deadline_at = now + timedelta(days=10)
+
+    first_slots, first_fail = await schedule_for_task(
+        page_id, "title", peer, deadline_at, 50, now=now, user_tz="America/Chicago",
+    )
+    assert first_fail == []
+    assert first_slots
+
+    # Snapshot counts after first run.
+    async with db_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        await cur.execute(
+            "SELECT COUNT(*) AS n FROM reminder_outbox WHERE notion_page_id = %s",
+            (page_id,),
+        )
+        first_outbox = (await cur.fetchone())["n"]
+        await cur.execute(
+            "SELECT COUNT(*) AS n FROM reminder_scheduling_ledger "
+            "WHERE notion_page_id = %s",
+            (page_id,),
+        )
+        first_ledger = (await cur.fetchone())["n"]
+
+    # Second run — same (page_id, deadline_at).
+    _second_slots, second_fail = await schedule_for_task(
+        page_id, "title", peer, deadline_at, 50, now=now, user_tz="America/Chicago",
+    )
+    assert second_fail == []
+
+    async with db_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        await cur.execute(
+            "SELECT COUNT(*) AS n FROM reminder_outbox WHERE notion_page_id = %s",
+            (page_id,),
+        )
+        second_outbox = (await cur.fetchone())["n"]
+        await cur.execute(
+            "SELECT COUNT(*) AS n FROM reminder_scheduling_ledger "
+            "WHERE notion_page_id = %s",
+            (page_id,),
+        )
+        second_ledger = (await cur.fetchone())["n"]
+
+    assert second_outbox == first_outbox, "Idempotent re-run added outbox rows"
+    assert second_ledger == first_ledger, "Idempotent re-run added ledger rows"
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — get_active_deadline_for_page
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_active_deadline_for_page_round_trips_timestamp(db_conn: Any) -> None:
+    """get_active_deadline_for_page returns the deadline_at value with tzinfo,
+    matching the original input (modulo Postgres TIMESTAMPTZ second granularity)."""
+    from app.scheduler.reminder_scheduling import (
+        get_active_deadline_for_page,
+        schedule_for_task,
+    )
+
+    page_id = f"page-{uuid.uuid4()}"
+    now = datetime.now(UTC)
+    deadline_at = (now + timedelta(days=10)).replace(microsecond=0)
+
+    await schedule_for_task(
+        page_id, "title", "<peer>", deadline_at, 50,
+        now=now, user_tz="America/Chicago",
+    )
+
+    result = await get_active_deadline_for_page(page_id)
+    assert result is not None
+    assert result.tzinfo is not None
+    # Round-tripped value matches at second granularity.
+    assert abs((result - deadline_at).total_seconds()) < 1.0
+
+
+@pytest.mark.asyncio
+async def test_get_active_deadline_returns_none_when_no_ledger_rows(db_conn: Any) -> None:
+    """Returns None when no ledger row exists for the page."""
+    from app.scheduler.reminder_scheduling import get_active_deadline_for_page
+
+    result = await get_active_deadline_for_page(f"page-{uuid.uuid4()}")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — supersede_ledger_rows returns UUIDs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_supersede_ledger_rows_marks_and_returns_outbox_uuids(db_conn: Any) -> None:
+    """supersede_ledger_rows must:
+      - set superseded_at on every active ledger row for the page,
+      - return the corresponding reminder_outbox_id UUIDs as uuid.UUID values.
+    """
+    import psycopg.rows
+
+    from app.scheduler.reminder_scheduling import (
+        schedule_for_task,
+        supersede_ledger_rows,
+    )
+
+    page_id = f"page-{uuid.uuid4()}"
+    now = datetime.now(UTC)
+    deadline_at = now + timedelta(days=10)
+
+    await schedule_for_task(
+        page_id, "title", "<peer>", deadline_at, 50,
+        now=now, user_tz="America/Chicago",
+    )
+
+    superseded_ids = await supersede_ledger_rows(page_id)
+    assert superseded_ids, "Expected at least one superseded outbox UUID"
+    for oid in superseded_ids:
+        assert isinstance(oid, uuid.UUID), (
+            f"supersede_ledger_rows returned {type(oid).__name__}, expected uuid.UUID"
+        )
+
+    # All active ledger rows now have superseded_at set.
+    async with db_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        await cur.execute(
+            "SELECT COUNT(*) AS n FROM reminder_scheduling_ledger "
+            "WHERE notion_page_id = %s AND superseded_at IS NULL",
+            (page_id,),
+        )
+        active_remaining = (await cur.fetchone())["n"]
+
+    assert active_remaining == 0, (
+        f"Expected 0 active ledger rows after supersede, got {active_remaining}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — cancel_outbox_rows updates only matching pending/scheduled rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancel_outbox_rows_marks_state_dead(db_conn: Any) -> None:
+    """cancel_outbox_rows must transition pending/scheduled rows to 'dead'
+    with last_error='superseded_by_deadline_change'."""
+    import psycopg.rows
+
+    from app.scheduler.reminder_scheduling import (
+        cancel_outbox_rows,
+        schedule_for_task,
+        supersede_ledger_rows,
+    )
+
+    page_id = f"page-{uuid.uuid4()}"
+    now = datetime.now(UTC)
+    deadline_at = now + timedelta(days=10)
+
+    await schedule_for_task(
+        page_id, "title", "<peer>", deadline_at, 50,
+        now=now, user_tz="America/Chicago",
+    )
+
+    superseded_ids = await supersede_ledger_rows(page_id)
+    await cancel_outbox_rows(superseded_ids)
+
+    async with db_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        await cur.execute(
+            "SELECT state, last_error FROM reminder_outbox WHERE notion_page_id = %s",
+            (page_id,),
+        )
+        rows = await cur.fetchall()
+
+    assert rows, "Outbox rows missing after schedule_for_task"
+    for r in rows:
+        assert r["state"] == "dead", (
+            f"Expected state='dead', got {r['state']!r}"
+        )
+        assert r["last_error"] == "superseded_by_deadline_change"
+
+
+@pytest.mark.asyncio
+async def test_cancel_outbox_rows_skips_already_delivered_rows(db_conn: Any) -> None:
+    """cancel_outbox_rows must NOT clobber state when the row has already
+    been delivered. Only pending/scheduled rows are affected."""
+    import psycopg.rows
+
+    from app.scheduler.reminder_scheduling import (
+        cancel_outbox_rows,
+        schedule_for_task,
+        supersede_ledger_rows,
+    )
+
+    page_id = f"page-{uuid.uuid4()}"
+    now = datetime.now(UTC)
+    deadline_at = now + timedelta(days=10)
+
+    await schedule_for_task(
+        page_id, "title", "<peer>", deadline_at, 50,
+        now=now, user_tz="America/Chicago",
+    )
+
+    # Force one row into 'delivered' state.
+    async with db_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        await cur.execute(
+            "SELECT id FROM reminder_outbox WHERE notion_page_id = %s LIMIT 1",
+            (page_id,),
+        )
+        target = (await cur.fetchone())["id"]
+        await cur.execute(
+            "UPDATE reminder_outbox SET state='delivered' WHERE id=%s",
+            (target,),
+        )
+    await db_conn.commit()
+
+    superseded_ids = await supersede_ledger_rows(page_id)
+    await cancel_outbox_rows(superseded_ids)
+
+    async with db_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        await cur.execute(
+            "SELECT state FROM reminder_outbox WHERE id = %s",
+            (target,),
+        )
+        row = await cur.fetchone()
+
+    assert row["state"] == "delivered", (
+        "cancel_outbox_rows incorrectly clobbered a delivered row"
+    )

--- a/tests/smoke/test_compose_round_trip.py
+++ b/tests/smoke/test_compose_round_trip.py
@@ -189,6 +189,38 @@ def test_app_receives_llm_proxy_env(compose_stack: object) -> None:
     assert "LLM_PROXY_BASE_URL=https://proxy.test/v1" in env_lines
 
 
+def test_app_receives_reminder_scheduling_env(compose_stack: object) -> None:
+    """Compose must thread reminder-scheduling knobs into the app container.
+
+    The four REMINDER_* vars tune the deadline-driven reminder scheduler
+    (slot bucket size, capacity, quiet hours). Defaults must reach the
+    app container even when the operator does not override them — otherwise
+    the daemon falls back to whatever Python-level default
+    `_env_defaults()` reads, which silently re-introduces the deployment-gap
+    bug class the smoke test exists to catch.
+    """
+    result = subprocess.run(  # noqa: S603
+        ["docker", "compose", "-f", str(_COMPOSE_FILE), "exec", "-T", "app", "env"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert result.returncode == 0, f"could not inspect app env: {result.stderr}"
+    env_lines = set(result.stdout.splitlines())
+    assert "REMINDER_SLOT_MINUTES=30" in env_lines, (
+        "REMINDER_SLOT_MINUTES default did not reach the app container"
+    )
+    assert "REMINDER_SLOT_CAPACITY=2" in env_lines, (
+        "REMINDER_SLOT_CAPACITY default did not reach the app container"
+    )
+    assert "REMINDER_QUIET_START_HOUR=22" in env_lines, (
+        "REMINDER_QUIET_START_HOUR default did not reach the app container"
+    )
+    assert "REMINDER_QUIET_END_HOUR=8" in env_lines, (
+        "REMINDER_QUIET_END_HOUR default did not reach the app container"
+    )
+
+
 def test_app_boots_runtime(compose_stack: object) -> None:
     """App must start and produce logs without an error exit.
 

--- a/tests/unit/test_deadline_planner.py
+++ b/tests/unit/test_deadline_planner.py
@@ -1,0 +1,419 @@
+"""Unit tests for app.scheduler.deadline_planner.
+
+Table-driven. Covers tier selection, milestone clipping, load-balancing
+outward walk, quiet-hours skip, never-past-deadline guard, fallback flag,
+and format_reminder_summary round-trips.
+
+No I/O, no DB, no async — all functions are pure.
+
+Private data: all test values use placeholder strings / synthetic datetimes.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.scheduler.deadline_planner import (
+    MilestoneSlot,
+    assign_slot,
+    format_reminder_summary,
+    plan_milestones,
+    tier_for,
+)
+
+# Use a fixed timezone throughout tests.
+_TZ_STR = "America/Chicago"
+_TZ = ZoneInfo(_TZ_STR)
+
+
+def _local(year: int, month: int, day: int, hour: int = 0, minute: int = 0) -> datetime:
+    """Build a tz-aware datetime in America/Chicago."""
+    return datetime(year, month, day, hour, minute, tzinfo=_TZ)
+
+
+def _utc(year: int, month: int, day: int, hour: int = 0, minute: int = 0) -> datetime:
+    """Build a tz-aware datetime in UTC."""
+    return datetime(year, month, day, hour, minute, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# tier_for — 6 table-driven cases
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("urgency,expected", [
+    (0,   "sparse"),
+    (39,  "sparse"),
+    (40,  "standard"),
+    (79,  "standard"),
+    (80,  "dense"),
+    (100, "dense"),
+])
+def test_tier_for(urgency: int, expected: str) -> None:
+    assert tier_for(urgency) == expected
+
+
+# ---------------------------------------------------------------------------
+# plan_milestones
+# ---------------------------------------------------------------------------
+
+class TestPlanMilestones:
+
+    def test_6_month_out_dense_returns_7_milestones(self) -> None:
+        """6-month deadline + dense urgency → all 7 milestones (90d..4h)."""
+        now = _local(2026, 1, 1, 10, 0)
+        # Deadline 200 days away (>90d) at end-of-day
+        deadline = _local(2026, 7, 20, 17, 0)
+        slots = plan_milestones(deadline, urgency=85, now=now, user_tz=_TZ_STR)
+        assert len(slots) == 7
+        labels = [s.label for s in slots]
+        assert labels == ["90d", "30d", "14d", "7d", "3d", "1d", "4h"]
+
+    def test_5_day_out_standard_clips_past_milestones(self) -> None:
+        """5-day deadline + standard urgency → only 3d, 1d, 4h milestones."""
+        now = _local(2026, 6, 1, 10, 0)
+        deadline = _local(2026, 6, 6, 17, 0)   # 5 days away
+        slots = plan_milestones(deadline, urgency=50, now=now, user_tz=_TZ_STR)
+        labels = [s.label for s in slots]
+        # 60d, 14d, 7d are in the past → clipped; 3d, 1d, 4h fit
+        assert "60d" not in labels
+        assert "14d" not in labels
+        assert "7d" not in labels
+        assert set(labels) == {"3d", "1d", "4h"}
+        assert len(slots) == 3
+
+    def test_1_day_out_sparse_returns_1_milestone(self) -> None:
+        """1-day deadline + sparse urgency → only 4h milestone."""
+        now = _local(2026, 6, 1, 10, 0)
+        deadline = _local(2026, 6, 2, 17, 0)   # ~31h away
+        slots = plan_milestones(deadline, urgency=20, now=now, user_tz=_TZ_STR)
+        labels = [s.label for s in slots]
+        assert labels == ["4h"]
+
+    def test_22h_clock_time_deadline_dense_yields_4h_at_6am(self) -> None:
+        """22h-out clock-time deadline (10am tomorrow) + dense → 1 milestone (4h ≈ 6am).
+
+        The 1d milestone is clipped because deadline - 1d is at or before now.
+        The 4h milestone ideal is deadline - 4h = 6am (clock-time anchoring).
+        """
+        now = _local(2026, 6, 1, 12, 0)        # noon today
+        deadline = _local(2026, 6, 2, 10, 0)   # 10am tomorrow (22h away, NOT end-of-day)
+        slots = plan_milestones(deadline, urgency=85, now=now, user_tz=_TZ_STR)
+        assert len(slots) == 1, f"Expected 1 slot, got {len(slots)}: {[s.label for s in slots]}"
+        assert slots[0].label == "4h"
+        # ideal_at should be 6am (deadline - 4h)
+        expected_ideal = deadline - timedelta(hours=4)
+        assert slots[0].ideal_at == expected_ideal
+
+    def test_past_deadline_returns_empty(self) -> None:
+        """Deadline in the past → empty list."""
+        now = _local(2026, 6, 10, 12, 0)
+        deadline = _local(2026, 6, 5, 17, 0)   # in the past
+        slots = plan_milestones(deadline, urgency=80, now=now, user_tz=_TZ_STR)
+        assert slots == []
+
+    def test_16_minutes_out_returns_empty(self) -> None:
+        """16-minute-out deadline → empty list (4h milestone would be -3h44m in past)."""
+        now = _local(2026, 6, 1, 12, 0)
+        deadline = now + timedelta(minutes=16)
+        # 4h-before fires at deadline - 4h = now - 3h44m → in the past → skipped
+        slots = plan_milestones(deadline, urgency=80, now=now, user_tz=_TZ_STR)
+        assert slots == []
+
+    def test_slots_sorted_ascending(self) -> None:
+        """plan_milestones returns slots sorted by ideal_at ascending."""
+        now = _local(2026, 1, 1, 10, 0)
+        deadline = _local(2026, 7, 20, 17, 0)
+        slots = plan_milestones(deadline, urgency=85, now=now, user_tz=_TZ_STR)
+        assert len(slots) >= 2
+        for a, b in zip(slots, slots[1:], strict=False):
+            assert a.ideal_at <= b.ideal_at
+
+    def test_milestone_slot_dataclass_fields(self) -> None:
+        """MilestoneSlot has label, tier, ideal_at fields."""
+        now = _local(2026, 1, 1, 10, 0)
+        deadline = _local(2026, 4, 15, 17, 0)
+        slots = plan_milestones(deadline, urgency=80, now=now, user_tz=_TZ_STR)
+        assert len(slots) > 0
+        s = slots[0]
+        assert isinstance(s, MilestoneSlot)
+        assert isinstance(s.label, str)
+        assert s.tier in ("dense", "standard", "sparse")
+        assert s.ideal_at.tzinfo is not None  # tz-aware
+
+
+# ---------------------------------------------------------------------------
+# assign_slot
+# ---------------------------------------------------------------------------
+
+class TestAssignSlot:
+
+    def _make_ideal(self) -> datetime:
+        """A simple ideal slot: Wednesday 10am local."""
+        return _local(2026, 6, 3, 10, 0)   # Wednesday
+
+    def _make_deadline(self) -> datetime:
+        """Deadline safely after the ideal."""
+        return _local(2026, 6, 6, 17, 0)
+
+    def test_empty_existing_returns_ideal(self) -> None:
+        """No existing slots → returns (ideal_snapped, False)."""
+        ideal = self._make_ideal()
+        slot, fallback = assign_slot(
+            ideal, [], self._make_deadline(),
+            user_tz=_TZ_STR,
+            quiet_hours=(22, 8),
+            slot_minutes=30,
+            slot_capacity=2,
+            max_drift_minutes=720,
+            now=_local(2026, 6, 1, 10, 0),
+        )
+        assert not fallback
+        assert slot <= ideal + timedelta(minutes=30)  # within one bucket of ideal
+
+    def test_full_ideal_bucket_walks_earlier(self) -> None:
+        """When ideal bucket is full, assign_slot returns a slot 30 min earlier."""
+        ideal = _local(2026, 6, 3, 10, 0)
+        deadline = _local(2026, 6, 6, 17, 0)
+        now = _local(2026, 6, 1, 8, 0)
+        # Two existing slots at the ideal time (fills capacity=2)
+        existing = [ideal, ideal + timedelta(minutes=5)]
+        slot, fallback = assign_slot(
+            ideal, existing, deadline,
+            user_tz=_TZ_STR,
+            quiet_hours=(22, 8),
+            slot_minutes=30,
+            slot_capacity=2,
+            max_drift_minutes=720,
+            now=now,
+        )
+        assert not fallback
+        # Should be 30 min before ideal (biased earlier)
+        assert slot < ideal
+
+    def test_full_bucket_and_earlier_also_full_walks_back_further(self) -> None:
+        """If ideal and ideal-30min are both full, walks to an adjacent open slot."""
+        ideal = _local(2026, 6, 3, 10, 0)
+        deadline = _local(2026, 6, 6, 17, 0)
+        now = _local(2026, 6, 1, 8, 0)
+        # Fill ideal and ideal-30min buckets; also fill ideal+30 to force wider walk
+        minus30 = ideal - timedelta(minutes=30)
+        plus30  = ideal + timedelta(minutes=30)
+        existing = [ideal, ideal, minus30, minus30, plus30, plus30]   # 2 each → all full
+        slot, fallback = assign_slot(
+            ideal, existing, deadline,
+            user_tz=_TZ_STR,
+            quiet_hours=(22, 8),
+            slot_minutes=30,
+            slot_capacity=2,
+            max_drift_minutes=720,
+            now=now,
+        )
+        assert not fallback
+        # Must be outside the three packed buckets
+        assert slot not in (ideal, minus30, plus30)
+        # Should be earlier or later by >=60 min from ideal
+        assert abs((slot - ideal).total_seconds()) >= 3600
+
+    def test_past_guard_causes_later_walk(self) -> None:
+        """When walking earlier would cross now+15min, falls through to later."""
+        # ideal is only 20 min after now → can't walk earlier at all
+        now = _local(2026, 6, 3, 9, 0)
+        ideal = _local(2026, 6, 3, 9, 30)   # only 30 min after now
+        deadline = _local(2026, 6, 6, 17, 0)
+        # Fill the ideal bucket
+        existing = [ideal, ideal]
+        slot, fallback = assign_slot(
+            ideal, existing, deadline,
+            user_tz=_TZ_STR,
+            quiet_hours=(22, 8),
+            slot_minutes=30,
+            slot_capacity=2,
+            max_drift_minutes=720,
+            now=now,
+        )
+        assert not fallback
+        # Must be later than ideal since earlier is blocked by the past guard
+        assert slot > ideal
+
+    def test_never_returns_slot_at_or_after_deadline(self) -> None:
+        """assign_slot never returns a slot >= deadline."""
+        ideal = _local(2026, 6, 3, 10, 0)
+        deadline = _local(2026, 6, 3, 11, 0)   # deadline only 1h after ideal
+        now = _local(2026, 6, 1, 8, 0)
+        # Fill every earlier bucket but leave ideal empty
+        slot, fallback = assign_slot(
+            ideal, [], deadline,
+            user_tz=_TZ_STR,
+            quiet_hours=(22, 8),
+            slot_minutes=30,
+            slot_capacity=2,
+            max_drift_minutes=720,
+            now=now,
+        )
+        assert slot < deadline
+
+    def test_all_slots_full_returns_fallback_true(self) -> None:
+        """When all slots within max_drift are full, returns (ideal, True)."""
+        ideal = _local(2026, 6, 3, 10, 0)
+        deadline = _local(2026, 6, 6, 17, 0)
+        now = _local(2026, 6, 1, 8, 0)
+        max_drift_minutes = 60  # only ±60 min search window
+        steps = max_drift_minutes // 30 + 1
+
+        # Pack every bucket within ±60 min (plus ideal itself)
+        existing: list[datetime] = []
+        for i in range(-steps, steps + 1):
+            t = ideal + timedelta(minutes=30 * i)
+            existing.extend([t, t])   # 2 per bucket → full
+
+        slot, fallback = assign_slot(
+            ideal, existing, deadline,
+            user_tz=_TZ_STR,
+            quiet_hours=(22, 8),
+            slot_minutes=30,
+            slot_capacity=2,
+            max_drift_minutes=max_drift_minutes,
+            now=now,
+        )
+        assert fallback is True
+        assert slot == ideal   # returns original ideal (not snapped) on fallback
+
+    def test_quiet_hours_6am_target_pushed_to_8am(self) -> None:
+        """Ideal at 6am is in quiet hours (22-8); assign_slot pushes to 8am."""
+        # ideal = 6am local (quiet hours 22-8 → 6am is quiet)
+        ideal = _local(2026, 6, 3, 6, 0)
+        deadline = _local(2026, 6, 6, 17, 0)
+        now = _local(2026, 6, 1, 8, 0)
+        slot, fallback = assign_slot(
+            ideal, [], deadline,
+            user_tz=_TZ_STR,
+            quiet_hours=(22, 8),
+            slot_minutes=30,
+            slot_capacity=2,
+            max_drift_minutes=720,
+            now=now,
+        )
+        assert not fallback
+        local_slot = slot.astimezone(_TZ)
+        assert local_slot.hour >= 8, f"Expected slot at or after 8am, got {local_slot.hour}:{local_slot.minute:02d}"
+
+    def test_high_urgency_small_drift_returns_fallback_sooner(self) -> None:
+        """max_drift=120 with packed schedule → fallback True sooner than default."""
+        ideal = _local(2026, 6, 3, 10, 0)
+        deadline = _local(2026, 6, 6, 17, 0)
+        now = _local(2026, 6, 1, 8, 0)
+        # Fill ±120 min with capacity=2 each
+        existing: list[datetime] = []
+        for i in range(-5, 6):
+            t = ideal + timedelta(minutes=30 * i)
+            existing.extend([t, t])
+
+        slot_small, fallback_small = assign_slot(
+            ideal, existing, deadline,
+            user_tz=_TZ_STR,
+            quiet_hours=(22, 8),
+            slot_minutes=30,
+            slot_capacity=2,
+            max_drift_minutes=120,
+            now=now,
+        )
+        assert fallback_small is True
+
+        # With default max_drift=720, the same schedule would have open slots
+        # (we only packed ±150 min worth of buckets, so outside that window is open)
+        slot_default, fallback_default = assign_slot(
+            ideal, existing, deadline,
+            user_tz=_TZ_STR,
+            quiet_hours=(22, 8),
+            slot_minutes=30,
+            slot_capacity=2,
+            max_drift_minutes=720,
+            now=now,
+        )
+        assert fallback_default is False
+
+
+# ---------------------------------------------------------------------------
+# format_reminder_summary — chronological order enforced
+# ---------------------------------------------------------------------------
+
+class TestFormatReminderSummary:
+
+    def test_three_slots_returned_chronologically(self) -> None:
+        """format_reminder_summary sorts slots by datetime ascending, regardless of input order.
+
+        The 4h slot (Thu 8am) is earlier than the 1d slot (Thu 9am) and the 3d slot (Wed noon).
+        Passing them in non-chronological order must still produce ascending output.
+        """
+        wed_noon = _local(2026, 6, 3, 12, 0)   # Wed noon — earliest
+        thu_9am  = _local(2026, 6, 4, 9, 0)    # Thu 9am — middle
+        thu_8am  = _local(2026, 6, 4, 8, 0)    # Thu 8am — also earlier than thu_9am
+
+        # Pass in non-chronological order (as PR 600 had them — 9am before 8am)
+        slots_non_chron = [
+            ("3d", wed_noon),
+            ("1d", thu_9am),
+            ("4h", thu_8am),
+        ]
+        result = format_reminder_summary(slots_non_chron, user_tz=_TZ_STR)
+        # Chronological order: Wed noon → Thu 8am → Thu 9am
+        assert result == "I'll ping you Wed noon, Thu 8am, Thu 9am."
+
+    def test_one_slot(self) -> None:
+        """Single slot → singular form."""
+        slots = [("4h", _local(2026, 6, 5, 8, 0))]
+        result = format_reminder_summary(slots, user_tz=_TZ_STR)
+        assert result.startswith("I'll ping you ")
+        assert result.endswith(".")
+
+    def test_empty_returns_empty_string(self) -> None:
+        """Empty slot list → empty string."""
+        result = format_reminder_summary([], user_tz=_TZ_STR)
+        assert result == ""
+
+    def test_midnight_label(self) -> None:
+        """Slot at midnight → 'midnight', not '12am'."""
+        slots = [("4h", _local(2026, 6, 3, 0, 0))]  # Wednesday midnight
+        result = format_reminder_summary(slots, user_tz=_TZ_STR)
+        assert "midnight" in result
+        assert "12am" not in result
+
+    def test_noon_label(self) -> None:
+        """Slot at noon → 'noon', not '12pm'."""
+        slots = [("3d", _local(2026, 6, 3, 12, 0))]  # Wednesday noon
+        result = format_reminder_summary(slots, user_tz=_TZ_STR)
+        assert "noon" in result
+        assert "12pm" not in result
+
+    def test_am_pm_formatting(self) -> None:
+        """Regular hours format correctly as Xam / Xpm."""
+        slots_am = [("1d", _local(2026, 6, 4, 9, 0))]
+        slots_pm = [("1d", _local(2026, 6, 4, 21, 0))]
+        assert "9am" in format_reminder_summary(slots_am, user_tz=_TZ_STR)
+        assert "9pm" in format_reminder_summary(slots_pm, user_tz=_TZ_STR)
+
+    def test_minute_suffix_included_when_nonzero(self) -> None:
+        """Times with non-zero minutes include the minute portion."""
+        slots = [("4h", _local(2026, 6, 4, 9, 30))]
+        result = format_reminder_summary(slots, user_tz=_TZ_STR)
+        assert "9:30am" in result
+
+    def test_tz_conversion_applied(self) -> None:
+        """Datetimes are converted to user_tz before formatting."""
+        # 15:00 UTC = 10:00 CDT (America/Chicago, UTC-5 in June)
+        dt_utc = _utc(2026, 6, 3, 15, 0)
+        slots = [("3d", dt_utc)]
+        result = format_reminder_summary(slots, user_tz=_TZ_STR)
+        assert "10am" in result
+
+    def test_already_sorted_input_stays_sorted(self) -> None:
+        """Already-sorted input produces the same chronological output."""
+        wed_noon = _local(2026, 6, 3, 12, 0)
+        thu_8am  = _local(2026, 6, 4, 8, 0)
+        thu_9am  = _local(2026, 6, 4, 9, 0)
+
+        slots_chron = [("3d", wed_noon), ("4h", thu_8am), ("1d", thu_9am)]
+        result = format_reminder_summary(slots_chron, user_tz=_TZ_STR)
+        assert result == "I'll ping you Wed noon, Thu 8am, Thu 9am."

--- a/tests/unit/test_reachability.py
+++ b/tests/unit/test_reachability.py
@@ -57,6 +57,9 @@ _ENTRY_POINTS: frozenset[str] = frozenset(
         "run_state_audit",  # func=run_state_audit in JobSpec
         "generate_weekly_recap",  # func=generate_weekly_recap in JobSpec
         "dispatch_check_ins",  # func=dispatch_check_ins in JobSpec
+        "run_reminder_scheduler_job",  # func=run_reminder_scheduler_job in JobSpec
+        # app/scheduler/reminder_scheduler.py — called from jobs.run_reminder_scheduler_job
+        "run_reminder_scheduler",  # invoked by run_reminder_scheduler_job
         # app/ingress/signal_listener.py — called by main.py via asyncio.run()
         "run",  # asyncio.run(run()) in main.py
     ]

--- a/tests/unit/test_reminder_worker.py
+++ b/tests/unit/test_reminder_worker.py
@@ -74,3 +74,94 @@ async def test_dispatch_due_reminders_accepts_native_uuid_rows(
     complete_reminder.assert_awaited_once_with("<page-id>", "sent")
     assert conn.rollbacks == 0
     assert any(params is not None and params[-1] == str(reminder_id) for _, params in conn.executed)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_skips_complete_reminder_for_deadline_kind(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CRITICAL: rows with kind='deadline' must NOT trigger
+    notion.complete_reminder. Without this branch, the worker would silently
+    mark the user's task as Completed on the first deadline ping (the page
+    id is the user's task page id, not a dedicated reminder page).
+
+    This guards the d-001 design collision from closed PR #601.
+    """
+    from app.scheduler import reminder_worker
+    from app.tools import notion
+
+    reminder_id = uuid.uuid4()
+    idempotency_key = "deadline-<page-id>-3d-2026-06-01T17:00:00+00:00"
+    row = {
+        "id": reminder_id,
+        "peer": "<peer>",
+        "body": "Task placeholder is coming up in 3 days - want to start now?",
+        "notion_page_id": "<page-id>",
+        "idempotency_key": idempotency_key,
+        "attempt": 0,
+        "due_at": datetime.now(UTC) - timedelta(seconds=1),
+        "kind": "deadline",
+    }
+
+    async def fake_claim_due_reminders(
+        conn: Any,
+        worker_id: str,
+    ) -> list[dict[str, Any]]:
+        return [row]
+
+    monkeypatch.setattr(reminder_worker, "_claim_due_reminders", fake_claim_due_reminders)
+    complete_reminder = AsyncMock(return_value={})
+    monkeypatch.setattr(notion, "complete_reminder", complete_reminder)
+
+    signal_send = AsyncMock(return_value={"timestamp": 12345})
+    conn = FakeConnection()
+
+    await reminder_worker.dispatch_due_reminders(conn, signal_send_fn=signal_send)
+
+    signal_send.assert_awaited_once()
+    # The whole point of the test: complete_reminder must NOT be called for
+    # a deadline-kind row, because notion_page_id is the user's task page id
+    # and complete_reminder would set Status=Completed.
+    complete_reminder.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_treats_missing_kind_as_reminder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy rows that pre-date migration 0008 may surface with no `kind`
+    field on the row dict; the worker must default to 'reminder' to preserve
+    existing wall-clock completion behavior."""
+    from app.scheduler import reminder_worker
+    from app.tools import notion
+
+    reminder_id = uuid.uuid4()
+    row = {
+        "id": reminder_id,
+        "peer": "<peer>",
+        "body": "Legacy reminder",
+        "notion_page_id": "<legacy-page>",
+        "idempotency_key": str(uuid.uuid4()),
+        "attempt": 0,
+        "due_at": datetime.now(UTC) - timedelta(seconds=1),
+        # No `kind` key — simulates a row missing the column at the dict
+        # mapping level.
+    }
+
+    async def fake_claim_due_reminders(
+        conn: Any,
+        worker_id: str,
+    ) -> list[dict[str, Any]]:
+        return [row]
+
+    monkeypatch.setattr(reminder_worker, "_claim_due_reminders", fake_claim_due_reminders)
+    complete_reminder = AsyncMock(return_value={})
+    monkeypatch.setattr(notion, "complete_reminder", complete_reminder)
+
+    signal_send = AsyncMock(return_value={"timestamp": 12345})
+    conn = FakeConnection()
+
+    await reminder_worker.dispatch_due_reminders(conn, signal_send_fn=signal_send)
+
+    # Default behavior is preserved — legacy rows complete the task.
+    complete_reminder.assert_awaited_once_with("<legacy-page>", "sent")


### PR DESCRIPTION
## Summary

Redesigned, smaller follow-up to closed PR #601. Ships the core
deadline-reminders capability correctly. All 7 reviewer blockers from the
closed PR are addressed — 5 fixed structurally, 2 resolved by scope trim.

**File count:** 18 (vs 22 on closed PR). **Diff:** +2949 / -25.

## What's in scope

- **Migration 0008** — adds `reminder_outbox.kind` discriminator (`'reminder' | 'deadline'`, default `'reminder'`) with a CHECK constraint. **Cornerstone fix for `design/d-001`.** Without this column, `reminder_worker.dispatch_due_reminders` calls `notion.complete_reminder(notion_page_id, "sent")` after every successful delivery — which would silently mark the user's task Completed on the very first deadline ping (deadline rows set `notion_page_id` to the task page id).
- **`app/scheduler/reminder_worker.py`** — branches on `kind`. Only `kind='reminder'` rows trigger `notion.complete_reminder`; `kind='deadline'` rows just deliver. Legacy rows (no `kind` field on the row dict) default to `'reminder'` so existing wall-clock behavior is preserved.
- **`app/scheduler/deadline_planner.py`** — pure-function tier table (dense/standard/sparse), `plan_milestones`, load-balanced `assign_slot` (quiet-hours-aware), `format_reminder_summary` (sorts chronologically before formatting). Env-tunable defaults via `REMINDER_SLOT_MINUTES`, `REMINDER_SLOT_CAPACITY`, `REMINDER_QUIET_START_HOUR`, `REMINDER_QUIET_END_HOUR`.
- **`app/scheduler/reminder_scheduling.py`** — shared `schedule_for_task` helper used by intake (inline) and the daemon. Enqueues outbox rows with `kind='deadline'`, inserts ledger rows. Exposes `supersede_ledger_rows`, `cancel_outbox_rows`, `get_active_deadline_for_page`.
- **`app/scheduler/reminder_scheduler.py`** — nightly backstop daemon (04:00 user TZ). **DUAL Notion query — fixes `doc-001` / `d-002`:** orphan catch-up (`Reminder Scheduled At is_empty`) AND edit detection (`is_not_empty` + cross-check current Notion `Due At` against ledger's `deadline_at` with ±60s tolerance). When an edit is detected: supersede ledger rows, mark outbox rows dead, schedule a fresh series.
- **`app/tools/notion.py`** — adds `query_scheduled_tasks_with_deadlines` verb (counterpart to the existing unscheduled-deadline query) for the edit-detection path.
- **`app/tools/reminders.py`** — `enqueue` takes a `kind` parameter (default `'reminder'`).
- **`app/graph/nodes/intake.py`** — adds deadline detection + inline scheduling. **Privacy-safe parse-failure logging (fixes `sec-001`):** logs only flags (`has_due_at`, `parse_failed`), never the raw value or a Python exception message that might echo the input. **No infra/retry state leaked on failure (fixes `psy-001`):** when `schedule_for_task` fails the user sees a clean confirmation; the daemon silently picks the task up on its next run. On success the confirmation gets the deterministic reminder summary (`"I'll ping you Wed noon, Thu 9am."`) computed from `assigned_slots`, not the LLM.
- **`app/prompts/intake.md.j2`** — minimal addition: `DEADLINE DETECTION` block and `due_at` in the output schema. Existing sub-task default and confirmation format are left untouched (deferred to a follow-up; avoids the `prm-001`/`prm-002` drift cascade that hit the previous PR).
- **Tests** — 31 deadline-planner unit tests (with chronological-sort regression), 7 real-Postgres round-trip tests for `schedule_for_task` and the ledger helpers (**fixes `tst-001`** — clause 1 of the test-rig contract requires real-DB coverage for UUID + timestamp fields), 4 daemon integration tests covering the dual-query edit-detection path explicitly, 4 intake integration tests asserting the privacy-safe and shame-safe contracts, 2 worker unit tests guarding the kind-branching invariant.
- **DEV-AGENTS.md** — inventory entries for every new file. **Minimal `docs/architecture.md`** update: one row in the Scheduled Jobs table for `reminder_scheduler`.

## What's deferred to follow-up PRs

Cutting these from scope made the diff tighter, the review surface smaller, and avoided the spec-drift cascades that the previous PR triggered.

- **Stakes detection + clarification question** for life/health/legal/financial tasks. High value, but adds a new clarification path and intake-prompt complexity. Worth its own PR with its own psych review.
- **Drop-default sub-task generation.** Orthogonal to deadline reminders. Touching it now would force `docs/user-interactions.md` + `docs/task-lifecycle.md` updates and create the exact `prm-001`/`prm-002`/`doc-002`/`doc-003`/`psy-003` cascade that drove this redesign.
- **Confirmation format rewrite (`"Saved — ..."`).** Kept the existing format. Just append the deterministic reminder summary when `due_at` is set.

## Why `d-001` is fixed

Migration 0008 adds `kind TEXT NOT NULL DEFAULT 'reminder' CHECK (kind IN ('reminder','deadline'))` to `reminder_outbox`. `reminder_scheduling.schedule_for_task` enqueues with `kind='deadline'`. `reminder_worker.dispatch_due_reminders` reads `row.get("kind") or "reminder"` and skips `notion.complete_reminder` when `kind == "deadline"`. Existing wall-clock reminder rows continue to work unchanged (default column value preserves legacy behavior).

Unit test `test_dispatch_skips_complete_reminder_for_deadline_kind` asserts this directly: with `kind='deadline'`, `complete_reminder.assert_not_awaited()`. The companion test `test_dispatch_treats_missing_kind_as_reminder` asserts legacy compatibility.

## Why `doc-001` / `d-002` is fixed

`reminder_scheduler._run_once` calls BOTH `notion.query_tasks_with_unscheduled_deadlines` (orphan catch-up) AND `notion.query_scheduled_tasks_with_deadlines` (edit detection). The second query is the explicit fix for the previous design's blind spot — already-scheduled tasks now flow through `_detect_and_reschedule_edit`, which compares current Notion `Due At` against the ledger's `deadline_at` with a 60-second tolerance and reschedules on drift.

Integration test `test_daemon_detects_deadline_edit_and_reschedules` seeds a schedule against an old deadline, mocks Notion to return the task with a new deadline, and asserts: old ledger rows superseded, old outbox rows marked dead, new outbox rows with idempotency keys encoding the new deadline.

## Validation

- 250 unit tests pass (including 31 new deadline-planner tests and 2 new worker kind-branching tests).
- 34 targeted integration tests pass against real Postgres (`test_reminder_scheduling`, `test_reminder_scheduler`, `test_intake_deadlines`, `test_intake`, `test_reminder_ledger_schema`, `test_notion_due_at`).
- `ruff check app/ tests/ migrations/` — clean.
- `mypy app/ --ignore-missing-imports` — clean (38 source files).
- 2 pre-existing integration failures (`test_outbox::test_retry_on_signal_failure`, `test_scheduler::test_orphan_job_removed_on_reconcile`) reproduce on `main` and are NOT caused by this PR.

## Test plan

- [ ] `pytest tests/unit/test_deadline_planner.py -v` — 31 algorithm tests
- [ ] `pytest tests/unit/test_reminder_worker.py -v` — kind-branching invariant
- [ ] `DATABASE_URL=... pytest tests/integration/test_reminder_scheduling.py -v` — 7 real-Postgres round-trip tests for `schedule_for_task` + ledger helpers
- [ ] `DATABASE_URL=... pytest tests/integration/test_reminder_scheduler.py -v` — 4 daemon tests including dual-query edit detection
- [ ] `pytest tests/integration/test_intake_deadlines.py -v` — 4 intake tests covering privacy-safe and shame-safe contracts

🤖 Generated with [Claude Code](https://claude.com/claude-code)