### PR TITLE
Fix intake handling for truncated LLM output

### DIFF
--- a/app/graph/nodes/intake.py
+++ b/app/graph/nodes/intake.py
@@ -83,6 +83,8 @@ async def intake_node(state: State) -> dict[str, Any]:
         response_text = str(response.content).strip()
 
         parsed = _parse_intake_response(response_text)
+        if parsed is None:
+            return await _save_raw_task_after_parse_failure(peer=peer, incoming=incoming)
 
         if parsed.get("action") == "clarify":
             question = parsed.get("clarification_question", "Which task are you thinking of?")
@@ -165,13 +167,69 @@ async def intake_node(state: State) -> dict[str, Any]:
         }
 
     except Exception:
-        log.exception("intake_node.error", peer=peer)
+        log.exception("intake_node.error")
+        try:
+            from app.tools import ops_alerts
+
+            await ops_alerts.enqueue(
+                kind="intake_node_failed",
+                body="Intake node failed before it could confirm task capture.",
+                severity="warning",
+            )
+        except Exception:
+            log.exception("intake_node.ops_alert_failed")
         fallback: OutboundDraft = {
             "recipient": peer,
-            "body": "Got it, I'll add that to your list.",
+            "body": "I hit a problem and couldn't add that. Please send it again.",
             "notion_page_id": None,
         }
         return {"pending_outbound": [fallback]}
