### PR TITLE
fix(intake): uncap reasoning-tier output + stop faking success on parse failure

### DIFF
--- a/app/graph/nodes/intake.py
+++ b/app/graph/nodes/intake.py
@@ -84,6 +84,11 @@ async def intake_node(state: State) -> dict[str, Any]:
 
         parsed = _parse_intake_response(response_text)
 
+        if parsed is None:
+            # Unparseable model output (e.g. truncated mid-JSON). Do not fake a
+            # success: preserve capture, alert the operator, tell the truth.
+            return await _handle_parse_failure(peer=peer, incoming=incoming)
+
         if parsed.get("action") == "clarify":
             question = parsed.get("clarification_question", "Which task are you thinking of?")
             draft = {
@@ -166,12 +171,73 @@ async def intake_node(state: State) -> dict[str, Any]:
 
     except Exception:
         log.exception("intake_node.error", peer=peer)
+        # Something raised before the task was stored. Do not claim success —
+        # nothing was saved. Alert the operator and ask the user to resend.
+        try:
+            from app.tools import ops_alerts
+            await ops_alerts.enqueue(
+                kind="intake_node_error",
+                body="Intake node raised before saving; the task was not stored. See logs.",
+                severity="warning",
+            )
+        except Exception:
+            log.exception("intake_node.error.ops_alert_failed", peer=peer)
         fallback: OutboundDraft = {
             "recipient": peer,
-            "body": "Got it, I'll add that to your list.",
+            "body": "Something hiccupped on my end with that one — mind sending it again?",
             "notion_page_id": None,
         }
         return {"pending_outbound": [fallback]}
+
+
+async def _handle_parse_failure(*, peer: str, incoming: str) -> dict[str, Any]:
+    """Handle an unparseable intake LLM response without faking success.
+
+    Preserves capture by saving the user's raw message as a plain task — titled
+    from their own words, never the garbled model output — alerts the operator
+    so model degradation is visible, and returns an honest confirmation that
+    flags the un-captured timing. Never claims a reminder was set.
+    """
+    from app.tools import notion
+
+    log.error("intake_node.parse_failed", peer=peer)
+
+    page_id: str | None = None
+    try:
+        notion_page = await notion.create_task(
+            title=incoming[:200],
+            work_type="focus",
+            urgency=50,
+            time_estimate=30,
+            energy_required="Medium",
+        )
+        page_id = (notion_page or {}).get("id")
+    except Exception:
+        log.exception("intake_node.parse_failed.raw_save_failed", peer=peer)
+
+    try:
+        from app.tools import ops_alerts
+        await ops_alerts.enqueue(
+            kind="intake_parse_failed",
+            body=(
+                "Intake LLM returned unparseable output; saved a raw task with no "
+                "labels or reminder. Model may be truncating or degraded."
+            ),
+            severity="warning",
+        )
+    except Exception:
+        log.exception("intake_node.parse_failed.ops_alert_failed", peer=peer)
+
+    draft: OutboundDraft = {
+        "recipient": peer,
+        "body": (
+            "Added that to your list. I couldn't quite pin down the timing on that "
+            "one though — if there's a deadline or a time you want a nudge, send it "
+            "again and I'll set the reminder."
+        ),
+        "notion_page_id": page_id,
+    }
+    return {"pending_outbound": [draft], "conversation_state": "idle"}
 
 
 async def _create_reminder(
@@ -251,9 +317,15 @@ def _parse_remind_at(remind_at_str: str) -> datetime:
         raise ValueError(f"Cannot parse remind_at: {remind_at_str!r}") from exc
 
 
-def _parse_intake_response(response_text: str) -> dict[str, Any]:
-    """Extract JSON from LLM intake response."""
-    # Try to find a JSON block
+def _parse_intake_response(response_text: str) -> dict[str, Any] | None:
+    """Extract JSON from an LLM intake response.
+
+    Returns None when no JSON object can be parsed — e.g. the response was
+    truncated at the output-token ceiling, or the model returned prose. The
+    caller MUST treat None as a parse failure, never as a non-reminder task: a
+    fabricated default here would let a dropped reminder masquerade as a
+    confirmed plain task (the exact bug this guards against).
+    """
     json_match = re.search(r"\{.*\}", response_text, re.DOTALL)
     if json_match:
         try:
@@ -263,21 +335,7 @@ def _parse_intake_response(response_text: str) -> dict[str, Any]:
         except json.JSONDecodeError:
             pass
 
-    # Fallback: return a save action with the raw text as title
-    return {
-        "action": "save",
-        "title": response_text[:200],
-        "work_type": "focus",
-        "urgency": 50,
-        "time_estimate_minutes": 30,
-        "energy_required": "Medium",
-        "is_reminder": False,
-        "remind_at": None,
-        "use_hidden_subtasks": False,
-        "sub_tasks": [],
-        "inline_steps": "",
-        "confirmation_message": "Got it — added.",
-    }
+    return None
 
 
 def _build_prefs_context(user_prefs: Mapping[str, object]) -> str:

--- a/app/models.py
+++ b/app/models.py
@@ -5,13 +5,18 @@ a single llm(tier) factory function. Validates model IDs at startup.
 
 Tiers (model alias resolves via setup/model-tiers.json; per-tier reasoning
 behavior is set here):
-  expensive -> gemma4-small, think=on  (GET_TASK scoring; nuance matters)
-  medium    -> gemma4-small, think=on  (user-facing replies; shame-safety
-                                        contract depends on careful phrasing)
-  cheap     -> gemma4-small, think=off (label-only classification; reasoning
-                                        is wasted overhead — significant token
-                                        reduction at equivalent accuracy)
-  reminder  -> gemma4-small, think=on  (reminder cron; currently no caller)
+  expensive -> gemma4-small, think=on,  uncapped (GET_TASK scoring; nuance matters)
+  medium    -> gemma4-small, think=on,  uncapped (user-facing replies + intake's
+                                        structured JSON; shame-safety contract
+                                        depends on careful phrasing)
+  cheap     -> gemma4-small, think=off, max_tokens=1024 (label-only
+                                        classification; reasoning is wasted
+                                        overhead and a small cap is free safety)
+  reminder  -> gemma4-small, think=on,  uncapped (reminder cron; currently no caller)
+
+Reasoning tiers send no max_tokens: think+JSON output must not be truncated, or
+the partial JSON fails to parse and a reminder is silently dropped. Only the
+label-only cheap tier carries an output cap (see _TIER_MAX_TOKENS).
 
 All tiers point at the same model alias because the LLM host can only
 hold one Gemma model in RAM at a time. Differentiation lives entirely
@@ -61,6 +66,17 @@ _VALID_MODEL_PREFIXES: tuple[str, ...] = ("claude-", "gemma", "gpt-")
 # classify prompt.
 _TIER_EXTRA_BODY: dict[str, dict[str, Any]] = {
     "cheap": {"think": False},
+}
+
+# Per-tier output-token cap. Only the cheap tier is capped: its sole caller
+# (intent classifier) emits a single label, so a small ceiling is free safety.
+# Reasoning tiers (expensive/medium/reminder) are intentionally absent — they
+# run think=on and emit structured JSON (e.g. intake's full task object), and a
+# cap truncates that output mid-JSON. Truncated JSON then fails to parse and the
+# task is silently saved without its reminder. Tokens are cheap; correctness is
+# not — so reasoning tiers send no max_tokens and let the model finish.
+_TIER_MAX_TOKENS: dict[str, int] = {
+    "cheap": 1024,
 }
 
 
@@ -181,10 +197,12 @@ def llm(tier: Tier, *, temperature: float = 0.0, caller: str | None = None) -> C
     kwargs: dict[str, Any] = {
         "model": model_id,
         "temperature": temperature,
-        "max_tokens": 1024,
         "base_url": base_url,
         "api_key": api_key,
     }
+    max_tokens = _TIER_MAX_TOKENS.get(tier)
+    if max_tokens is not None:
+        kwargs["max_tokens"] = max_tokens
     extra_body = _TIER_EXTRA_BODY.get(tier)
     if extra_body:
         kwargs["extra_body"] = extra_body

--- a/tests/evals/fixtures/intake/remind_deadline_before_time.yaml
+++ b/tests/evals/fixtures/intake/remind_deadline_before_time.yaml
@@ -1,0 +1,42 @@
+---
+# Bug-class 5 surface: a reminder phrased as a DEADLINE with no explicit
+# "remind me" trigger word — "<chore> <weekday> before <time>". Intake
+# must still return is_reminder=true with a parseable remind_at at the
+# named wall-clock deadline, so the outbox/ledger gets a row and the
+# reminder fires.
+#
+# An underpowered medium-tier model (observed: gemma4-small) cannot emit
+# intake's structured JSON for this phrasing: it runs to the output-token
+# ceiling and produces truncated/unparseable JSON. intake_node's
+# _parse_intake_response then SILENTLY falls back to a default dict with
+# is_reminder=false / remind_at=null, takes the no_reminder branch, saves
+# a plain task, and replies "Got it — added." No reminder is ever
+# scheduled — the user believes one was. This fixture catches that:
+# a capable model confirms a reminder; the fallback's generic
+# "added" confirmation fails the regex_require below.
+id: intake-remind-deadline-before-time-001
+node: intake
+tier: medium
+peer: "<test-peer-5>"
+inbound: "I need to clean the kitchen Friday before 10pm"
+prior_state:
+  active_task: null
+  conversation_state: idle
+  user_prefs:
+    timezone: America/Chicago
+contracts:
+  # Deterministic discriminator: the user-visible confirmation must
+  # acknowledge a reminder. The silent-fallback path emits only
+  # "Got it — added." (no reminder language) and fails here.
+  - kind: regex_require
+    pattern: "(?i)(remind|reminder)"
+  - kind: judge
+    rubric: |
+      The user-visible response confirms a reminder/nudge was set for the
+      stated deadline (Friday, before ~10pm) AND names what it is for
+      (cleaning the kitchen). It does NOT merely confirm a task was added
+      without a reminder, and does NOT mention internal infrastructure
+      (cron, worker, queue, outbox). Score 1.0 when it confirms a
+      deadline reminder for the task, 0.5 for a reminder without the
+      deadline or task, 0.0 for a task-only "added" confirmation.
+    threshold: 0.7

--- a/tests/integration/test_intake.py
+++ b/tests/integration/test_intake.py
@@ -330,3 +330,82 @@ async def test_intake_clarify_response_when_vague() -> None:
     assert result["pending_outbound"]
     body = result["pending_outbound"][0]["body"]
     assert "which" in body.lower() or "thing" in body.lower() or "?" in body
+
+
+@pytest.mark.asyncio
+async def test_unparseable_output_saves_raw_task_and_alerts() -> None:
+    """A truncated/garbled LLM response must NOT masquerade as a confirmed task.
+
+    Regression for the intake reminder-drop: when the model output is
+    unparseable (e.g. truncated at the output-token ceiling), the node must
+    (1) preserve capture by saving a raw task titled from the user's own
+    words, (2) never claim a reminder was set, and (3) emit an ops alert so
+    the operator sees the model degradation. The old behavior silently saved
+    a plain task titled with the garbled LLM text and replied "Got it — added."
+    """
+    page_id = str(uuid.uuid4())
+    incoming = "I need to clean the kitchen Friday before 10pm"
+    # Truncated JSON: opening brace, cut off mid-value, no closing brace.
+    truncated = '{"action": "save", "title": "clean the kitchen", "is_reminder": tr'
+
+    create_task_calls: list[dict] = []
+    create_reminder_calls: list[dict] = []
+    alert_calls: list[dict] = []
+
+    async def mock_create_task(**kwargs: Any) -> dict:
+        create_task_calls.append(kwargs)
+        return _make_notion_page(page_id=page_id, title="Placeholder task")
+
+    async def mock_create_reminder(**kwargs: Any) -> dict:
+        create_reminder_calls.append(kwargs)
+        return _make_notion_page(page_id=page_id)
+
+    async def mock_alert(*, kind: str, body: str, severity: str = "warning", **_: Any) -> Any:
+        alert_calls.append({"kind": kind, "body": body, "severity": severity})
+        return uuid.uuid4()
+
+    with (
+        patch("app.tools.notion.create_task", side_effect=mock_create_task),
+        patch("app.tools.notion.create_reminder", side_effect=mock_create_reminder),
+        patch("app.tools.ops_alerts.enqueue", side_effect=mock_alert),
+    ):
+        mock_llm_response = MagicMock()
+        mock_llm_response.content = truncated
+        mock_model = AsyncMock()
+        mock_model.ainvoke = AsyncMock(return_value=mock_llm_response)
+
+        with patch("app.models.llm", return_value=mock_model):
+            from app.graph.nodes.intake import intake_node
+
+            state: State = {
+                "peer": "<test-intake-unparseable>",
+                "incoming": incoming,
+                "intent": "ADD_TASK",
+                "messages": [],
+                "active_task": None,
+                "streak": 0,
+                "tasks_completed_today": 0,
+                "user_prefs": {},
+                "mood": None,
+                "available_minutes": None,
+                "conversation_state": "idle",
+                "pending_outbound": [],
+            }
+
+            result = await intake_node(state)
+
+    # Raw task saved, titled from the user's words — NOT the garbled LLM output.
+    assert len(create_task_calls) == 1
+    assert create_task_calls[0]["title"] == incoming
+    assert "is_reminder" not in create_task_calls[0]["title"]
+    # No reminder was fabricated.
+    assert len(create_reminder_calls) == 0
+    # Operator was alerted to the parse failure.
+    assert len(alert_calls) == 1
+    assert alert_calls[0]["kind"] == "intake_parse_failed"
+    # User got an honest message — not a bare "Got it — added." false success,
+    # and it flags that the timing/reminder wasn't captured.
+    assert result["pending_outbound"]
+    body = result["pending_outbound"][0]["body"].lower()
+    assert body.strip() != "got it — added."
+    assert "remind" in body or "timing" in body or "time" in body

--- a/tests/regressions/bug_0603_intake_truncation_silent_fallback/README.md
+++ b/tests/regressions/bug_0603_intake_truncation_silent_fallback/README.md
@@ -1,0 +1,64 @@
+# Bug 0603: Intake silently drops reminders on truncated LLM output
+
+**Issue:** #603
+
+## Bug Story
+
+A task phrased as a deadline reminder (`<chore> <weekday> before <time>`) was
+acknowledged by intake ("Got it — added.") but **no reminder was ever
+scheduled** — no `reminder_outbox` / `reminder_scheduling_ledger` row was
+created, so nothing fired. Two stacked bugs caused it:
+
+1. **Trigger — output-token cap truncates intake.** `app/models.py` hardcoded
+   `max_tokens: 1024` for every tier. That was a sane default under the original
+   `ChatAnthropic` backend (concise; intake JSON ~240 tokens) and rode through
+   the swap to a local reasoning model unexamined. On the `medium` tier
+   (`think=on`) the model spent its 1024-token budget on reasoning and was cut
+   off mid-JSON; every intake call returned `output_tokens: 1024` exactly.
+2. **Mask — parse fallback fabricates success.** `_parse_intake_response`
+   silently returned a default dict (`is_reminder=False`,
+   `confirmation="Got it — added."`) when the output would not parse. The node
+   saved a plain task with no reminder and confirmed success. The outer `except`
+   had the same lie-on-failure shape.
+
+Structural/unit tests with mocked-clean JSON could not catch this: the failure
+only appears when the *model* returns malformed output, and the parser disguised
+that as a normal non-reminder task.
+
+## Fix
+
+- `app/models.py`: per-tier `max_tokens` (`_TIER_MAX_TOKENS`). Reasoning tiers
+  (expensive/medium/reminder) send no cap; only the label-only `cheap` tier is
+  capped, so structured-JSON output is never truncated.
+- `app/graph/nodes/intake.py`: `_parse_intake_response` returns `None` on parse
+  failure; `intake_node` saves the user's **raw message** as a plain task
+  (preserve capture), emits an `intake_parse_failed` ops alert, and returns an
+  honest confirmation that flags the un-captured timing — never fakes a reminder.
+
+## Regression Tests
+
+**Output-cap (unit):** test lives in `tests/unit/test_models.py` —
+`test_max_tokens_per_tier` asserts reasoning tiers send no `max_tokens` and
+`cheap` keeps its cap; `test_llm_constructs_chatopenai_with_expected_kwargs`
+asserts the `medium` tier carries no cap.
+
+**Parser (unit):** test lives in `tests/unit/test_intake_parse.py` — truncated
+and non-JSON responses return `None`; valid JSON returns a dict.
+
+**Node behavior (integration):** test lives in
+`tests/integration/test_intake.py` —
+`test_unparseable_output_saves_raw_task_and_alerts` asserts a raw task is saved
+titled from the user's words, no reminder is fabricated, an `intake_parse_failed`
+ops alert is emitted, and the user-visible message is honest (not "Got it —
+added.").
+
+**Cross-model efficacy (eval, live-gated):** the regression fixture lives at
+`tests/evals/fixtures/intake/remind_deadline_before_time.yaml`, exercised by
+`tests/evals/test_evals.py`. A capable model confirms a reminder for the
+deadline; an underpowered model that truncates fails the `regex_require`. Run on
+demand:
+
+```
+ENABLE_LIVE_LLM_EVALS=true EVAL_MODELS=claude-sonnet-4-6 \
+  pytest tests/evals/test_evals.py -k remind_deadline_before_time -v
+```

--- a/tests/unit/test_intake_parse.py
+++ b/tests/unit/test_intake_parse.py
@@ -1,0 +1,51 @@
+"""Unit tests for intake's response parser.
+
+`_parse_intake_response` must distinguish a parseable LLM response from an
+unparseable one. The bug this guards against: when the parser could not extract
+JSON it silently returned a fabricated default dict (is_reminder=False,
+confirmation="Got it — added."), so a truncated/garbled model response was
+indistinguishable from a real "plain task" and any reminder in the message was
+silently dropped. The parser must now return None on failure so the node can
+handle it honestly (raw-save + ops alert + truthful confirmation).
+"""
+from __future__ import annotations
+
+import json
+
+from app.graph.nodes.intake import _parse_intake_response
+
+
+def test_valid_json_returns_dict() -> None:
+    payload = {
+        "action": "save",
+        "title": "Placeholder task",
+        "is_reminder": True,
+        "remind_at": "2026-01-02T17:00:00-06:00",
+        "confirmation_message": "Got it — I'll remind you at 5pm.",
+    }
+    parsed = _parse_intake_response(json.dumps(payload))
+    assert parsed is not None
+    assert parsed["action"] == "save"
+    assert parsed["is_reminder"] is True
+    assert parsed["remind_at"] == "2026-01-02T17:00:00-06:00"
+
+
+def test_json_embedded_in_prose_is_extracted() -> None:
+    text = 'Here is the result:\n{"action": "save", "title": "x"}\nDone.'
+    parsed = _parse_intake_response(text)
+    assert parsed is not None
+    assert parsed["title"] == "x"
+
+
+def test_truncated_json_returns_none() -> None:
+    """A response cut off at the output-token ceiling has no closing brace."""
+    truncated = '{"action": "save", "title": "clean the fountain", "is_reminder": tr'
+    assert _parse_intake_response(truncated) is None
+
+
+def test_non_json_prose_returns_none() -> None:
+    assert _parse_intake_response("Sure, I can help you set that up!") is None
+
+
+def test_empty_response_returns_none() -> None:
+    assert _parse_intake_response("") is None

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -155,9 +155,51 @@ def test_llm_constructs_chatopenai_with_expected_kwargs() -> None:
             call_kwargs = mock_cls.call_args.kwargs
             assert call_kwargs["model"] == expected_model
             assert call_kwargs["temperature"] == 0.0
-            assert call_kwargs["max_tokens"] == 1024
+            # medium is a reasoning tier: it must NOT carry an output-token cap.
+            # A cap (formerly hardcoded 1024) truncates intake's think+JSON and
+            # the truncated output silently falls back to a non-reminder task.
+            assert "max_tokens" not in call_kwargs
             assert call_kwargs["base_url"] == "https://proxy.test/v1"
             assert call_kwargs["api_key"] == "test-key"
+
+    models_module._load_model_tiers.cache_clear()
+
+
+def test_max_tokens_per_tier() -> None:
+    """Reasoning tiers send NO max_tokens; only the label-only cheap tier is capped.
+
+    The output-token cap was a Claude-era default that truncated gemma4-small's
+    think+structured-JSON intake output. Reasoning tiers (medium/expensive/reminder)
+    must let the model finish; cheap (intent classifier) only emits a label and
+    keeps a small cap.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from app import models as models_module
+
+    fake_instance = MagicMock()
+    fake_instance.with_config.return_value = fake_instance
+
+    env = {k: v for k, v in os.environ.items() if k not in ("LANGSMITH_TRACING",)}
+    env["LLM_PROXY_BASE_URL"] = "https://proxy.test/v1"
+    env["LLM_PROXY_API_KEY"] = "test-key"
+
+    with patch.dict(os.environ, env, clear=True):
+        for tier in ("medium", "expensive", "reminder"):
+            models_module._load_model_tiers.cache_clear()
+            with patch("app.models.ChatOpenAI", return_value=fake_instance) as mock_cls:
+                models_module.llm(tier, caller="test")
+                assert "max_tokens" not in mock_cls.call_args.kwargs, (
+                    f"{tier} tier must not cap output tokens; "
+                    f"got {mock_cls.call_args.kwargs.get('max_tokens')!r}"
+                )
+
+        models_module._load_model_tiers.cache_clear()
+        with patch("app.models.ChatOpenAI", return_value=fake_instance) as mock_cls:
+            models_module.llm("cheap", caller="test")
+            assert mock_cls.call_args.kwargs.get("max_tokens") == 1024, (
+                "cheap tier (label-only classifier) keeps a small output cap"
+            )
 
     models_module._load_model_tiers.cache_clear()
 


### PR DESCRIPTION
## Problem

A deadline-style reminder (`<chore> <weekday> before <time>`) was acknowledged by intake ("Got it — added.") but **never scheduled** — no `reminder_outbox` / `reminder_scheduling_ledger` row was written, so it never fired. Two stacked bugs:

1. **Trigger — output cap truncates intake.** `app/models.py` hardcoded `max_tokens: 1024` for *every* tier (a `ChatAnthropic`-era default that rode through the swap to a local reasoning model unexamined). On the `medium` tier (`think=on`) the model spent its 1024-token budget on reasoning and was cut off mid-JSON — every intake call returned `output_tokens: 1024` exactly. The model's context window is 256K, so the **output cap, not the window, was the sole binding limit**.
2. **Mask — parse fallback fabricates success.** `_parse_intake_response` silently returned a default dict (`is_reminder=False`, `confirmation="Got it — added."`) when the output wouldn't parse, so a truncated response was indistinguishable from a real plain task and any reminder was dropped. The outer `except` had the same lie-on-failure shape.

## Fix

- **`app/models.py`** — per-tier `max_tokens` (`_TIER_MAX_TOKENS`). Reasoning tiers (expensive/medium/reminder) send no cap; only the label-only `cheap` tier keeps one. Structured-JSON output is never truncated; tokens are cheap, correctness isn't.
- **`app/graph/nodes/intake.py`** — `_parse_intake_response` returns `None` on failure. `intake_node` then saves the user's **raw message** as a plain task (preserve capture, titled from their words — not the garbled LLM output), emits an `intake_parse_failed` ops alert, and returns an honest message that flags the un-captured timing. Never fakes a reminder. The outer `except` is tightened the same way (alert + "send it again", no false success).

## Tests (written failing-first, then fixed)

- `tests/unit/test_models.py` — reasoning tiers carry no `max_tokens`; `cheap` stays capped.
- `tests/unit/test_intake_parse.py` — truncated / non-JSON → `None`; valid JSON → dict.
- `tests/integration/test_intake.py` — unparseable output saves a raw task titled from the user's words, emits the alert, fabricates no reminder, replies honestly (not "Got it — added.").
- `tests/evals/fixtures/intake/remind_deadline_before_time.yaml` — cross-model efficacy fixture for the deadline-phrasing class (live-gated). A capable model confirms a reminder; a truncating model fails the `regex_require`.
- `tests/regressions/bug_0603_intake_truncation_silent_fallback/` — regression-catalog entry.

## Scope note

This is the **code** fix: the cap can no longer truncate, and a parse failure can no longer masquerade as a confirmed reminder (failure is now loud + non-destructive). Which model serves the `medium` tier — i.e. whether it reliably emits intake's structured JSON — is a separate model-tier/infra decision (`setup/model-tiers.json` / `model-swap.yml`), not changed here.

Closes #603

🤖 Generated with [Claude Code](https://claude.com/claude-code)