### PR TITLE
fix(ci): guard navigator assignment in mermaid validator for Node 24

### DIFF
--- a/.github/workflows/python-validation.yml
+++ b/.github/workflows/python-validation.yml
@@ -1,7 +1,10 @@
 name: Python Validation
 
-# Runs ruff, mypy, and pytest on every PR that touches Python source files
-# under app/, migrations/, tests/, or scripts/*.py.
+# Runs on every PR so the required "Python Validation Required" check always
+# reports. The lint/type/test jobs (ruff, mypy, pytest-unit) are gated on the
+# `changes` job, which detects whether the PR touches Python source under
+# app/, migrations/, tests/, scripts/*.py, or pyproject.toml. On PRs with no
+# Python changes those jobs skip and the required check reports green quickly.
 #
 # This is a required check: ALL three gates (ruff, mypy, pytest-unit) must
 # pass before merge. Integration tests (pytest-integration) run only when
@@ -24,12 +27,6 @@ on:
       - main
       - master
       - '**'
-    paths:
-      - 'app/**'
-      - 'migrations/**'
-      - 'tests/**'
-      - 'scripts/*.py'
-      - 'pyproject.toml'
   workflow_dispatch:
     inputs:
       ref:

--- a/DEV-AGENTS.md
+++ b/DEV-AGENTS.md
@@ -118,7 +118,7 @@ Support dev pipeline. Edit directly via PRs — any contributor or agent (Claude
 - `scripts/validate-mermaid.sh`, `scripts/lint-mermaid-rendering.sh` — Diagram validation
 - `setup/model-tiers.json` — Repo metadata mapping expensive, medium, and cheap model tiers; read by `app/models.py` at startup
 - `pyproject.toml` — Python 3.12 dependency manifest for the LangGraph stack; runtime and dev deps pinned by version
-- `.github/workflows/python-validation.yml` — Required CI gate: ruff + mypy + pytest-unit on every PR touching Python source files
+- `.github/workflows/python-validation.yml` — Required CI gate: runs on every PR. The `Python Validation Required` status check always reports. `ruff`, `mypy`, and `pytest-unit` run only when the Python change filter matches `app/`, `migrations/`, `tests/`, `scripts/*.py`, or `pyproject.toml`; they are skipped (and treated as success) on non-Python PRs.
 - `.github/workflows/nightly-evals.yml` — Cron (09:00 UTC) + `workflow_dispatch`. Runs `python -m tests.evals.runner` against current `setup/model-tiers.json` values via the LiteLLM proxy. Posts `report.md` as a workflow artifact. Budget default $10.
 - `.github/workflows/model-swap.yml` — `workflow_dispatch` only. Inputs: candidate_model, candidate_tier, budget_usd. Runs baseline + candidate side-by-side; surfaces comparison in job summary. Budget default $15. Use before swapping a tier in `setup/model-tiers.json`.
 - `.github/scripts/review/prompts/test.md` — Test coverage reviewer: enforces 6 test-rig contract clauses on PRs touching app/**, migrations/**, setup/model-tiers.json, app/prompts/**, docs/ai-prompts/**, tests/**, the test reviewer prompt, review schemas, docs/python-rewrite/test-rig.md, and docker/compose.yaml

--- a/DEV-AGENTS.md.tmp
+++ b/DEV-AGENTS.md.tmp
@@ -1,0 +1,1 @@
+placeholder

--- a/scripts/validate-mermaid.sh
+++ b/scripts/validate-mermaid.sh
@@ -46,7 +46,7 @@ import { JSDOM } from "jsdom";
 const dom = new JSDOM("<!DOCTYPE html><html><body></body></html>");
 global.window = dom.window;
 global.document = dom.window.document;
-global.navigator = dom.window.navigator;
+if (!('navigator' in globalThis)) global.navigator = dom.window.navigator;
 global.DOMPurify = (await import("dompurify")).default(dom.window);
 
 const { default: mermaid } = await import("mermaid");


### PR DESCRIPTION
## Summary

Fixes `scripts/validate-mermaid.sh`, which crashes on Node.js 24.

The script writes a temp `validate.mjs` that builds a JSDOM environment for the headless Mermaid render, including:

```js
global.navigator = dom.window.navigator;
```

On Node.js 24, `navigator` is a built-in read-only global getter, so this assignment throws:

```
TypeError: Cannot set property navigator of #<Object> which has only a getter
```

The exception fired on every diagram, was reported as a false "syntax error," and failed the review-pipeline fixer step's Mermaid render validation.

## Change

Guard the assignment so it only runs when `navigator` is not already present:

```js
if (!('navigator' in globalThis)) global.navigator = dom.window.navigator;
```

This preserves behavior on older Node (where `navigator` is absent and JSDOM's must be installed) while not throwing on Node 24 (where the global is already provided).

## Second fix: unblock required check on non-Python PRs

The branch ruleset requires the `Python Validation Required` status context, but `.github/workflows/python-validation.yml` was gated by an `on.pull_request.paths:` filter. PRs that touch no Python paths (like this one) never triggered the workflow, so the required check never reported and merge deadlocked.

Removed the `paths:` filter so the workflow runs on every PR. This is safe:

- The `changes` job (dorny/paths-filter) still computes `outputs.python`.
- `ruff`, `mypy`, `pytest-unit` are gated on `if: needs.changes.outputs.python == 'true'`, so they skip on non-Python PRs.
- `python-all-passed` (name: `Python Validation Required`) uses `if: always()` and treats skipped jobs as success, so it reports green quickly on non-Python PRs.

## Notes

- CI/infra-only changes (no app/runtime behavior affected).
- `jsdom`/`mermaid` deps are not installed in this worktree, so the validator was not run end-to-end here; the change is a one-line conditional guard around the failing assignment.
- `actionlint`, `validate-pr-tests-workflow.sh`, and `validate-workflow-refs.sh` all pass on the updated workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)