+
+
+async def _save_raw_task_after_parse_failure(*, peer: str, incoming: str) -> dict[str, Any]:
+    """Preserve capture when intake JSON is malformed without fabricating reminder success."""
+    from app.tools import notion
+
+    log.warning("intake_node.parse_failed")
+
+    notion_page = await notion.create_task(
+        title=incoming[:200],
+        work_type="focus",
+        urgency=50,
+        time_estimate=30,
+        energy_required="Medium",
+        inline_steps="",
+    )
+    page_id = (notion_page or {}).get("id")
+
+    try:
+        from app.tools import ops_alerts
+
+        await ops_alerts.enqueue(
+            kind="intake_parse_failed",
+            body=(
+                "Intake LLM response could not be parsed; saved raw user message "
+                "as a plain task without scheduling a reminder."
+            ),
+            severity="warning",
+        )
+    except Exception:
+        log.exception("intake_node.parse_failed_ops_alert_failed")
+
+    draft: OutboundDraft = {
+        "recipient": peer,
+        "body": (
+            "I added that to your list, but I couldn't reliably read any reminder "
+            "timing. If that was meant to be timed, send the time again and I'll "
+            "schedule it."
+        ),
+        "notion_page_id": page_id,
+    }
+    log.info("intake_node.raw_task_saved_after_parse_failure", page_id=page_id)
+    return {
+        "pending_outbound": [draft],
+        "conversation_state": "idle",
+    }
 
 
 async def _create_reminder(
@@ -251,8 +309,8 @@ def _parse_remind_at(remind_at_str: str) -> datetime:
         raise ValueError(f"Cannot parse remind_at: {remind_at_str!r}") from exc
 
 
-def _parse_intake_response(response_text: str) -> dict[str, Any]:
-    """Extract JSON from LLM intake response."""
+def _parse_intake_response(response_text: str) -> dict[str, Any] | None:
+    """Extract JSON from LLM intake response, returning None when malformed."""
     # Try to find a JSON block
     json_match = re.search(r"\{.*\}", response_text, re.DOTALL)
     if json_match:
@@ -261,23 +319,9 @@ def _parse_intake_response(response_text: str) -> dict[str, Any]:
             if isinstance(loaded, dict):
                 return cast(dict[str, Any], loaded)
         except json.JSONDecodeError:
-            pass
+            return None
 
-    # Fallback: return a save action with the raw text as title
-    return {
-        "action": "save",
-        "title": response_text[:200],
-        "work_type": "focus",
-        "urgency": 50,
-        "time_estimate_minutes": 30,
-        "energy_required": "Medium",
-        "is_reminder": False,
-        "remind_at": None,
-        "use_hidden_subtasks": False,
-        "sub_tasks": [],
-        "inline_steps": "",
-        "confirmation_message": "Got it — added.",
-    }
+    return None
 
 
 def _build_prefs_context(user_prefs: Mapping[str, object]) -> str:

--- a/app/models.py
+++ b/app/models.py
@@ -54,13 +54,16 @@ _VALID_TIERS: frozenset[str] = frozenset(["expensive", "medium", "cheap", "remin
 # allowlist catches typos in setup/model-tiers.json before the first call.
 _VALID_MODEL_PREFIXES: tuple[str, ...] = ("claude-", "gemma", "gpt-")
 
-# Per-tier extra request body forwarded to the LiteLLM proxy. The proxy
-# passes `think` straight through to the Ollama backend. Cheap tier turns
-# reasoning off because its sole caller (intent classifier) only needs a
-# label — significant token reduction with no accuracy loss on the
-# classify prompt.
+# Per-tier kwargs forwarded to ChatOpenAI. Reasoning tiers do not set
+# max_tokens because local reasoning models spend output tokens on hidden
+# reasoning before the final answer; capping them can truncate structured
+# JSON. Cheap is label-only classification, so it keeps a small response cap
+# and disables reasoning overhead.
 _TIER_EXTRA_BODY: dict[str, dict[str, Any]] = {
     "cheap": {"think": False},
+}
+_TIER_MAX_TOKENS: dict[str, int] = {
+    "cheap": 1024,
 }
 
 
@@ -181,10 +184,11 @@ def llm(tier: Tier, *, temperature: float = 0.0, caller: str | None = None) -> C
     kwargs: dict[str, Any] = {
         "model": model_id,
         "temperature": temperature,
-        "max_tokens": 1024,
         "base_url": base_url,
         "api_key": api_key,
     }
+    if tier in _TIER_MAX_TOKENS:
+        kwargs["max_tokens"] = _TIER_MAX_TOKENS[tier]
     extra_body = _TIER_EXTRA_BODY.get(tier)
     if extra_body:
         kwargs["extra_body"] = extra_body

--- a/tests/evals/fixtures/intake/remind_deadline_before_time.yaml
+++ b/tests/evals/fixtures/intake/remind_deadline_before_time.yaml
@@ -1,0 +1,24 @@
+---
+# Deadline phrasing fixture: "<task> <weekday> before <time>" must be
+# treated as a reminder request, not as a plain task with a vague date.
+id: intake-remind-deadline-before-time-001
+node: intake
+tier: medium
+peer: "<test-peer-deadline>"
+inbound: "Submit sample form Tuesday before 9am"
+prior_state:
+  active_task: null
+  conversation_state: idle
+  user_prefs:
+    timezone: America/Chicago
+contracts:
+  - kind: regex_require
+    pattern: "(?i)(remind|reminder|scheduled|set).*(tuesday|9\\s*am|09:00)"
+  - kind: judge
+    rubric: |
+      The response confirms a reminder was set for the task before the
+      named weekday/time deadline. It does NOT merely add a plain task
+      without acknowledging the timing. It does NOT mention internal
+      infrastructure. Score 1.0 for reminder plus timing, 0.5 for task
+      capture with timing but no reminder, 0.0 for task-only capture.
+    threshold: 0.7

--- a/tests/integration/test_intake.py
+++ b/tests/integration/test_intake.py
@@ -208,6 +208,75 @@ async def test_task_without_reminder_creates_notion_task_only() -> None:
 
 
 @pytest.mark.asyncio
+async def test_unparseable_intake_output_saves_raw_task_and_alerts() -> None:
+    """Malformed intake JSON preserves capture without fabricating reminder scheduling."""
+    page_id = str(uuid.uuid4())
+    incoming = "Submit sample form Tuesday before 9am"
+    create_task_calls: list[dict[str, Any]] = []
+
+    async def mock_create_task(**kwargs: Any) -> dict:
+        create_task_calls.append(kwargs)
+        return _make_notion_page(page_id=page_id, title=incoming)
+
+    mock_llm_response = MagicMock()
+    mock_llm_response.content = (
+        '{"action": "save", "title": "Submit sample form", '
+        '"is_reminder": true, "remind_at": "2026-06'
+    )
+    mock_model = AsyncMock()
+    mock_model.ainvoke = AsyncMock(return_value=mock_llm_response)
+    ops_enqueue = AsyncMock()
+
+    with (
+        patch("app.models.llm", return_value=mock_model),
+        patch("app.tools.notion.create_task", side_effect=mock_create_task),
+        patch("app.tools.notion.create_reminder", new_callable=AsyncMock) as create_reminder,
+        patch("app.tools.reminders.enqueue", new_callable=AsyncMock) as enqueue,
+        patch("app.tools.ops_alerts.enqueue", ops_enqueue),
+    ):
+        from app.graph.nodes.intake import intake_node
+
+        state: State = {
+            "peer": "<test-intake-parse-failure>",
+            "incoming": incoming,
+            "intent": "ADD_TASK",
+            "messages": [],
+            "active_task": None,
+            "streak": 0,
+            "tasks_completed_today": 0,
+            "user_prefs": {"timezone": "America/Chicago"},
+            "mood": None,
+            "available_minutes": None,
+            "conversation_state": "idle",
+            "pending_outbound": [],
+        }
+
+        result = await intake_node(state)
+
+    assert create_task_calls == [
+        {
+            "title": incoming,
+            "work_type": "focus",
+            "urgency": 50,
+            "time_estimate": 30,
+            "energy_required": "Medium",
+            "inline_steps": "",
+        }
+    ]
+    create_reminder.assert_not_awaited()
+    enqueue.assert_not_awaited()
+    ops_enqueue.assert_awaited_once()
+    assert ops_enqueue.await_args.kwargs["kind"] == "intake_parse_failed"
+
+    draft = result["pending_outbound"][0]
+    assert draft["recipient"] == "<test-intake-parse-failure>"
+    assert draft["notion_page_id"] == page_id
+    assert "added" in draft["body"].lower()
+    assert "timing" in draft["body"].lower()
+    assert "schedule" in draft["body"].lower()
+
+
+@pytest.mark.asyncio
 async def test_recurring_reminder_gets_explicit_response() -> None:
     """'every weekday at 8' receives a response (recurring not fully supported in v1).
 

--- a/tests/regressions/bug_0603_intake_truncated_output/README.md
+++ b/tests/regressions/bug_0603_intake_truncated_output/README.md
@@ -1,0 +1,16 @@
+# Bug 0603: Truncated Intake Output
+
+**Issue:** #603
+
+## Bug Story
+
+Medium-tier intake responses could be truncated before the JSON object was
+complete. The parser converted that malformed output into a fake successful
+plain-task save, so reminder-shaped requests were acknowledged without creating
+reminder scheduling state.
+
+## Regression Tests
+
+Tests live in `tests/unit/test_intake_parse.py`,
+`tests/integration/test_intake.py`, and
+`tests/evals/fixtures/intake/remind_deadline_before_time.yaml`.

--- a/tests/unit/test_intake_parse.py
+++ b/tests/unit/test_intake_parse.py
@@ -1,0 +1,28 @@
+"""Unit tests for intake LLM response parsing."""
+from __future__ import annotations
+
+from app.graph.nodes.intake import _parse_intake_response
+
+
+def test_parse_intake_response_accepts_json_object() -> None:
+    parsed = _parse_intake_response(
+        '{"action": "save", "title": "Test task", "is_reminder": false}'
+    )
+
+    assert parsed is not None
+    assert parsed["action"] == "save"
+    assert parsed["title"] == "Test task"
+
+
+def test_parse_intake_response_returns_none_for_non_json() -> None:
+    assert _parse_intake_response("I can help with that.") is None
+
+
+def test_parse_intake_response_returns_none_for_truncated_json() -> None:
+    assert _parse_intake_response(
+        '{"action": "save", "title": "Test task", "is_reminder": true,'
+    ) is None
+
+
+def test_parse_intake_response_returns_none_for_non_object_json() -> None:
+    assert _parse_intake_response('["not", "an", "object"]') is None

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -131,7 +131,7 @@ def test_valid_tier_returns_llm_instance() -> None:
 
 
 def test_llm_constructs_chatopenai_with_expected_kwargs() -> None:
-    """llm() must pass tier model id, temperature, max_tokens, base_url, and api_key to ChatOpenAI."""
+    """llm() must pass tier model id, temperature, base_url, and api_key to ChatOpenAI."""
     import json
     from pathlib import Path
     from unittest.mock import MagicMock, patch
@@ -155,7 +155,7 @@ def test_llm_constructs_chatopenai_with_expected_kwargs() -> None:
             call_kwargs = mock_cls.call_args.kwargs
             assert call_kwargs["model"] == expected_model
             assert call_kwargs["temperature"] == 0.0
-            assert call_kwargs["max_tokens"] == 1024
+            assert "max_tokens" not in call_kwargs
             assert call_kwargs["base_url"] == "https://proxy.test/v1"
             assert call_kwargs["api_key"] == "test-key"
 
@@ -230,6 +230,33 @@ def test_cheap_tier_sets_think_false_extra_body() -> None:
                 f"{tier} tier must NOT set think (defaults to thinking=on); "
                 f"got extra_body={extra!r}"
             )
+
+    models_module._load_model_tiers.cache_clear()
+
+
+def test_only_cheap_tier_sets_max_tokens() -> None:
+    """Reasoning tiers must avoid app-side output caps; cheap stays bounded."""
+    from unittest.mock import MagicMock, patch
+
+    from app import models as models_module
+    models_module._load_model_tiers.cache_clear()
+
+    fake_instance = MagicMock()
+    fake_instance.with_config.return_value = fake_instance
+
+    env = dict(os.environ)
+    env.pop("LANGSMITH_TRACING", None)
+    env.setdefault("LLM_PROXY_API_KEY", "test-key-not-used")
+    env.setdefault("LLM_PROXY_BASE_URL", "https://proxy.test/v1")
+
+    with patch.dict(os.environ, env, clear=True):
+        with patch("app.models.ChatOpenAI", return_value=fake_instance) as mock_cls:
+            for tier in ("medium", "expensive", "reminder"):
+                models_module.llm(tier)  # type: ignore[arg-type]
+                assert "max_tokens" not in mock_cls.call_args.kwargs
+
+            models_module.llm("cheap")
+            assert mock_cls.call_args.kwargs["max_tokens"] == 1024
 
     models_module._load_model_tiers.cache_clear()
 


### PR DESCRIPTION
Resolves #603

## Summary
- Remove the app-side output-token cap from reasoning model tiers so medium intake JSON is not truncated by a shared 1024-token limit.
- Make malformed intake output fail closed: save the raw user message as a plain task, emit an ops alert, and return an honest confirmation that no reminder timing was captured.
- Add unit, integration, regression-catalog, and eval fixture coverage for truncated/non-JSON intake output and deadline-before-time reminder phrasing.

## Test Plan
- `ruff check app/ tests/`
- `mypy app/`
- `pytest tests/unit/ -x`
- `pytest tests/integration/test_intake.py -q`
- `pytest tests/integration/ -x` skipped because `DATABASE_URL` is unset in this environment.
- Pre-push hook also ran shell script linting, script permission checks, doc link validation, Mermaid lint/render validation, workflow YAML linting, actionlint, workflow reference validation, and GitHub CLI workflow usage validation.

## Review Pipeline Fallback
If review pipeline checks do not appear within 2 minutes of opening this PR,
comment `/review` on the PR to manually trigger a fresh review cycle.

Generated with Codex

Author-Session: codex/26676387463