### PR TITLE
chore: refresh stale AI CLI pins (claude 2.1.126→2.1.167, codex 0.128.0→0.137.0)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -38,8 +38,8 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
     && rm -rf /var/lib/apt/lists/*
 
 # Pin AI CLI versions so Dockerfile, post-create script, and updater workflow stay in sync
-ARG CLAUDE_CODE_VERSION=2.1.126
-ARG CODEX_CLI_VERSION=0.128.0
+ARG CLAUDE_CODE_VERSION=2.1.167
+ARG CODEX_CLI_VERSION=0.137.0
 
 # Install Node.js LTS (needed for Claude Code plugins and Mermaid validation)
 ARG NODE_VERSION=20

--- a/.github/ci/versions.env
+++ b/.github/ci/versions.env
@@ -3,8 +3,8 @@
 # Keep in sync with `.devcontainer/Dockerfile` via its own ARG lines
 # (or remove the devcontainer dependency on pins once it stops pulling
 # from GHCR for local-dev speedups).
-CLAUDE_CODE_VERSION=2.1.126
-CODEX_CLI_VERSION=0.128.0
+CLAUDE_CODE_VERSION=2.1.167
+CODEX_CLI_VERSION=0.137.0
 OPENCLAW_VERSION=2026.5.2
 ACTIONLINT_VERSION=1.7.7
 NODE_MAJOR=20


### PR DESCRIPTION
## What

Bumps the pinned AI CLI versions to current latest:

- **Claude Code:** `2.1.126` → `2.1.167`
- **Codex CLI:** `0.128.0` → `0.137.0`

Updated in both pin locations: `.github/ci/versions.env` (source of truth for the CI image build args) and `.devcontainer/Dockerfile` (`ARG` lines).

## Why

The pins were 41 Claude patch releases behind latest. Root cause: the weekly `update-ai-clis` job hasn't landed a bump since 2026-05-04 — its 2026-06-01 scheduled run hung ~11h on the self-hosted `homelab` runner and failed, so the pins went stale.

Because the devcontainer is pin-driven and the CI image only rebuilds on `.github/ci/**` changes, a stale pin shows up as devcontainer ↔ pipeline version skew (the symptom that surfaced this). This manually catches both pins up to latest.

The weekly job already rewrites **both** `versions.env` and `.devcontainer/Dockerfile`, so it keeps them in sync once its next run succeeds — no change to the updater's file coverage is needed.

## Notes / not included

- The actual reliability gap is that `update-ai-clis.yml` runs only on the flaky self-hosted `homelab` runner with no `timeout-minutes` (hence the ~11h hang). Moving it to `ubuntu-latest` (it only curls public endpoints + opens a PR) and adding a timeout would prevent silent multi-week staleness — left out of this PR to keep it a clean pin bump; happy to follow up.
- `.devcontainer/.claude-config` (an orphan personal config with `autoUpdates:false`) is already covered by `.gitignore` and was never tracked, so no repo change is required for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)